### PR TITLE
Add scale worker nodes common function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift-knative/hack
+
+go 1.17

--- a/lib.sh
+++ b/lib.sh
@@ -1,0 +1,26 @@
+# scale up worker nodes to at least the provided number of nodes
+# Inputs:
+#  1: number of minimum worker nodes
+function scale_worker_nodes() {
+  echo "Reconcile workers to at least ${1} nodes"
+
+  additional_replicas=$(oc get machineset -n openshift-machine-api | awk '{print $2}' | tail -n +2 | awk -v workers="$1" '{sum+=$1} END {print workers-sum}')
+  echo "Additional replicas ${additional_replicas}"
+
+  if [[ ${additional_replicas} -gt 0 ]]; then
+    machineset="$(oc get machineset -n openshift-machine-api | awk '{print $1}' | tail -n +2 | head -1)"
+    replicas=$(oc get machineset -n openshift-machine-api "${machineset}" -o=jsonpath='{.spec.replicas}')
+    replicas=$(expr ${replicas} + ${additional_replicas})
+    oc scale machineset "${machineset}" -n openshift-machine-api --replicas="${replicas}"
+    wait_for_machine_set_to_be_ready "${machineset}"
+  fi
+}
+
+# Waits for the provided machineset to have all expected replicas ready
+# Inputs:
+#  1: machineset name
+function wait_for_machine_set_to_be_ready() {
+  replicas=$(oc get machineset -n openshift-machine-api "${1}" -o=jsonpath='{.spec.replicas}')
+  oc wait machineset "${machineset}" -n openshift-machine-api --for=jsonpath='{.status.readyReplicas}'="${replicas}" --timeout=30m
+}
+

--- a/lib.sh
+++ b/lib.sh
@@ -2,9 +2,11 @@
 # Inputs:
 #  1: number of minimum worker nodes
 function scale_worker_nodes() {
-  echo "Reconcile workers to at least ${1} nodes"
+  num_workers=${1:?Pass num_workers as arg[1]}
 
-  additional_replicas=$(oc get machineset -n openshift-machine-api | awk '{print $2}' | tail -n +2 | awk -v workers="$1" '{sum+=$1} END {print workers-sum}')
+  echo "Reconcile workers to at least ${num_workers} nodes"
+
+  additional_replicas=$(oc get machineset -n openshift-machine-api | awk '{print $2}' | tail -n +2 | awk -v workers="${num_workers}" '{sum+=$1} END {print workers-sum}')
   echo "Additional replicas ${additional_replicas}"
 
   if [[ ${additional_replicas} -gt 0 ]]; then
@@ -20,7 +22,8 @@ function scale_worker_nodes() {
 # Inputs:
 #  1: machineset name
 function wait_for_machine_set_to_be_ready() {
-  replicas=$(oc get machineset -n openshift-machine-api "${1}" -o=jsonpath='{.spec.replicas}')
+  machineset_name=${1:?Pass machineset_name as arg[1]}
+  replicas=$(oc get machineset -n openshift-machine-api "${machineset_name}" -o=jsonpath='{.spec.replicas}')
   oc wait machineset "${machineset}" -n openshift-machine-api --for=jsonpath='{.status.readyReplicas}'="${replicas}" --timeout=30m
 }
 


### PR DESCRIPTION
A common use case across midstream repos is to scale up the worker
nodes.

The way it has been done so far is to always set whatever is the
first machineset to a specified number of workers. Obviously, this
isn't ideal since the sum of worker nodes across the (usual)
multiple machineset might already meet the expected number of
replicas. [1]

In this PR, we are considering every machineset and scale
up only when there are missing nodes.

https://github.com/openshift/knative-eventing/blob/21b347723056d07a96e79ab44744d6f4b8217c26/openshift/e2e-common.sh#L34-L66

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>