### PR TITLE
Added release-v1.10 to config for CI

### DIFF
--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -18,6 +18,10 @@ config:
       openShiftVersions:
         - 4.12
         - 4.10
+    "release-v1.10":
+      openShiftVersions:
+        - 4.13
+        - 4.10
     "release-next":
       openShiftVersions:
         - 4.12


### PR DESCRIPTION
This PR adds release-v1.10 for the eventing kafka broker to the CI config.

The generated CI files for `openshift/release` are here: https://github.com/openshift/release/pull/40854