### PR TITLE
Use OCP 4.13 for serving midstream CI

### DIFF
--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -4,11 +4,11 @@ config:
   branches:
     "release-v1.9":
       openShiftVersions:
-        - 4.12
+        - 4.13
         - 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.12
+        - 4.13
         - 4.10
 
 repositories:

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -4,11 +4,11 @@ config:
   branches:
     "release-v1.9":
       openShiftVersions:
-        - 4.12
+        - 4.13
         - 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.12
+        - 4.13
         - 4.10
 
 repositories:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -5,22 +5,22 @@ config:
     "release-v1.8":
       cron: "0 19 * * 1-5"
       openShiftVersions:
-        - 4.12
+        - 4.13
         - 4.10
     "release-v1.9":
       cron: "0 21 * * 1-5"
       openShiftVersions:
-        - 4.12
+        - 4.13
         - 4.10
     "release-v1.10":
       cron: "0 23 * * 1-5"
       openShiftVersions:
-        - 4.12
+        - 4.13
         - 4.10
     "release-next":
       cron: "0 8 * * 1-5"
       openShiftVersions:
-        - 4.12
+        - 4.13
         - 4.10
 
 repositories:


### PR DESCRIPTION
This patch changes to use OCP 4.13 for serving midstream CI.
The configfiles generated by this change is adding via https://github.com/openshift/release/pull/40674

/cc @skonto @ReToCode 