### PR TITLE
Bump Go to 1.18 for multiarch image build

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Setup ko
         uses: imjasonh/setup-ko@v0.6


### PR DESCRIPTION
It is failing in https://github.com/openshift-knative/eventing-kafka-broker/actions/runs/3388469369/jobs/5630487966

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>