### PR TITLE
Install helm from binary

### DIFF
--- a/cmd/generate/BuildImageDockerfile.template
+++ b/cmd/generate/BuildImageDockerfile.template
@@ -11,7 +11,12 @@ RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "repo_gpgcheck=0" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo
 
-RUN yum install -y kubectl httpd-tools helm
+RUN yum install -y kubectl httpd-tools
+
+RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 ./get-helm-3
+
+RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 

--- a/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
@@ -11,7 +11,12 @@ RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "repo_gpgcheck=0" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo
 
-RUN yum install -y kubectl httpd-tools helm
+RUN yum install -y kubectl httpd-tools
+
+RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 ./get-helm-3
+
+RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 


### PR DESCRIPTION
Some images are based on Centos7 and they don't have helm repositories and we get `No package helm available.`

Tested with:
```
docker build -f pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile .
```