### PR TITLE
Run openshift core must gather as post step

### DIFF
--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -73,6 +73,21 @@ func DiscoverTests(r Repository, openShiftVersion string) ReleaseBuildConfigurat
 								Cli:        "latest",
 							},
 						},
+						{
+							LiteralTestStep: &cioperatorapi.LiteralTestStep{
+								As:       "openshift-must-gather",
+								From:     "src",
+								Commands: `oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"`,
+								Resources: cioperatorapi.ResourceRequirements{
+									Requests: cioperatorapi.ResourceList{
+										"cpu": "100m",
+									},
+								},
+								Timeout:    &prowapi.Duration{Duration: 20 * time.Minute},
+								BestEffort: pointer.Bool(true),
+								Cli:        "latest",
+							},
+						},
 					},
 					Workflow: pointer.String("generic-claim"),
 				},


### PR DESCRIPTION
Knative must gather is not always enough to debug
test failures.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>