### PR TITLE
Make generate-groups.sh and generate-knative.sh executable

### DIFF
--- a/cmd/generate/SourceImageDockerfile.template
+++ b/cmd/generate/SourceImageDockerfile.template
@@ -1,3 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile.
 
 FROM src
+
+RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh vendor/knative.dev/pkg/hack/generate-knative.sh


### PR DESCRIPTION
Place this in "src" template which is guaranteed to have the right version of Eventing checked out and workdir properly set. Upstream scripts make the files executable but they would fail because CI pods do not run with root access and don't have permissions to change ownership.