### PR TITLE
:recycle: Running multi-arch build on Ubuntu 22.04

### DIFF
--- a/.github/workflows/multiarch-containerfile-build.yaml
+++ b/.github/workflows/multiarch-containerfile-build.yaml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   multiarch-build:
     name: Build images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Changes

 * :recycle: Running multi-arch build on Ubuntu 22.04

Confirmed to be working on https://github.com/cardil/kn-plugin-event/actions/runs/3629400516/jobs/6121557648. Previously it was failing on s390x architecture: https://github.com/cardil/kn-plugin-event/actions/runs/3583459982/jobs/6028914644 

/cc @mgencur 