### PR TITLE
Add workflow to run a command in a repository

### DIFF
--- a/.github/workflows/run-command-repository.yaml
+++ b/.github/workflows/run-command-repository.yaml
@@ -1,0 +1,66 @@
+---
+name: Run Makefile command
+
+on:
+  workflow_dispatch: # Manual workflow trigger
+    inputs:
+      repository:
+        description: "Repository 'org/name'"
+        default: "openshift-knative/eventing"
+        required: true
+      command:
+        description: "Command to run"
+        default: "generate-release"
+        required: true
+      branch:
+        description: "Branch name"
+        default: "release-v1.11"
+        required: true
+
+jobs:
+  run-command:
+    name: run-command ${{ inputs.repository }} - ${{ inputs.command }}
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+    steps:
+      - name: Setup Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.20.x
+
+      - name: Install prerequisites
+        env:
+          YQ_VERSION: 3.4.0
+        run: |
+          sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+          sudo mv /usr/bin/yq /usr/local/bin/yq
+
+      - name: Checkout ${{ inputs.repository }}
+        uses: actions/checkout@v3
+        with:
+          repository: '${{ inputs.repository }}'
+          path: "./src/github.com/${{ inputs.repository }}"
+
+      - name: Configure Git user
+        run: |
+          git config --global user.email "serverless-support@redhat.com"
+          git config --global user.name "OpenShift Serverless"
+
+      - name: Generate release
+        working-directory: "./src/github.com/${{ inputs.repository }}"
+        run: make ${{ inputs.command }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.SERVERLESS_QE_ROBOT }}
+          path: "./src/github.com/${{ inputs.repository }}"
+          base: ${{ inputs.branch }}
+          branch: run-command-${{ inputs.branch }}-${{ inputs.command }}
+          title: "[${{ inputs.branch }}] Run `make ${{ inputs.command }}`"
+          commit-message: "Run `make ${{ inputs.command }}`"
+          delete-branch: true
+          body: |
+            Run `make ${{ inputs.command }}` using openshift-knative/hack.


### PR DESCRIPTION
This will allow running `make generate-release` for a midstream repository.