### PR TITLE
Remove the 1.5 midstream CI since we do not support 1.26 anymore

### DIFF
--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -2,10 +2,6 @@
 
 config:
   branches:
-    "release-v1.5":
-      openShiftVersions:
-        - 4.11
-        - 4.8
     "release-v1.6":
       openShiftVersions:
         - 4.12

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -2,10 +2,6 @@
 
 config:
   branches:
-    "release-v1.5":
-      openShiftVersions:
-        - 4.11
-        - 4.8
     "release-v1.6":
       openShiftVersions:
         - 4.12


### PR DESCRIPTION
This PR was used to generate this one: https://github.com/openshift/release/pull/38743