### PR TITLE
Reverting the CI for release-v1.10 to openshift 4.12

### DIFF
--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -20,7 +20,7 @@ config:
         - 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.13
+        - 4.12
         - 4.10
     "release-next":
       openShiftVersions:


### PR DESCRIPTION
It looks like the CI is failing on openshift 4.13 (potentially because of cert-manager GA). We will open a ticket to investigate this, but for now should revert to 4.12 so that there can be tests running on the `release-v1.10` branch.