### PR TITLE
Introduce Prowcopy to generate Prow config starting from another branch config

### DIFF
--- a/cmd/prowcopy/main.go
+++ b/cmd/prowcopy/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+
+	"github.com/openshift-knative/hack/pkg/prowcopy"
+)
+
+func main() {
+	if err := prowcopy.Main(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/prowcopy/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/prowcopy/Dockerfile
@@ -1,0 +1,20 @@
+# DO NOT EDIT! Generated Dockerfile for cmd/prowgen.
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+
+RUN mkdir -p /var/run/ko && \
+    mkdir -p cmd/prowgen/kodata && \
+    go build -o /usr/bin/main ./cmd/prowgen && \
+    cp -r cmd/prowgen/kodata /var/run/ko
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
+USER 65532
+
+COPY --from=builder /usr/bin/main /usr/bin/main
+COPY --from=builder /var/run/ko /var/run/ko
+ENTRYPOINT ["/usr/bin/main"]

--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -24,6 +24,7 @@ type Config struct {
 	Branch         string
 	Tag            string
 	RemovePeriodic bool
+	Remote         string
 }
 
 func Main() error {
@@ -37,6 +38,7 @@ func Main() error {
 	flag.StringVar(&c.Branch, "branch", "", "Target branch name")
 	flag.StringVar(&c.Tag, "tag", "", "Target promotion name or tag")
 	flag.BoolVar(&c.RemovePeriodic, "remove-periodic-tests", true, "Remove periodic tests")
+	flag.StringVar(&c.Remote, "remote", "", "Git remote URL")
 	flag.Parse()
 
 	// Clone openshift/release and clean up existing jobs for the configured branches
@@ -74,7 +76,7 @@ func Main() error {
 		log.Fatalln("Failed to run openshift/release generator:", err)
 	}
 
-	if err := prowgen.PushBranch(ctx, openShiftRelease, nil, fmt.Sprintf("generate-%s-%s-%s-ci-config", c.Org, c.Repo, c.Branch), ""); err != nil {
+	if err := prowgen.PushBranch(ctx, openShiftRelease, &c.Remote, fmt.Sprintf("generate-%s-%s-%s-ci-config", c.Org, c.Repo, c.Branch), ""); err != nil {
 		log.Fatalln("Failed to run openshift/release generator:", err)
 	}
 

--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -1,0 +1,169 @@
+package prowcopy
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gyaml "github.com/ghodss/yaml"
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"k8s.io/utils/pointer"
+
+	"github.com/openshift-knative/hack/pkg/prowgen"
+)
+
+type Config struct {
+	Org            string
+	Repo           string
+	FromBranch     string
+	Branch         string
+	Tag            string
+	RemovePeriodic bool
+}
+
+func Main() error {
+	ctx := context.Background()
+
+	c := Config{}
+
+	flag.StringVar(&c.Org, "org", "openshift-knative", "GH organization name")
+	flag.StringVar(&c.Repo, "repo", "serverless-operator", "GH repository name")
+	flag.StringVar(&c.FromBranch, "from-branch", "main", "Branch name to copy prow configs from")
+	flag.StringVar(&c.Branch, "branch", "", "Target branch name")
+	flag.StringVar(&c.Tag, "tag", "", "Target promotion name or tag")
+	flag.BoolVar(&c.RemovePeriodic, "remove-periodic-tests", true, "Remove periodic tests")
+	flag.Parse()
+
+	// Clone openshift/release and clean up existing jobs for the configured branches
+	openShiftRelease := prowgen.Repository{
+		Org:  "openshift",
+		Repo: "release",
+	}
+	if err := prowgen.InitializeOpenShiftReleaseRepository(ctx, openShiftRelease, &prowgen.Config{}, pointer.String("")); err != nil {
+		return err
+	}
+
+	if err := prowgen.DeleteExistingReleaseBuildConfigurationForBranch(pointer.String(""), prowgen.Repository{Org: c.Org, Repo: c.Repo}, c.Branch); err != nil {
+		return err
+	}
+
+	files, err := discoverJobConfigs(openShiftRelease, c)
+	if err != nil {
+		return err
+	}
+	log.Println("Matching job configs for branch", c.FromBranch, "files", files)
+
+	jobs, err := getJobConfigs(files, c)
+	if err != nil {
+		return err
+	}
+	log.Println("Got", len(jobs), "jobs config")
+
+	for _, j := range jobs {
+		if err := prowgen.SaveReleaseBuildConfiguration(pointer.String(""), j); err != nil {
+			return err
+		}
+	}
+
+	if err := prowgen.RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
+		log.Fatalln("Failed to run openshift/release generator:", err)
+	}
+
+	if err := prowgen.PushBranch(ctx, openShiftRelease, nil, fmt.Sprintf("generate-%s-%s-%s-ci-config", c.Org, c.Repo, c.Branch), ""); err != nil {
+		log.Fatalln("Failed to run openshift/release generator:", err)
+	}
+
+	return nil
+}
+
+func getJobConfigs(files []string, c Config) ([]prowgen.ReleaseBuildConfiguration, error) {
+	jobs := make([]prowgen.ReleaseBuildConfiguration, 0, len(files))
+	for _, match := range files {
+		jc, err := getJobConfig(match, c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get job config for %s: %w", match, err)
+		}
+		jobs = append(jobs, *jc)
+	}
+
+	return transform(jobs, c), nil
+}
+
+func discoverJobConfigs(openShiftRelease prowgen.Repository, c Config) ([]string, error) {
+	ciConfigDir := filepath.Join(openShiftRelease.RepositoryDirectory(), "ci-operator", "config", c.Org, c.Repo)
+
+	glob := filepath.Join(ciConfigDir, fmt.Sprintf("%s-%s-%s__*.yaml", c.Org, c.Repo, c.FromBranch))
+	log.Println(glob)
+	return filepath.Glob(glob)
+}
+
+func transform(jobs []prowgen.ReleaseBuildConfiguration, c Config) []prowgen.ReleaseBuildConfiguration {
+	r := make([]prowgen.ReleaseBuildConfiguration, 0, len(jobs))
+	for _, j := range jobs {
+		j = removePeriodicTests(j, c)
+		r = append(r, j)
+	}
+
+	return r
+}
+
+func removePeriodicTests(job prowgen.ReleaseBuildConfiguration, c Config) prowgen.ReleaseBuildConfiguration {
+	if !c.RemovePeriodic {
+		return job
+	}
+
+	tests := make([]cioperatorapi.TestStepConfiguration, 0, len(job.Tests))
+	for _, t := range job.Tests {
+		if t.Cron != nil && *t.Cron != "" {
+			continue
+		}
+		tests = append(tests, *t.DeepCopy())
+	}
+
+	r := prowgen.ReleaseBuildConfiguration{
+		ReleaseBuildConfiguration: *job.DeepCopy(),
+		Path:                      job.Path,
+		Branch:                    job.Branch,
+	}
+	r.Tests = tests
+
+	return r
+}
+
+func getJobConfig(match string, c Config) (*prowgen.ReleaseBuildConfiguration, error) {
+	// Going directly from YAML raw input produces unexpected configs (due to missing YAML tags),
+	// so we convert YAML to JSON and unmarshal the struct from the JSON object.
+	y, err := os.ReadFile(match)
+	if err != nil {
+		return nil, err
+	}
+	j, err := gyaml.YAMLToJSON(y)
+	if err != nil {
+		return nil, err
+	}
+
+	jobConfig := &prowgen.ReleaseBuildConfiguration{}
+	if err := json.Unmarshal(j, jobConfig); err != nil {
+		return nil, err
+	}
+
+	jobConfig.Path = strings.Replace(match, c.FromBranch, c.Branch, 1)
+	jobConfig.Branch = c.Branch
+	jobConfig.Metadata.Branch = c.Branch
+
+	if jobConfig.PromotionConfiguration != nil && c.Tag != "" {
+		if jobConfig.PromotionConfiguration.Name != "" {
+			jobConfig.PromotionConfiguration.Name = c.Tag
+		}
+		if jobConfig.PromotionConfiguration.Tag != "" {
+			jobConfig.PromotionConfiguration.Tag = c.Tag
+		}
+	}
+
+	return jobConfig, nil
+}

--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -27,6 +27,11 @@ type Config struct {
 	Remote         string
 }
 
+// Main is the main function for prowcopy.
+//
+// prowcopy allows to create Prow configuration in openshift/release starting from the configuration
+// of another branch. For example, if you have configuration for CI of the main branch, and then you
+// cut a new branch, the main branch configuration can be used to define CI of the new branch.
 func Main() error {
 	ctx := context.Background()
 

--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -76,10 +76,6 @@ func Main() error {
 		log.Fatalln("Failed to run openshift/release generator:", err)
 	}
 
-	if err := prowgen.PushBranch(ctx, openShiftRelease, &c.Remote, fmt.Sprintf("generate-%s-%s-%s-ci-config", c.Org, c.Repo, c.Branch), ""); err != nil {
-		log.Fatalln("Failed to run openshift/release generator:", err)
-	}
-
 	return nil
 }
 

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -145,7 +145,7 @@ func PushBranch(ctx context.Context, release Repository, remote *string, branch 
 	if _, err := run(ctx, release, "git", "add", "."); err != nil {
 		return err
 	}
-	if _, err := run(ctx, release, "git", "commit", "-s", "-S", "-m", "Sync Serverless CI "+config); err != nil {
+	if _, err := run(ctx, release, "git", "commit", "-m", "Sync Serverless CI "+config); err != nil {
 		// Ignore error since we could have nothing to commit
 		log.Println("Ignored error", err)
 	}

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -70,7 +70,7 @@ func Main() {
 	// Clone openshift/release and clean up existing jobs for the configured branches
 	openshiftReleaseInitialization, openshiftReleaseInitCtx := errgroup.WithContext(ctx)
 	openshiftReleaseInitialization.Go(func() error {
-		return initializeOpenShiftReleaseRepository(openshiftReleaseInitCtx, openShiftRelease, inConfig, outConfig)
+		return InitializeOpenShiftReleaseRepository(openshiftReleaseInitCtx, openShiftRelease, inConfig, outConfig)
 	})
 
 	// For each repository and branch generate openshift/release configuration, and write it to the output file.
@@ -92,14 +92,14 @@ func Main() {
 
 			// Delete existing configuration for each configured branch.
 			for branch := range inConfig.Config.Branches {
-				if err := deleteExistingReleaseBuildConfigurationForBranch(outConfig, repository, branch); err != nil {
+				if err := DeleteExistingReleaseBuildConfigurationForBranch(outConfig, repository, branch); err != nil {
 					return err
 				}
 			}
 
 			// Write generated configurations.
 			for _, cfg := range cfgs {
-				if err := saveReleaseBuildConfiguration(outConfig, cfg); err != nil {
+				if err := SaveReleaseBuildConfiguration(outConfig, cfg); err != nil {
 					return err
 				}
 			}
@@ -122,31 +122,25 @@ func Main() {
 		log.Fatalln("Failed waiting for repositories generator", err)
 	}
 
-	if err := runOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
+	if err := RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
 		log.Fatalln("Failed to run openshift/release generator:", err)
 	}
 	if err := runJobConfigInjectors(inConfig, openShiftRelease); err != nil {
 		log.Fatalln("Failed to inject Slack reporter", err)
 	}
-	if err := runOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
+	if err := RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
 		log.Fatalln("Failed to run openshift/release generator after injecting Slack reporter", err)
 	}
-	if err := pushBranch(ctx, openShiftRelease, remote, "sync-serverless-ci", *inputConfig); err != nil {
+	if err := PushBranch(ctx, openShiftRelease, remote, "sync-serverless-ci", *inputConfig); err != nil {
 		log.Fatalln("Failed to push branch to openshift/release fork", *remote, err)
 	}
 }
 
-func pushBranch(ctx context.Context, release Repository, remote *string, branch string, config string) error {
-	if remote == nil || *remote == "" {
-		return nil
-	}
-
-	log.Println("Pushing branch", branch, "to", *remote)
+func PushBranch(ctx context.Context, release Repository, remote *string, branch string, config string) error {
 
 	// Ignore error since remote and branch might be already there
 	_, _ = run(ctx, release, "git", "checkout", "-b", branch)
 	_, _ = run(ctx, release, "git", "checkout", branch)
-	_, _ = run(ctx, release, "git", "remote", "add", "fork", *remote)
 
 	if _, err := run(ctx, release, "git", "add", "."); err != nil {
 		return err
@@ -155,6 +149,14 @@ func pushBranch(ctx context.Context, release Repository, remote *string, branch 
 		// Ignore error since we could have nothing to commit
 		log.Println("Ignored error", err)
 	}
+
+	if remote == nil || *remote == "" {
+		return nil
+	}
+
+	log.Println("Pushing branch", branch, "to", *remote)
+
+	_, _ = run(ctx, release, "git", "remote", "add", "fork", *remote)
 	if _, err := run(ctx, release, "git", "push", "fork", branch, "-f"); err != nil {
 		return err
 	}
@@ -162,7 +164,7 @@ func pushBranch(ctx context.Context, release Repository, remote *string, branch 
 	return nil
 }
 
-func deleteExistingReleaseBuildConfigurationForBranch(outConfig *string, r Repository, branch string) error {
+func DeleteExistingReleaseBuildConfigurationForBranch(outConfig *string, r Repository, branch string) error {
 	dir := filepath.Join(*outConfig, r.RepositoryDirectory())
 	matches, err := filepath.Glob(filepath.Join(dir, "*"+branch+"*"))
 	if err != nil {
@@ -179,7 +181,7 @@ func deleteExistingReleaseBuildConfigurationForBranch(outConfig *string, r Repos
 	return nil
 }
 
-func saveReleaseBuildConfiguration(outConfig *string, cfg ReleaseBuildConfiguration) error {
+func SaveReleaseBuildConfiguration(outConfig *string, cfg ReleaseBuildConfiguration) error {
 	dir := filepath.Join(*outConfig, filepath.Dir(cfg.Path))
 
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
@@ -201,7 +203,7 @@ func saveReleaseBuildConfiguration(outConfig *string, cfg ReleaseBuildConfigurat
 	return nil
 }
 
-func runOpenShiftReleaseGenerator(ctx context.Context, openShiftRelease Repository) error {
+func RunOpenShiftReleaseGenerator(ctx context.Context, openShiftRelease Repository) error {
 	if _, err := run(ctx, openShiftRelease, "make", "ci-operator-config", "jobs"); err != nil {
 		return err
 	}
@@ -361,9 +363,9 @@ func getJobConfig(match string) (*prowconfig.JobConfig, error) {
 	return jobConfig, nil
 }
 
-// initializeOpenShiftReleaseRepository clones openshift/release and clean up existing jobs
+// InitializeOpenShiftReleaseRepository clones openshift/release and clean up existing jobs
 // for the configured branches
-func initializeOpenShiftReleaseRepository(ctx context.Context, openShiftRelease Repository, inConfig *Config, outputConfig *string) error {
+func InitializeOpenShiftReleaseRepository(ctx context.Context, openShiftRelease Repository, inConfig *Config, outputConfig *string) error {
 	if err := GitMirror(ctx, openShiftRelease); err != nil {
 		return err
 	}

--- a/pkg/prowgen/prowgen_git.go
+++ b/pkg/prowgen/prowgen_git.go
@@ -45,6 +45,7 @@ func gitClone(ctx context.Context, r Repository, mirror bool) error {
 
 	remoteRepo := fmt.Sprintf("https://github.com/%s/%s.git", r.Org, r.Repo)
 	if mirror {
+		log.Println("Mirroring repository", r.RepositoryDirectory())
 		if _, err := runNoRepo(ctx, "git", "clone", "--mirror", remoteRepo, filepath.Join(r.RepositoryDirectory(), ".git")); err != nil {
 			return fmt.Errorf("[%s] failed to clone repository: %w", r.RepositoryDirectory(), err)
 		}
@@ -52,6 +53,7 @@ func gitClone(ctx context.Context, r Repository, mirror bool) error {
 			return fmt.Errorf("[%s] failed to set config for repository: %w", r.RepositoryDirectory(), err)
 		}
 	} else {
+		log.Println("Cloning repository", r.RepositoryDirectory())
 		if _, err := runNoRepo(ctx, "git", "clone", remoteRepo, r.RepositoryDirectory()); err != nil {
 			return fmt.Errorf("[%s] failed to clone repository: %w", r.RepositoryDirectory(), err)
 		}


### PR DESCRIPTION
`prowcopy` allows to create Prow configuration in openshift/release starting from the configuration
of another branch. For example, if you have configuration for CI of the main branch, and then you
cut a new branch, the main branch configuration can be used to define CI of the new branch.

For now, it is specifically tailored for serverless-operator.

This is to be able to automate PRs like: https://github.com/openshift/release/pull/40491 using
workflows like: https://github.com/pierDipi/serverless-operator/blob/main/.github/workflows/release-generate-ci.yaml

See usage in https://github.com/openshift-knative/serverless-operator/pull/2131