### PR TITLE
Update OCP min-versions to versions in release-matrix

### DIFF
--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -13,7 +13,7 @@ config:
     "release-v1.10":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-v1.11":
       openShiftVersions:
         - 4.13

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -21,7 +21,7 @@ config:
     "release-v1.10":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-v1.11":
       openShiftVersions:
         - 4.13

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -21,7 +21,7 @@ config:
     "release-v1.10":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-v1.11":
       openShiftVersions:
         - 4.13

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -9,11 +9,11 @@ config:
     "release-v1.10":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-v1.11":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -9,11 +9,11 @@ config:
     "release-v1.10":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-v1.11":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -13,11 +13,11 @@ config:
     "release-v1.10":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-v1.11":
       openShiftVersions:
         - 4.13
-        - 4.10
+        - 4.11
     "release-next":
       openShiftVersions:
         - 4.13


### PR DESCRIPTION
# Changes
- Update OCP min-versions to versions in release-matrix
  - 1.10 should have OCP min-version: 4.11
  - 1.11 should have OCP min-version: 4.11

/assign @nak3 
/assign @pierDipi 
/assign @skonto 
