### PR TITLE
testselect for selecting tests based on clonerefs and testsuites yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ unit-tests:
 
 # TESTSUITES=/home/mgencur/go/src/github.com/openshift-knative/hack/config/testsuites.yaml CLONEREFS=/home/mgencur/go/src/github.com/openshift-knative/hack/config/clonerefs.json make test-select
 test-select:
-	go run github.com/openshift-knative/hack/cmd/testselect --testsuites $(TESTSUITES) --clonerefs $(CLONEREFS)
+	go run github.com/openshift-knative/hack/cmd/testselect --testsuites $(TESTSUITES) --clonerefs $(CLONEREFS) --output=tests.txt
 .PHONY: test-select

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ unit-tests:
 	go test ./pkg/...
 .PHONY: unit-tests
 
-# TESTSUITES=/home/mgencur/go/src/github.com/openshift-knative/hack/config/testsuites.yaml CLONEREFS=/home/mgencur/go/src/github.com/openshift-knative/hack/config/clonerefs.json make test-select
 test-select:
 	go run github.com/openshift-knative/hack/cmd/testselect --testsuites $(TESTSUITES) --clonerefs $(CLONEREFS) --output=tests.txt
 .PHONY: test-select

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,8 @@ generate-ci:
 unit-tests:
 	go test ./pkg/...
 .PHONY: unit-tests
+
+# TESTSUITES=/home/mgencur/go/src/github.com/openshift-knative/hack/config/testsuites.yaml CLONEREFS=/home/mgencur/go/src/github.com/openshift-knative/hack/config/clonerefs.json make test-select
+test-select:
+	go run github.com/openshift-knative/hack/cmd/testselect --testsuites $(TESTSUITES) --clonerefs $(CLONEREFS)
+.PHONY: test-select

--- a/cmd/testselect/testselect.go
+++ b/cmd/testselect/testselect.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/openshift-knative/hack/pkg/testselect"
+)
+
+func main() {
+	testselect.Main()
+}

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -143,18 +143,18 @@ func pushBranch(ctx context.Context, release Repository, remote *string, branch 
 	log.Println("Pushing branch", branch, "to", *remote)
 
 	// Ignore error since remote and branch might be already there
-	_ = run(ctx, release, "git", "checkout", "-b", branch)
-	_ = run(ctx, release, "git", "checkout", branch)
-	_ = run(ctx, release, "git", "remote", "add", "fork", *remote)
+	_, _ = run(ctx, release, "git", "checkout", "-b", branch)
+	_, _ = run(ctx, release, "git", "checkout", branch)
+	_, _ = run(ctx, release, "git", "remote", "add", "fork", *remote)
 
-	if err := run(ctx, release, "git", "add", "."); err != nil {
+	if _, err := run(ctx, release, "git", "add", "."); err != nil {
 		return err
 	}
-	if err := run(ctx, release, "git", "commit", "-s", "-S", "-m", "Sync Serverless CI "+config); err != nil {
+	if _, err := run(ctx, release, "git", "commit", "-s", "-S", "-m", "Sync Serverless CI "+config); err != nil {
 		// Ignore error since we could have nothing to commit
 		log.Println("Ignored error", err)
 	}
-	if err := run(ctx, release, "git", "push", "fork", branch, "-f"); err != nil {
+	if _, err := run(ctx, release, "git", "push", "fork", branch, "-f"); err != nil {
 		return err
 	}
 
@@ -201,7 +201,7 @@ func saveReleaseBuildConfiguration(outConfig *string, cfg ReleaseBuildConfigurat
 }
 
 func runOpenShiftReleaseGenerator(ctx context.Context, openShiftRelease Repository) error {
-	if err := run(ctx, openShiftRelease, "make", "ci-operator-config", "jobs"); err != nil {
+	if _, err := run(ctx, openShiftRelease, "make", "ci-operator-config", "jobs"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/prowgen/prowgen_cmd.go
+++ b/pkg/prowgen/prowgen_cmd.go
@@ -1,28 +1,33 @@
 package prowgen
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
 
-func runNoRepo(ctx context.Context, name string, args ...string) error {
+func runNoRepo(ctx context.Context, name string, args ...string) ([]byte, error) {
+	var buf bytes.Buffer
+
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return buf.Bytes(), ctx.Err()
 	default:
 	}
 
 	cmd := exec.Command(name, args...)
 
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to run %s %v: %w", name, args, err)
+		return nil, fmt.Errorf("failed to run %s %v: %w", name, args, err)
 	}
-	return nil
+
+	return buf.Bytes(), nil
 }
 
 func run(ctx context.Context, r Repository, name string, args ...string) error {

--- a/pkg/prowgen/prowgen_cmd.go
+++ b/pkg/prowgen/prowgen_cmd.go
@@ -30,21 +30,23 @@ func runNoRepo(ctx context.Context, name string, args ...string) ([]byte, error)
 	return buf.Bytes(), nil
 }
 
-func run(ctx context.Context, r Repository, name string, args ...string) error {
+func run(ctx context.Context, r Repository, name string, args ...string) ([]byte, error) {
+	var buf bytes.Buffer
+
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return buf.Bytes(), ctx.Err()
 	default:
 	}
 
 	cmd := exec.Command(name, args...)
 
 	cmd.Dir = r.RepositoryDirectory()
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("[%s] failed to run %s %v: %w", r.RepositoryDirectory(), name, args, err)
+		return nil, fmt.Errorf("[%s] failed to run %s %v: %w", r.RepositoryDirectory(), name, args, err)
 	}
-	return nil
+	return buf.Bytes(), nil
 }

--- a/pkg/prowgen/prowgen_git.go
+++ b/pkg/prowgen/prowgen_git.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func GitCheckout(ctx context.Context, r Repository, branch string) error {
@@ -36,7 +37,7 @@ func GitClone(ctx context.Context, r Repository) error {
 		return fmt.Errorf("[%s] failed to create directory: %w", r.RepositoryDirectory(), err)
 	}
 
-	if err := runNoRepo(ctx, "git", "clone", "--mirror", remoteRepo, localRepo); err != nil {
+	if _, err := runNoRepo(ctx, "git", "clone", "--mirror", remoteRepo, localRepo); err != nil {
 		return fmt.Errorf("[%s] failed to clone repository: %w", r.RepositoryDirectory(), err)
 	}
 
@@ -45,4 +46,17 @@ func GitClone(ctx context.Context, r Repository) error {
 	}
 
 	return nil
+}
+
+func GitFetch(ctx context.Context, remoteRepo, sha string) error {
+	_, err := runNoRepo(ctx, "git", "fetch", remoteRepo, sha)
+	return err
+}
+
+func GitDiffNameOnly(ctx context.Context, baseSha, sha string) ([]string, error) {
+	out, err := runNoRepo(ctx, "git", "diff", "--name-only", fmt.Sprintf("%s..%s", baseSha, sha))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.TrimSpace(string(out)), "\n"), nil
 }

--- a/pkg/testselect/testselect.go
+++ b/pkg/testselect/testselect.go
@@ -28,7 +28,9 @@ type TestSuites struct {
 type TestSuite struct {
 	Name         string   `yaml:"name"`
 	RunIfChanged []string `yaml:"run_if_changed"`
-	Tests        []string `yaml:"tests"`
+	// Tests are arbitrary strings. It is up to the caller to check the strings and decide whether
+	// some code should be run. For example, they can match specific Bash function names or Make targets.
+	Tests []string `yaml:"tests"`
 }
 
 func Main() {

--- a/pkg/testselect/testselect.go
+++ b/pkg/testselect/testselect.go
@@ -129,7 +129,7 @@ func filterTests(testSuites TestSuites, paths []string) ([]string, error) {
 		// If the path doesn't match any path expressions then it is unknown
 		// path and all test suites should be run.
 		if !matchAny {
-			return []string{all}, nil
+			testsToRun[all] = true
 		}
 	}
 

--- a/pkg/testselect/testselect.go
+++ b/pkg/testselect/testselect.go
@@ -26,9 +26,9 @@ type TestSuites struct {
 }
 
 type TestSuite struct {
-	Name 		 string   `yaml:"name"`
+	Name         string   `yaml:"name"`
 	RunIfChanged []string `yaml:"run_if_changed"`
-	Tests 		 []string   `yaml:"tests"`
+	Tests        []string `yaml:"tests"`
 }
 
 func Main() {
@@ -66,7 +66,7 @@ func Main() {
 
 	if len(cloneRefs.GitRefs) == 0 || len(cloneRefs.GitRefs[0].Pulls) == 0 {
 		log.Println(`Clone refs do not include required SHAs. Returning "All".`)
-		tests = []string{ all }
+		tests = []string{all}
 	} else {
 		repo := prowgen.Repository{
 			Org:  cloneRefs.GitRefs[0].Org,
@@ -129,7 +129,7 @@ func filterTests(testSuites TestSuites, paths []string) ([]string, error) {
 		// If the path doesn't match any path expressions then it is unknown
 		// path and all test suites should be run.
 		if !matchAny {
-			return []string{ all }, nil
+			return []string{all}, nil
 		}
 	}
 

--- a/pkg/testselect/testselect.go
+++ b/pkg/testselect/testselect.go
@@ -38,12 +38,7 @@ type TestSuites struct {
 type TestSuite struct {
 	Name 		 string   `yaml:"name"`
 	RunIfChanged []string `yaml:"run_if_changed"`
-	Tests 		 []Test   `yaml:"tests"`
-}
-
-type Test struct {
-	Name 	 string `yaml:"name"`
-	Upstream bool   `yaml:"upstream"`
+	Tests 		 []string   `yaml:"tests"`
 }
 
 func Main() {
@@ -136,7 +131,7 @@ func filterTests(testSuites TestSuites, paths []string) ([]string, error) {
 				if matched {
 					matchAny = true
 					for _, test := range suite.Tests {
-						testsToRun[test.Name] = true
+						testsToRun[test] = true
 					}
 				}
 			}
@@ -155,7 +150,7 @@ func filterTests(testSuites TestSuites, paths []string) ([]string, error) {
 		for _, suite := range testSuites.List {
 			if len(suite.RunIfChanged) == 0 {
 				for _, test := range suite.Tests {
-					testsToRun[test.Name] = true
+					testsToRun[test] = true
 				}
 			}
 		}

--- a/pkg/testselect/testselect.go
+++ b/pkg/testselect/testselect.go
@@ -1,13 +1,3 @@
-// prowgen generates openshift/release configurations based on the OpenShift serverless
-// teams conventions.
-//
-// For example, it extracts image builds Dockerfile from the common
-// directory `openshift/ci-operator/**/Dockerfile.
-//
-// To onboard a new repository, update the configuration in config/repositories.yaml
-// and run the program, or alternatively, you can provide your own configuration file
-// using the -config <path> argument.
-
 package testselect
 
 import (

--- a/pkg/testselect/testselect.go
+++ b/pkg/testselect/testselect.go
@@ -133,15 +133,11 @@ func filterTests(testSuites TestSuites, paths []string) ([]string, error) {
 		}
 	}
 
-	// If no tests were chosen at this point then the changes don't require any tests.
-	// If a "reduced" but non-empty test suite is generated we also want to add tests
-	// that don't have any path expression (run_if_changed) and thus should always be added.
-	if len(testsToRun) != 0 {
-		for _, suite := range testSuites.List {
-			if len(suite.RunIfChanged) == 0 {
-				for _, test := range suite.Tests {
-					testsToRun[test] = true
-				}
+	// Add tests that should always run.
+	for _, suite := range testSuites.List {
+		if len(suite.RunIfChanged) == 0 {
+			for _, test := range suite.Tests {
+				testsToRun[test] = true
 			}
 		}
 	}

--- a/pkg/testselect/testselect.go
+++ b/pkg/testselect/testselect.go
@@ -14,13 +14,18 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/openshift-knative/hack/pkg/prowgen"
 	"gopkg.in/yaml.v2"
 	"k8s.io/test-infra/prow/clonerefs"
+)
+
+const (
+	all = "All"
 )
 
 // TestSuites holds mapping between file path regular expressions and
@@ -46,9 +51,11 @@ func Main() {
 	ts := flag.String("testsuites", "testsuites.yaml", "Specify yaml file with path-to-testsuite mapping")
 	// Clonerefs options as defined in https://github.com/kubernetes/test-infra/blob/master/prow/clonerefs/options.go
 	refs := flag.String("clonerefs", "clonerefs.json", "Specify json file with clonerefs")
+	upstream := flag.Bool("upstream", false, "Specify whether upstream test suites should be selected")
+	outFile := flag.String("output", "tests.txt", "Specify name of output file")
 	flag.Parse()
 
-	log.Println(*ts, *refs)
+	log.Println(*ts, *refs, *outFile)
 
 	inRefs, err := os.ReadFile(*refs)
 	if err != nil {
@@ -70,6 +77,8 @@ func Main() {
 		log.Fatalln("Unmarshal test suite mappings", err)
 	}
 
+	//fmt.Printf("%+v", testSuites)
+
 	//log.Printf("Clonerefs:\n %+v\n TestSuites:\n%+v \n", cloneRefs, testSuites)
 
 	if len(cloneRefs.GitRefs) == 0 || len(cloneRefs.GitRefs[0].Pulls) == 0 {
@@ -83,5 +92,78 @@ func Main() {
 	if err != nil {
 		log.Fatalln("Error reading diff", err)
 	}
-	fmt.Printf("Files changed: %d", len(paths))
+	// "hack/generate/csv.sh", "docs/mesh.md", "hack/lib/serverless.bash"
+	paths = []string{ "knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go",
+		"openshift-knative-operator/cmd/operator/kodata/monitoring/rbac-proxy.yaml", }
+	tests, err := filterTests(*testSuites, paths, *upstream)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var sb strings.Builder
+	for _, tst := range tests {
+		sb.WriteString(tst + "\n")
+	}
+	if err := os.WriteFile(*outFile, []byte(sb.String()), os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func filterTests(testSuites TestSuites, paths []string, upstream bool) ([]string, error) {
+	testsToRun := make(map[string]bool)
+	for _, path := range paths {
+		matchAny := false
+		for _, suite := range testSuites.List {
+			for _, pathRegex := range suite.RunIfChanged {
+				matched, err := regexp.MatchString(pathRegex, path)
+				if err != nil {
+					return nil, err
+				}
+				if matched {
+					matchAny = true
+					for _, test := range suite.Tests {
+						// Choose either upstream or downstream tests only.
+						if test.Upstream == upstream {
+							testsToRun[test.Name] = true
+						}
+					}
+				}
+			}
+		}
+		// If the path doesn't match any path expressions then it is unknown
+		// path and all test suites should be run.
+		if !matchAny {
+			return []string{ all }, nil
+		}
+	}
+
+	// If no tests were chosen at this point then the changes don't require any tests.
+	// If a "reduced" but non-empty test suite is generated we also want to add tests
+	// that don't have any path expression (run_if_changed) and thus should always be added.
+	if len(testsToRun) != 0 {
+		for _, suite := range testSuites.List {
+			if len(suite.RunIfChanged) == 0 {
+				for _, test := range suite.Tests {
+					testsToRun[test.Name] = true
+				}
+			}
+		}
+	}
+
+	return keys(testsToRun), nil
+}
+
+func keys(stringMap map[string]bool) []string {
+	keys := make([]string, 0, len(stringMap))
+	for k := range stringMap {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func saveTests(filePath *string, tests []byte) error {
+	if err := os.WriteFile(*filePath, tests, os.ModePerm); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/testselect/testselect.go
+++ b/pkg/testselect/testselect.go
@@ -1,0 +1,69 @@
+// prowgen generates openshift/release configurations based on the OpenShift serverless
+// teams conventions.
+//
+// For example, it extracts image builds Dockerfile from the common
+// directory `openshift/ci-operator/**/Dockerfile.
+//
+// To onboard a new repository, update the configuration in config/repositories.yaml
+// and run the program, or alternatively, you can provide your own configuration file
+// using the -config <path> argument.
+
+package testselect
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v2"
+	"k8s.io/test-infra/prow/clonerefs"
+)
+
+// TestSuites holds mapping between file path regular expressions and
+// test suites that cover the paths.
+type TestSuites struct {
+	List []TestSuite `json:"testsuites" yaml:"testsuites"`
+}
+
+type TestSuite struct {
+	Name 		 string   `json:"name" yaml:"name"`
+	RunIfChanged []string `json:"run_if_changed" yaml:"run_if_changed"`
+	Tests 		 []Test   `json:"tests" yaml:"tests"`
+}
+
+type Test struct {
+	Name 	 string `json:"name" yaml:"name"`
+	Upstream bool   `json:"upstream" yaml:"upstream"`
+}
+
+func Main() {
+	ts := flag.String("testsuites", "testsuites.yaml", "Specify yaml file with path-to-testsuite mapping")
+	// Clonerefs options as defined in https://github.com/kubernetes/test-infra/blob/master/prow/clonerefs/options.go
+	refs := flag.String("clonerefs", "clonerefs.json", "Specify json file with clonerefs")
+	flag.Parse()
+
+	log.Println(*ts, *refs)
+
+	inRefs, err := os.ReadFile(*refs)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	cloneRefs := new(clonerefs.Options)
+	if err := json.Unmarshal(inRefs, cloneRefs); err != nil {
+		log.Fatalln("Unmarshal clone refs options", err)
+	}
+
+	inTs, err := os.ReadFile(*ts)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	testSuites := new(TestSuites)
+	if err := yaml.UnmarshalStrict(inTs, testSuites); err != nil {
+		log.Fatalln("Unmarshal test suite mappings", err)
+	}
+
+	log.Printf("Clonerefs:\n %+v\n TestSuites:\n%+v \n", cloneRefs, testSuites)
+}

--- a/pkg/testselect/testselect_test.go
+++ b/pkg/testselect/testselect_test.go
@@ -83,12 +83,21 @@ func TestSelectTestsuites(t *testing.T) {
 			},
 		},
 		{
-			name: "Choose None",
+			name: "Choose always-run tests #1",
 			paths: []string{
 				"hack/generate/csv.sh",
 				"docs/mesh.md",
 			},
-			selectedTests: []string{},
+			selectedTests: []string{
+				"serverless_operator_e2e_tests",
+			},
+		},
+		{
+			name: "Choose always-run tests #2",
+			paths: []string{},
+			selectedTests: []string{
+				"serverless_operator_e2e_tests",
+			},
 		},
 	}
 

--- a/pkg/testselect/testselect_test.go
+++ b/pkg/testselect/testselect_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 type test struct {
-	name string
-	paths []string
+	name          string
+	paths         []string
 	selectedTests []string
 }
 
 func TestSelectTestsuites(t *testing.T) {
 	ts := TestSuites{
-		List: []TestSuite {
+		List: []TestSuite{
 			{
 				Name: "Run Always",
 				// RunIfChanged: not defined
@@ -93,7 +93,7 @@ func TestSelectTestsuites(t *testing.T) {
 			},
 		},
 		{
-			name: "Choose always-run tests #2",
+			name:  "Choose always-run tests #2",
 			paths: []string{},
 			selectedTests: []string{
 				"serverless_operator_e2e_tests",

--- a/pkg/testselect/testselect_test.go
+++ b/pkg/testselect/testselect_test.go
@@ -18,10 +18,8 @@ func TestSelectTestsuites(t *testing.T) {
 			{
 				Name: "Run Always",
 				// RunIfChanged: not defined
-				Tests: []Test{
-					{
-						Name: "serverless_operator_e2e_tests",
-					},
+				Tests: []string{
+					"serverless_operator_e2e_tests",
 				},
 			},
 			{
@@ -30,13 +28,9 @@ func TestSelectTestsuites(t *testing.T) {
 					"^knative-operator/pkg/controller/knativekafka/",
 					"^knative-operator/pkg/webhook/knativekafka/",
 				},
-				Tests: []Test{
-					{
-						Name: "serverless_operator_kafka_e2e_tests",
-					},
-					{
-						Name: "downstream_knative_kafka_e2e_tests",
-					},
+				Tests: []string{
+					"serverless_operator_kafka_e2e_tests",
+					"downstream_knative_kafka_e2e_tests",
 				},
 			},
 			{
@@ -45,13 +39,9 @@ func TestSelectTestsuites(t *testing.T) {
 					"^knative-operator/pkg/controller/knativeeventing/",
 					"^knative-operator/pkg/webhook/knativeeventing/",
 				},
-				Tests: []Test{
-					{
-						Name: "downstream_eventing_e2e_tests",
-					},
-					{
-						Name: "upstream_knative_eventing_e2e",
-					},
+				Tests: []string{
+					"downstream_eventing_e2e_tests",
+					"upstream_knative_eventing_e2e",
 				},
 			},
 			{

--- a/pkg/testselect/testselect_test.go
+++ b/pkg/testselect/testselect_test.go
@@ -1,0 +1,124 @@
+package testselect
+
+import "testing"
+
+type test struct {
+	name string
+	upstream bool
+	paths []string
+	selectedTests []string
+}
+
+func TestSelectTestsuites(t *testing.T) {
+	ts := TestSuites{
+		List: []TestSuite {
+			{
+				Name: "Always",
+				//RunIfChanged: not defined
+				Tests: []Test{
+					{
+						Name: "serverless_operator_e2e_tests",
+						Upstream: false,
+					},
+				},
+			},
+			{
+				Name: "Eventing Kafka",
+				RunIfChanged: []string{
+					"^knative-operator/pkg/controller/knativekafka/",
+					"^knative-operator/pkg/webhook/knativekafka/",
+				},
+				Tests: []Test{
+					{
+						Name: "serverless_operator_kafka_e2e_tests",
+						Upstream: false,
+					},
+					{
+						Name: "downstream_knative_kafka_e2e_tests",
+						Upstream: false,
+					},
+				},
+			},
+			{
+				Name: "Eventing",
+				RunIfChanged: []string{
+					"^knative-operator/pkg/controller/knativeeventing/",
+					"^knative-operator/pkg/webhook/knativeeventing/",
+				},
+				Tests: []Test{
+					{
+						Name: "downstream_eventing_e2e_tests",
+						Upstream: false,
+					},
+					{
+						Name: "upstream_knative_eventing_e2e",
+						Upstream: true,
+					},
+				},
+			},
+			{
+				Name: "NoTests",
+				RunIfChanged: []string{
+					"^hack/generate/",
+					"^docs/",
+				},
+				// Tests: not defined
+			},
+		},
+	}
+
+	tests := []test{
+		{
+			name: "Choose Eventing, Eventing Kafka, Common",
+			upstream: false,
+			paths: []string{
+				"knative-operator/pkg/webhook/knativeeventing/webhook_mutating.go",
+				"knative-operator/pkg/webhook/knativekafka/webhook_validating.go",
+			},
+			selectedTests: []string{
+				"downstream_eventing_e2e_tests",
+				"serverless_operator_kafka_e2e_tests",
+				"downstream_knative_kafka_e2e_tests",
+				"serverless_operator_e2e_tests",
+			},
+		},
+		{
+			name: "Choose All",
+			upstream: false,
+			paths: []string{
+				"hack/generate/csv.sh",
+				"docs/mesh.md",
+				"hack/lib/serverless.bash",
+			},
+			selectedTests: []string{
+				"All",
+			},
+		},
+		{
+			name: "Choose None",
+			upstream: false,
+			paths: []string{
+				"hack/generate/csv.sh",
+				"docs/mesh.md",
+			},
+			selectedTests: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := filterTests(ts, tt.paths, tt.upstream)
+			if err != nil {
+				t.Error(err)
+			}
+			if len(result) != len(tt.selectedTests) {
+				t.Fatalf("Selected tests don't match, got: %v, want: %v", result, tt.selectedTests)
+			}
+			for i, tst := range result {
+				if tst != tt.selectedTests[i] {
+					t.Fatalf("Unexpected test. Got: %s, want: %s", tst, tt.selectedTests[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/testselect/testselect_test.go
+++ b/pkg/testselect/testselect_test.go
@@ -98,8 +98,6 @@ func TestSelectTestsuites(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			t.Logf("Expected: %+v", tt.selectedTests)
-			t.Logf("Result: %+v", result)
 			diff := cmp.Diff(tt.selectedTests, result)
 			if diff != "" {
 				t.Errorf("Unexpected tests (-want, +got): \n%s", diff)

--- a/pkg/testselect/testselect_test.go
+++ b/pkg/testselect/testselect_test.go
@@ -80,6 +80,9 @@ func TestSelectTestsuites(t *testing.T) {
 			},
 			selectedTests: []string{
 				"All",
+				"downstream_knative_kafka_e2e_tests",
+				"serverless_operator_e2e_tests",
+				"serverless_operator_kafka_e2e_tests",
 			},
 		},
 		{


### PR DESCRIPTION
It is used in https://github.com/openshift-knative/serverless-operator/pull/1985

Example clonerefs file looks like this:
```
{
  "src_root":"/go",
  "log":"/dev/null",
  "git_user_name":"ci-robot",
  "git_user_email":"ci-robot@openshift.io",
  "refs":[
    {
      "org":"openshift-knative",
      "repo":"serverless-operator",
      "repo_link":"https://github.com/openshift-knative/serverless-operator",
      "base_ref":"main",
      "base_sha":"c87aedad039fb1b605ad799bf8c6166b84f4bf0d",
      "base_link":"https://github.com/openshift-knative/serverless-operator/commit/c87aedad039fb1b605ad799bf8c6166b84f4bf0d",
      "pulls":[
        {
          "number":1965,
          "author":"mgencur",
          "sha":"dfe84fd44fbdba3c2561da74ef96a702b418116c",
          "link":"https://github.com/openshift-knative/serverless-operator/pull/1965",
          "commit_link":"https://github.com/openshift-knative/serverless-operator/pull/1965/commits/dfe84fd44fbdba3c2561da74ef96a702b418116c",
          "author_link":"https://github.com/mgencur"
        }
      ]
    }
  ],
  "fail":true
}
```
Example testsuites.yaml:
```
testsuites:
  - name: "Serverless Operator E2E"
    run_if_changed:
      - ^knative-operator/pkg/controller/knativeeventing/
      - ^knative-operator/pkg/controller/knativeserving/
      - ^knative-operator/pkg/webhook/knativeeventing/
      - ^knative-operator/pkg/webhook/knativeserving/
      - ^openshift-knative-operator/cmd/operator/kodata/knative-eventing/
      - ^openshift-knative-operator/cmd/operator/kodata/knative-serving/
      - ^openshift-knative-operator/pkg/eventing/
      - ^openshift-knative-operator/pkg/serving/
      - ^serving/ingress/
    tests:
      - serverless_operator_e2e_tests
  - name: "Eventing Kafka"
    run_if_changed:
      - "^knative-operator/pkg/controller/knativekafka/"
      - "^knative-operator/pkg/webhook/knativekafka/"
    tests:
      - serverless_operator_kafka_e2e_tests
      - downstream_knative_kafka_e2e_tests
      - upstream_knative_eventing_kafka_e2e
      - upstream_knative_eventing_kafka_broker_e2e
```
