### PR TITLE
Add Serving 1.12 and bump to OCP 4.14

### DIFF
--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -8,11 +8,15 @@ config:
         - 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.13
+        - 4.14
         - 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.13
+        - 4.14
+        - 4.11
+    "release-v1.12":
+      openShiftVersions:
+        - 4.14
         - 4.11
 
 repositories:

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -8,11 +8,15 @@ config:
         - 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.13
+        - 4.14
         - 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.13
+        - 4.14
+        - 4.11
+    "release-v1.12":
+      openShiftVersions:
+        - 4.14
         - 4.11
 
 repositories:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -12,15 +12,19 @@ config:
         - 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.13
+        - 4.14
         - 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.13
+        - 4.14
+        - 4.11
+    "release-v1.12":
+      openShiftVersions:
+        - 4.14
         - 4.11
     "release-next":
       openShiftVersions:
-        - 4.13
+        - 4.14
         - 4.11
 
 repositories:


### PR DESCRIPTION
# Changes
- Add Serving CI for 1.12 branches
- Bump OCP min-version to 1.14 as it seems that OCP 4.14 build pools are now available

/assign @skonto 
/assign @nak3 
