### PR TITLE
Use openshift-knative/hack for net-* repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ generate-ci:
 generate-serving-ci:
 	rm -rf openshift openshift-knative
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving.yaml --remote $(REMOTE)
+	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving-net-istio.yaml --remote $(REMOTE)
+	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving-net-kourier.yaml --remote $(REMOTE)
 .PHONY: generate-ci
 
 generate-eventing-ci:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -1,0 +1,18 @@
+# Full struct in cmd/prowgen/prowgen.go#Config
+
+config:
+  branches:
+    "release-1.9":
+      openShiftVersions:
+        - 4.12
+        - 4.10
+    "release-1.10":
+      openShiftVersions:
+        - 4.12
+        - 4.10
+
+repositories:
+  - org: openshift-knative
+    repo: net-istio
+    imagePrefix: net-istio
+    slackChannel: "#knative-serving-ci"

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -2,11 +2,11 @@
 
 config:
   branches:
-    "release-1.9":
+    "release-v1.9":
       openShiftVersions:
         - 4.12
         - 4.10
-    "release-1.10":
+    "release-v1.10":
       openShiftVersions:
         - 4.12
         - 4.10

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -2,11 +2,11 @@
 
 config:
   branches:
-    "release-1.9":
+    "release-v1.9":
       openShiftVersions:
         - 4.12
         - 4.10
-    "release-1.10":
+    "release-v1.10":
       openShiftVersions:
         - 4.12
         - 4.10

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -1,0 +1,18 @@
+# Full struct in cmd/prowgen/prowgen.go#Config
+
+config:
+  branches:
+    "release-1.9":
+      openShiftVersions:
+        - 4.12
+        - 4.10
+    "release-1.10":
+      openShiftVersions:
+        - 4.12
+        - 4.10
+
+repositories:
+  - org: openshift-knative
+    repo: net-kourier
+    imagePrefix: net-kourier
+    slackChannel: "#knative-serving-ci"

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -127,7 +127,12 @@ func (t *Test) HexSha() string {
 }
 
 func discoverE2ETests(r Repository) ([]Test, error) {
-	mc, err := os.ReadFile(filepath.Join(r.RepositoryDirectory(), "Makefile"))
+	makefilePath := filepath.Join(r.RepositoryDirectory(), "Makefile")
+	if _, err := os.Stat(makefilePath); err != nil && os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	mc, err := os.ReadFile(makefilePath)
 	if err != nil {
 		return nil, fmt.Errorf("[%s] failed to read file %s: %w", r.RepositoryDirectory(), "Makefile", err)
 	}


### PR DESCRIPTION
- Use openshift-knative/hack for net-* repositories
- Do not fail if no `Makefile` is defined in the repository

