### PR TITLE
Add 'make clean' and remove duplicated target commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,31 +2,21 @@
 # replacing reference images via env variable.
 include pkg/project/testdata/env
 
-generate-ci:
-	rm -rf openshift openshift-knative
+generate-ci: clean generate-eventing-ci generate-serving-ci
+.PHONY: generate-ci
+
+generate-eventing-ci: clean
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing.yaml --remote $(REMOTE)
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing-istio.yaml --remote $(REMOTE)
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing-kafka-broker.yaml --remote $(REMOTE)
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing-hyperfoil-benchmark.yaml --remote $(REMOTE)
+.PHONY: generate-eventing-ci
+
+generate-serving-ci: clean
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving.yaml --remote $(REMOTE)
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving-net-istio.yaml --remote $(REMOTE)
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving-net-kourier.yaml --remote $(REMOTE)
-.PHONY: generate-ci
-
-generate-serving-ci:
-	rm -rf openshift openshift-knative
-	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving.yaml --remote $(REMOTE)
-	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving-net-istio.yaml --remote $(REMOTE)
-	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving-net-kourier.yaml --remote $(REMOTE)
-.PHONY: generate-ci
-
-generate-eventing-ci:
-	rm -rf openshift openshift-knative
-	go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing.yaml --remote $(REMOTE)
-	go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing-istio.yaml --remote $(REMOTE)
-	go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing-kafka-broker.yaml --remote $(REMOTE)
-	go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing-hyperfoil-benchmark.yaml --remote $(REMOTE)
-.PHONY: generate-ci
+.PHONY: generate-serving-ci
 
 unit-tests:
 	go test ./pkg/...
@@ -46,3 +36,7 @@ unit-tests:
 test-select:
 	go run github.com/openshift-knative/hack/cmd/testselect --testsuites $(TESTSUITES) --clonerefs $(CLONEREFS) --output=tests.txt
 .PHONY: test-select
+
+clean:
+	rm -rf openshift openshift-knative
+.PHONY: clean


### PR DESCRIPTION
As per title, this patch cleans up Makefile.