### PR TITLE
Install missing zoneinfo into to ubi-minimal image

### DIFF
--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r {{ .main }}/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/generate/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/generate/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/generate/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/prowgen/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/prowgen/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/prowgen/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main

--- a/pkg/project/testoutput/openshift/ci-operator/knative-test-images/testselect/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-test-images/testselect/Dockerfile
@@ -9,6 +9,10 @@ RUN mkdir -p /var/run/ko && \
     cp -r cmd/testselect/kodata /var/run/ko
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
 USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main


### PR DESCRIPTION
The `zoneinfo` is missing on UBI Minimal images, but the `PingSource` makes usage of that, hence installing it to our midstream images