### PR TITLE
Add CI for serving 1.11 family

### DIFF
--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -10,6 +10,10 @@ config:
       openShiftVersions:
         - 4.13
         - 4.10
+    "release-v1.11":
+      openShiftVersions:
+        - 4.13
+        - 4.10
 
 repositories:
   - org: openshift-knative

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -10,6 +10,10 @@ config:
       openShiftVersions:
         - 4.13
         - 4.10
+    "release-v1.11":
+      openShiftVersions:
+        - 4.13
+        - 4.10
 
 repositories:
   - org: openshift-knative

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -17,6 +17,11 @@ config:
       openShiftVersions:
         - 4.13
         - 4.10
+    "release-v1.11":
+      cron: "0 1 * * 1-5"
+      openShiftVersions:
+        - 4.13
+        - 4.10
     "release-next":
       cron: "0 8 * * 1-5"
       openShiftVersions:


### PR DESCRIPTION
As per title, this patch adds CI for serving 1.11 family.

/cc @skonto @ReToCode 