### PR TITLE
Update ocp for recent knative eventings

### DIFF
--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -20,8 +20,8 @@ config:
         - 4.11
     "release-next":
       openShiftVersions:
-        - 4.12
-        - 4.10
+        - 4.13
+        - 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -17,7 +17,7 @@ config:
     "release-v1.11":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-next":
       openShiftVersions:
         - 4.12

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -25,7 +25,7 @@ config:
     "release-v1.11":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-next":
       openShiftVersions:
         - 4.12

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -28,8 +28,8 @@ config:
         - 4.11
     "release-next":
       openShiftVersions:
-        - 4.12
-        - 4.10
+        - 4.13
+        - 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -25,7 +25,7 @@ config:
     "release-v1.11":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-next":
       openShiftVersions:
         - 4.12

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -28,8 +28,8 @@ config:
         - 4.11
     "release-next":
       openShiftVersions:
-        - 4.12
-        - 4.10
+        - 4.13
+        - 4.11
 
 repositories:
   - org: openshift-knative


### PR DESCRIPTION
As per title

With 1.11 we do support 4.11+

Hence updating:
* 1.11
* release-next (and aligning to what serving does here)

