### PR TITLE
Set base branch for `create-pull-request` action

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -59,6 +59,7 @@ jobs:
         with:
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
           path: ./src/github.com/openshift-knative/hack/openshift/release
+          base: master
           branch: sync-serverless-ci
           title: "Sync Serverless CI"
           commit-message: "Sync Serverless CI"


### PR DESCRIPTION
The action assumes the working branch as base branch, which is not
what we want since the working branch is the target branch of the
fork for us.

see https://github.com/peter-evans/create-pull-request/blob/5f8399b325911a0981ba132a51cceecce543d255/src/create-or-update-branch.ts#L116-L200