### PR TITLE
Github action for multiarch test images

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -1,0 +1,48 @@
+name: Multiarch builds
+
+on:
+  workflow_call: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  multiarch-build:
+    name: Build test images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
+      - name: Setup ko
+        uses: imjasonh/setup-ko@v0.6
+        with:
+          version: v0.12.0
+
+      - name: Setup make
+        run: |
+          sudo apt-get update
+          sudo apt-get install make
+
+      - name: Login to quay.io
+        env:
+          quay_user: ${{ secrets.QUAY_USER }}
+          quay_password: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          ko login -u="${quay_user}" -p="${quay_password}" quay.io
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build and push multiarch test images
+        env:
+          ref: ${{ github.ref_name }}
+        run: |
+          echo "Building images from ${GITHUB_REF}@${GITHUB_SHA}"
+          # Remove release-v prefix and parse major and minor version
+          major_minor=$(echo ${ref#release-v} | awk -F \. '{printf "%d.%d", $1, $2}')
+          make test-images DOCKER_REPO_OVERRIDE=quay.io/${{ github.repository }}/ \
+            KO_FLAGS="--platform=all --sbom=none" TEST_IMAGE_TAG=v${major_minor}


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/SRVCOM-2053

This is a reusable github action which builds all test images from the given repository for multiple architectures and pushes them to a predefined repository structure in quay.io

The quay username and password will be defined at organization level and passed to the action.

This is used in https://github.com/openshift-knative/eventing-kafka-broker/pull/420