### PR TITLE
Improve parsing major and minor version from branch name in github ac…

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -42,7 +42,7 @@ jobs:
           ref: ${{ github.ref_name }}
         run: |
           echo "Building images from ${GITHUB_REF}@${GITHUB_SHA}"
-          # Remove release-v prefix and parse major and minor version
-          major_minor=$(echo ${ref#release-v} | awk -F \. '{printf "%d.%d", $1, $2}')
+          # Ref: https://regex101.com/r/Po1HA3/1
+          major_minor=$(echo ${ref#release-} | sed 's/^v\?\([[:digit:]]\+\)\.\([[:digit:]]\+\).*/\1.\2/')
           make test-images DOCKER_REPO_OVERRIDE=quay.io/${{ github.repository }}/ \
             KO_FLAGS="--platform=all --sbom=none" TEST_IMAGE_TAG=v${major_minor}


### PR DESCRIPTION
…tion

* It can now work with all styles: release-vX.Y.Z release-X.Y.Z release-X.Y

This is to make it work with https://github.com/openshift-knative/kn-plugin-event which has different naming style for branches.