### PR TITLE
Populate `images[*].inputs` and `base_images` in CI configs

### DIFF
--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -99,13 +99,6 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 					Variant: variant,
 				},
 				InputConfiguration: cioperatorapi.InputConfiguration{
-					BaseImages: map[string]cioperatorapi.ImageStreamTagReference{
-						"base": {
-							Namespace: "ocp",
-							Name:      ov,
-							Tag:       "base",
-						},
-					},
 					BuildRootImage: &cioperatorapi.BuildRootImageConfiguration{
 						ProjectImageBuild: &cioperatorapi.ProjectDirectoryImageBuildInputs{
 							DockerfilePath: "openshift/ci-operator/build-image/Dockerfile",

--- a/pkg/prowgen/prowgen_images.go
+++ b/pkg/prowgen/prowgen_images.go
@@ -17,6 +17,7 @@ var (
 type ImageInput struct {
 	Context        imageContext
 	DockerfilePath string
+	Inputs         map[string]cioperatorapi.ImageBuildInputs
 }
 
 func ProjectDirectoryImageBuildStepConfigurationFuncFromImageInput(r Repository, input ImageInput) ProjectDirectoryImageBuildStepConfigurationFunc {
@@ -34,6 +35,7 @@ func ProjectDirectoryImageBuildStepConfigurationFuncFromImageInput(r Repository,
 			To: cioperatorapi.PipelineImageStreamTagReference(to),
 			ProjectDirectoryImageBuildInputs: cioperatorapi.ProjectDirectoryImageBuildInputs{
 				DockerfilePath: input.DockerfilePath,
+				Inputs:         input.Inputs,
 			},
 		}, nil
 	}
@@ -47,6 +49,20 @@ func WithImage(ibcFunc ProjectDirectoryImageBuildStepConfigurationFunc) ReleaseB
 		}
 
 		cfg.Images = append(cfg.Images, ibc)
+		return nil
+	}
+}
+
+func WithBaseImages(baseImages map[string]cioperatorapi.ImageStreamTagReference) ReleaseBuildConfigurationOption {
+	return func(cfg *cioperatorapi.ReleaseBuildConfiguration) error {
+		if cfg.InputConfiguration.BaseImages == nil {
+			cfg.InputConfiguration.BaseImages = make(map[string]cioperatorapi.ImageStreamTagReference)
+		}
+
+		for key, img := range baseImages {
+			cfg.InputConfiguration.BaseImages[key] = img
+		}
+
 		return nil
 	}
 }

--- a/pkg/prowgen/prowgen_images_discovery.go
+++ b/pkg/prowgen/prowgen_images_discovery.go
@@ -1,15 +1,30 @@
 package prowgen
 
 import (
+	"bufio"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+var registryRegex = regexp.MustCompile(`registry\.(|svc\.)ci\.openshift\.org/\S+`)
+
+type orgRepoTag struct {
+	Org  string
+	Repo string
+	Tag  string
+}
+
+func (ort orgRepoTag) String() string {
+	return ort.Org + "_" + ort.Repo + "_" + ort.Tag
+}
 
 func DiscoverImages(r Repository) ReleaseBuildConfigurationOption {
 	return func(cfg *cioperatorapi.ReleaseBuildConfiguration) error {
@@ -35,10 +50,17 @@ func discoverImages(r Repository) ([]ReleaseBuildConfigurationOption, error) {
 	options := make([]ReleaseBuildConfigurationOption, 0, len(dockerfiles))
 
 	for _, dockerfile := range dockerfiles {
+		requiredBaseImages, inputImages, err := discoverInputImages(dockerfile)
+		if err != nil {
+			return nil, err
+		}
+
 		options = append(options,
+			WithBaseImages(requiredBaseImages),
 			WithImage(ProjectDirectoryImageBuildStepConfigurationFuncFromImageInput(r, ImageInput{
 				Context:        discoverImageContext(dockerfile),
 				DockerfilePath: strings.Join(strings.Split(dockerfile, string(os.PathSeparator))[2:], string(os.PathSeparator)),
+				Inputs:         inputImages,
 			})),
 		)
 	}
@@ -61,4 +83,85 @@ func discoverDockerfiles(r Repository) ([]string, error) {
 		return nil, fmt.Errorf("failed while discovering container images in %s: %w", dir, err)
 	}
 	return dockerfiles, nil
+}
+
+func discoverInputImages(dockerfile string) (map[string]cioperatorapi.ImageStreamTagReference, map[string]cioperatorapi.ImageBuildInputs, error) {
+	imagePaths, err := getPullStringsFromDockerfile(dockerfile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get pull images from dockerfile: %w", err)
+	}
+
+	requiredBaseImages := make(map[string]cioperatorapi.ImageStreamTagReference)
+	inputImages := make(map[string]cioperatorapi.ImageBuildInputs)
+
+	for _, imagePath := range imagePaths {
+		orgRepoTag, err := orgRepoTagFromPullString(imagePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse string %s as pullspec: %w", imagePath, err)
+		}
+
+		requiredBaseImages[orgRepoTag.String()] = cioperatorapi.ImageStreamTagReference{
+			Namespace: orgRepoTag.Org,
+			Name:      orgRepoTag.Repo,
+			Tag:       orgRepoTag.Tag,
+		}
+
+		inputs := inputImages[orgRepoTag.String()]
+		inputs.As = sets.NewString(inputs.As...).Insert(imagePath).List() //different registries can resolve to the same orgRepoTag
+		inputImages[orgRepoTag.String()] = inputs
+	}
+
+	return requiredBaseImages, inputImages, nil
+}
+
+func getPullStringsFromDockerfile(filename string) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open Dockerfile %s: %w", filename, err)
+	}
+	defer file.Close()
+
+	var images []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, "FROM ") {
+			continue
+		}
+
+		match := registryRegex.FindString(line)
+		if match != "" {
+			images = append(images, match)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read Dockerfile %s: %w", filename, err)
+	}
+
+	return images, nil
+}
+
+func orgRepoTagFromPullString(pullString string) (orgRepoTag, error) {
+	res := orgRepoTag{Tag: "latest"}
+	slashSplit := strings.Split(pullString, "/")
+	switch n := len(slashSplit); n {
+	case 1:
+		res.Org = "_"
+		res.Repo = slashSplit[0]
+	case 2:
+		res.Org = slashSplit[0]
+		res.Repo = slashSplit[1]
+	case 3:
+		res.Org = slashSplit[1]
+		res.Repo = slashSplit[2]
+	default:
+		return res, fmt.Errorf("pull string %q couldn't be parsed, expected to get between one and three elements after slashsplitting, got %d", pullString, n)
+	}
+	if repoTag := strings.Split(res.Repo, ":"); len(repoTag) == 2 {
+		res.Repo = repoTag[0]
+		res.Tag = repoTag[1]
+	}
+
+	return res, nil
 }

--- a/pkg/prowgen/testdata/eventing/openshift/ci-operator/knative-images/dispatcher/Dockerfile
+++ b/pkg/prowgen/testdata/eventing/openshift/ci-operator/knative-images/dispatcher/Dockerfile
@@ -1,0 +1,1 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.18


### PR DESCRIPTION
Currently the image inputs are not populated when generating CI configs. This makes PRs pretty verbose (see https://github.com/openshift/release/pull/34919) and it will be overwritten by the openshift-bot anyhow (e.g. https://github.com/openshift/release/pull/34956).

This PR addresses it and also populates the `images[*].inputs` fields based on the values from the corresponding Dockerfile when generating the CI configs.
The implementation for getting the image repo/tag/org is aligned with [ci-tools/cmd/registry-replacer](https://github.com/openshift/ci-tools/blob/187374202a2848648f736a82ae19e3f9cf60f972/cmd/registry-replacer/main.go) (does not provide a public API for this :/ ) which is used by the openshift-bot.