### PR TITLE
No more double dash in test names

### DIFF
--- a/pkg/prowgen/prowgen_command_name_mapping.go
+++ b/pkg/prowgen/prowgen_command_name_mapping.go
@@ -22,7 +22,13 @@ func ToName(r Repository, test *Test, openShiftVersion string) string {
 	maxCommandLength := maxNameLength - len(suffix) - len(continuousSuffix)
 	if len(test.Command) > maxCommandLength {
 		sha := test.HexSha() // guarantees uniqueness
-		newTarget := test.Command[:maxCommandLength-len(sha)-1] + "-" + sha
+		prefix := test.Command[:maxCommandLength-len(sha)-1]
+		if strings.HasSuffix(prefix, "-") {
+			// OpenShift CI doesnt' like double dashes, such as `stable-latest-test-kafka--7465737-aws-ocp-412`.
+			// So, if the prefix of the command ends with a dash, we remove it.
+			prefix = prefix[:len(prefix)-1]
+		}
+		newTarget := prefix + "-" + sha
 		log.Println(r.RepositoryDirectory(), "command as test name is too long", test.Command, "truncating it to", newTarget)
 		return fmt.Sprintf("%s%s", newTarget, suffix)
 	}

--- a/pkg/prowgen/prowgen_command_name_mapping_test.go
+++ b/pkg/prowgen/prowgen_command_name_mapping_test.go
@@ -62,7 +62,7 @@ func TestToName(t *testing.T) {
 				Command: "test-kafka-broker-upstream-nightly",
 			},
 			openShiftVersion: openshiftVersion,
-			want:             fmt.Sprintf("%s%s", "test-kafka--7465737", suffix),
+			want:             fmt.Sprintf("%s%s", "test-kafka-7465737", suffix),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixing the issue here: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_eventing-hyperfoil-benchmark/70/pull-ci-openshift-knative-eventing-hyperfoil-benchmark-main-412-test-kafka--7465737-aws-ocp-412/1620687039756242944

```
could not run steps: step [release:latest-test-kafka--7465737-aws-ocp-412] failed: could not create stable imagestream: ImageStream.image.openshift.io "stable-latest-test-kafka--7465737-aws-ocp-412" is invalid: metadata.name: Invalid value: "stable-latest-test-kafka--7465737-aws-ocp-412": must match "[a-z0-9]+(?:[._-][a-z0-9]+)*" 
```