### PR TITLE
Bump OCP min version for release-next to 4.11

### DIFF
--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -21,7 +21,7 @@ config:
     "release-next":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
 
 repositories:
   - org: openshift-knative


### PR DESCRIPTION
OCP 4.10 is EOL on September 10, 2023 as per https://access.redhat.com/support/policy/updates/openshift#dates so release-next (serving 1.12) should not need to test on 4.10.

(Also, net-kourier introduced the grpc probe so we cannot use 4.10).

/cc @ReToCode @skonto 