### PR TITLE
Drop cron config from serving

### DIFF
--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -3,27 +3,22 @@
 config:
   branches:
     "release-v1.8":
-      cron: "0 19 * * 1-5"
       openShiftVersions:
         - 4.13
         - 4.10
     "release-v1.9":
-      cron: "0 21 * * 1-5"
       openShiftVersions:
         - 4.13
         - 4.10
     "release-v1.10":
-      cron: "0 23 * * 1-5"
       openShiftVersions:
         - 4.13
         - 4.10
     "release-v1.11":
-      cron: "0 1 * * 1-5"
       openShiftVersions:
         - 4.13
         - 4.10
     "release-next":
-      cron: "0 8 * * 1-5"
       openShiftVersions:
         - 4.13
         - 4.10


### PR DESCRIPTION
As per title, cron config is modified by release repo's bot.
So this patch drops it.

Note, eventing and other config do not have it.