### PR TITLE
Generate CI config for openshift-knative/serverless-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include pkg/project/testdata/env
 generate-ci: clean generate-eventing-ci generate-serving-ci
 .PHONY: generate-ci
 
-generate-ci-no-clean: generate-eventing-ci generate-serving-ci
+generate-ci-no-clean: generate-eventing-ci generate-serving-ci generate-serverless-operator-ci
 .PHONY: generate-ci-no-clean
 
 generate-eventing-ci:
@@ -23,7 +23,7 @@ generate-serving-ci:
 
 generate-serverless-operator-ci:
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serverless-operator.yaml $(ARGS)
-.PHONY: generate-serving-ci
+.PHONY: generate-serverless-operator-ci
 
 unit-tests:
 	go test ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ generate-serving-ci:
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serving-net-kourier.yaml $(ARGS)
 .PHONY: generate-serving-ci
 
+generate-serverless-operator-ci:
+	go run github.com/openshift-knative/hack/cmd/prowgen --config config/serverless-operator.yaml $(ARGS)
+.PHONY: generate-serving-ci
+
 unit-tests:
 	go test ./pkg/...
 

--- a/cmd/generate/BuildImageDockerfile.template
+++ b/cmd/generate/BuildImageDockerfile.template
@@ -11,7 +11,19 @@ RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "repo_gpgcheck=0" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo
 
-RUN yum install -y kubectl httpd-tools
+RUN yum install -y kubectl httpd-tools \
+    https://rpm.nodesource.com/pub_16.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
+    gcc-c++ \
+    make \
+    nodejs \
+    xorg-x11-server-Xvfb \
+    gtk2-devel \
+    gtk3-devel \
+    libnotify-devel \
+    GConf2 \
+    nss \
+    libXScrnSaver \
+    alsa-lib
 
 RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 ./get-helm-3
@@ -19,6 +31,7 @@ RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && 
 RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
+RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 
 # go install creates $GOPATH/.cache with root permissions, we delete it here
 # to avoid permission issues with the runtime users

--- a/cmd/generate/BuildImageDockerfile.template
+++ b/cmd/generate/BuildImageDockerfile.template
@@ -11,19 +11,7 @@ RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "repo_gpgcheck=0" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo
 
-RUN yum install -y kubectl httpd-tools \
-    https://rpm.nodesource.com/pub_16.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
-    gcc-c++ \
-    make \
-    nodejs \
-    xorg-x11-server-Xvfb \
-    gtk2-devel \
-    gtk3-devel \
-    libnotify-devel \
-    GConf2 \
-    nss \
-    libXScrnSaver \
-    alsa-lib
+RUN yum install -y kubectl httpd-tools
 
 RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 ./get-helm-3
@@ -31,7 +19,6 @@ RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && 
 RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
-RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 
 # go install creates $GOPATH/.cache with root permissions, we delete it here
 # to avoid permission issues with the runtime users

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime/debug"
 	"strings"
 	"text/template"
@@ -101,8 +100,8 @@ func main() {
 		log.Fatal("Getwd", err, string(debug.Stack()))
 	}
 
-	includesRegex := toRegexp(includes)
-	excludesRegex := toRegexp(excludes)
+	includesRegex := prowgen.ToRegexp(includes)
+	excludesRegex := prowgen.ToRegexp(excludes)
 
 	mainPackagesPaths := sets.NewString()
 
@@ -331,16 +330,4 @@ func getGoMod(rootDir string) *modfile.File {
 		log.Fatal(err)
 	}
 	return gm
-}
-
-func toRegexp(s []string) []*regexp.Regexp {
-	includesRegex := make([]*regexp.Regexp, 0, len(s))
-	for _, i := range s {
-		r, err := regexp.Compile(i)
-		if err != nil {
-			log.Fatal("Regex", i, "doesn't compile", err)
-		}
-		includesRegex = append(includesRegex, r)
-	}
-	return includesRegex
 }

--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -4,7 +4,7 @@ config:
   branches:
     "main":
       openShiftVersions:
-        - 4.12
+        - version: 4.12
 
 repositories:
   - org: openshift-knative

--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -12,7 +12,7 @@ repositories:
     imagePrefix: knative-eventing-hyperfoil-benchmark
     slackChannel: "#knative-eventing-ci"
     e2e:
-      matches:
-        - ".*test-kafka-broker-upstream-.*"
-      onDemand:
-        - ".*test-kafka-broker-namespaced-midstream-.*"
+      - regexp: ".*test-kafka-broker-upstream-.*"
+      - regexp: ".*test-kafka-broker-namespaced-midstream-.*"
+        onDemand: true
+

--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -12,7 +12,7 @@ repositories:
     imagePrefix: knative-eventing-hyperfoil-benchmark
     slackChannel: "#knative-eventing-ci"
     e2e:
-      - regexp: ".*test-kafka-broker-upstream-.*"
-      - regexp: ".*test-kafka-broker-namespaced-midstream-.*"
+      - match: ".*test-kafka-broker-upstream-.*"
+      - match: ".*test-kafka-broker-namespaced-midstream-.*"
         onDemand: true
 

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -4,24 +4,24 @@ config:
   branches:
     "release-v1.8":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.9":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
     "release-next":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -29,5 +29,4 @@ repositories:
     imagePrefix: knative-eventing-istio
     slackChannel: "#knative-eventing-ci"
     e2e:
-      matches:
-        - ".*e2e-tests$"
+      - regexp: ".*e2e-tests$"

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -29,4 +29,4 @@ repositories:
     imagePrefix: knative-eventing-istio
     slackChannel: "#knative-eventing-ci"
     e2e:
-      - regexp: ".*e2e-tests$"
+      - match: ".*e2e-tests$"

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -4,32 +4,32 @@ config:
   branches:
     "release-v1.6":
       openShiftVersions:
-        - 4.12
-        - 4.8
+        - version: 4.12
+        - version: 4.8
     "release-v1.7":
       openShiftVersions:
-        - 4.12
-        - 4.8
+        - version: 4.12
+        - version: 4.8
     "release-v1.8":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.9":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
     "release-next":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -37,7 +37,6 @@ repositories:
     imagePrefix: knative-eventing-kafka-broker
     slackChannel: "#knative-eventing-ci"
     e2e:
-      matches:
-        - ".*e2e$"
-        - ".*reconciler.*"
-        - ".*conformance.*"
+      - regexp: ".*e2e$"
+      - regexp: ".*reconciler.*"
+      - regexp: ".*conformance.*"

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -37,6 +37,6 @@ repositories:
     imagePrefix: knative-eventing-kafka-broker
     slackChannel: "#knative-eventing-ci"
     e2e:
-      - regexp: ".*e2e$"
-      - regexp: ".*reconciler.*"
-      - regexp: ".*conformance.*"
+      - match: ".*e2e$"
+      - match: ".*reconciler.*"
+      - match: ".*conformance.*"

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -4,32 +4,32 @@ config:
   branches:
     "release-v1.6":
       openShiftVersions:
-        - 4.12
-        - 4.8
+        - version: 4.12
+        - version: 4.8
     "release-v1.7":
       openShiftVersions:
-        - 4.12
-        - 4.8
+        - version: 4.12
+        - version: 4.8
     "release-v1.8":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.9":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
     "release-next":
       openShiftVersions:
-        - 4.13
-        - 4.11
+        - version: 4.13
+        - version: 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -37,7 +37,6 @@ repositories:
     imagePrefix: knative-eventing
     slackChannel: "#knative-eventing-ci"
     e2e:
-      matches:
-        - ".*e2e$"
-        - ".*reconciler.*"
-        - ".*conformance.*"
+      - regexp: ".*e2e$"
+      - regexp: ".*reconciler.*"
+      - regexp: ".*conformance.*"

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -37,6 +37,6 @@ repositories:
     imagePrefix: knative-eventing
     slackChannel: "#knative-eventing-ci"
     e2e:
-      - regexp: ".*e2e$"
-      - regexp: ".*reconciler.*"
-      - regexp: ".*conformance.*"
+      - match: ".*e2e$"
+      - match: ".*reconciler.*"
+      - match: ".*conformance.*"

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -5,7 +5,9 @@ config:
     "source_image_cli_2":
       openShiftVersions:
         - version: 4.13
+          cron: "0 4,16 * * *"
         - version: 4.11
+          cron: "0 6,18 * * *"
           onDemand: true
 
 repositories:
@@ -17,6 +19,17 @@ repositories:
     imageNameOverrides:
       serverless-operator: bundle
     slackChannel: "#serverless-ci"
+    ignoreConfigs:
+      matches:
+        - ".*aws-ovn.*"
+        - ".*azure.*"
+        - ".*gcp.*"
+        - ".*hypershift.*"
+        - ".*osd.*"
+        - ".*single-node.*"
+        - ".*vsphere.*"
+        - ".*lp-interop.*"
+        - ".*lp-interop.*"
     dockerfiles:
       matches:
         - "knative-operator/.*"

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -40,28 +40,28 @@ repositories:
         - "olm-catalog/serverless-operator/Dockerfile"
         - "olm-catalog/serverless-operator/index/Dockerfile"
     e2e:
-      - regexp: "^operator-e2e$"
-      - regexp: "^test-upgrade$"
-      - regexp: "^upstream-e2e$"
+      - match: "^operator-e2e$"
+      - match: "^test-upgrade$"
+      - match: "^upstream-e2e$"
         ignoreError: true
         skipCron: true
-      - regexp: "^upstream-e2e-kafka$"
+      - match: "^upstream-e2e-kafka$"
         ignoreError: true
-      - regexp: "^mesh-e2e$"
+      - match: "^mesh-e2e$"
         onDemand: true
         ignoreError: true
-      - regexp: "^mesh-upgrade$"
+      - match: "^mesh-upgrade$"
         onDemand: true
         ignoreError: true
         skipCron: true
-      - regexp: "^ui-e2e$"
+      - match: "^ui-e2e$"
         onDemand: true
         runIfChanged: "test/ui"
         ignoreError: true
-      - regexp: "^kitchensink-e2e$"
+      - match: "^kitchensink-e2e$"
         onDemand: true
         ignoreError: true
-      - regexp: "^kitchensink-upgrade$"
+      - match: "^kitchensink-upgrade$"
         onDemand: true
         ignoreError: true
     resources:

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -30,6 +30,7 @@ repositories:
         - "^upstream-e2e$"
         - "^upstream-e2e-kafka$"
         - "^test-upgrade$"
+      onDemand:
         - "^mesh-e2e$"
         - "^mesh-upgrade$"
         - "^ui-e2e$"

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -2,13 +2,13 @@
 
 config:
   branches:
-    "main":
+    "source_image_cli":
       openShiftVersions:
         - 4.13
-        - 4.11
+        #- 4.11
 
 repositories:
-  - org: openshift-knative
+  - org: mgencur
     repo: serverless-operator
     promotion:
       namespace: knative
@@ -18,15 +18,23 @@ repositories:
     slackChannel: "#serverless-ci"
     dockerfiles:
       matches:
-        - "knative-operator.*"
-        - "openshift-knative-operator.*"
-        - "serving/metadata-webhook.*"
-        - "serving/ingress.*"
+        - "knative-operator/.*"
+        - "openshift-knative-operator/.*"
+        - "serving/metadata-webhook/.*"
+        - "serving/ingress/.*"
         - "olm-catalog/serverless-operator/Dockerfile"
         - "olm-catalog/serverless-operator/index/Dockerfile"
     e2e:
       matches:
-        - ".*test-upgrade$"
+        - "^operator-e2e$"
+        - "^upstream-e2e$"
+        - "^upstream-e2e-kafka$"
+        - "^test-upgrade$"
+        - "^mesh-e2e$"
+        - "^mesh-upgrade$"
+        - "^ui-e2e$"
+        - "^kitchensink-e2e$"
+        - "^kitchensink-upgrade$"
     resources:
       '*':
         limits:

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -4,8 +4,8 @@ config:
   branches:
     "source_image_cli_2":
       openShiftVersions:
-        - 4.13
-        #- 4.11
+        - version: 4.13
+        #- version: 4.11
 
 repositories:
   - org: mgencur

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -29,6 +29,7 @@ repositories:
       - regexp: "^test-upgrade$"
       - regexp: "^upstream-e2e$"
         ignoreError: true
+        skipCron: true
       - regexp: "^upstream-e2e-kafka$"
         ignoreError: true
       - regexp: "^mesh-e2e$"
@@ -37,6 +38,7 @@ repositories:
       - regexp: "^mesh-upgrade$"
         onDemand: true
         ignoreError: true
+        skipCron: true
       - regexp: "^ui-e2e$"
         onDemand: true
         runIfChanged: "test/ui"

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -2,7 +2,7 @@
 
 config:
   branches:
-    "source_image_cli":
+    "source_image_cli_2":
       openShiftVersions:
         - 4.13
         #- 4.11
@@ -25,17 +25,28 @@ repositories:
         - "olm-catalog/serverless-operator/Dockerfile"
         - "olm-catalog/serverless-operator/index/Dockerfile"
     e2e:
-      matches:
-        - "^operator-e2e$"
-        - "^upstream-e2e$"
-        - "^upstream-e2e-kafka$"
-        - "^test-upgrade$"
-      onDemand:
-        - "^mesh-e2e$"
-        - "^mesh-upgrade$"
-        - "^ui-e2e$"
-        - "^kitchensink-e2e$"
-        - "^kitchensink-upgrade$"
+      - regexp: "^operator-e2e$"
+      - regexp: "^test-upgrade$"
+      - regexp: "^upstream-e2e$"
+        ignoreError: true
+      - regexp: "^upstream-e2e-kafka$"
+        ignoreError: true
+      - regexp: "^mesh-e2e$"
+        onDemand: true
+        ignoreError: true
+      - regexp: "^mesh-upgrade$"
+        onDemand: true
+        ignoreError: true
+      - regexp: "^ui-e2e$"
+        onDemand: true
+        runIfChanged: "test/ui"
+        ignoreError: true
+      - regexp: "^kitchensink-e2e$"
+        onDemand: true
+        ignoreError: true
+      - regexp: "^kitchensink-upgrade$"
+        onDemand: true
+        ignoreError: true
     resources:
       '*':
         limits:

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -21,6 +21,7 @@ repositories:
     slackChannel: "#serverless-ci"
     ignoreConfigs:
       matches:
+        - ".*main.yaml$"
         - ".*aws-ovn.*"
         - ".*azure.*"
         - ".*gcp.*"

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -2,7 +2,7 @@
 
 config:
   branches:
-    "source_image_cli_2":
+    main:
       openShiftVersions:
         - version: 4.13
           cron: "0 4,16 * * *"
@@ -11,7 +11,7 @@ config:
           onDemand: true
 
 repositories:
-  - org: mgencur
+  - org: openshift-knative
     repo: serverless-operator
     promotion:
       namespace: knative

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -5,7 +5,8 @@ config:
     "source_image_cli_2":
       openShiftVersions:
         - version: 4.13
-        #- version: 4.11
+        - version: 4.11
+          onDemand: true
 
 repositories:
   - org: mgencur

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -1,0 +1,36 @@
+# Full struct in cmd/prowgen/prowgen.go#Config
+
+config:
+  branches:
+    "main":
+      openShiftVersions:
+        - 4.13
+        - 4.11
+
+repositories:
+  - org: openshift-knative
+    repo: serverless-operator
+    promotion:
+      namespace: knative
+    imagePrefix: serverless
+    imageNameOverrides:
+      serverless-operator: bundle
+    slackChannel: "#serverless-ci"
+    dockerfiles:
+      matches:
+        - "knative-operator.*"
+        - "openshift-knative-operator.*"
+        - "serving/metadata-webhook.*"
+        - "serving/ingress.*"
+        - "olm-catalog/serverless-operator/Dockerfile"
+        - "olm-catalog/serverless-operator/index/Dockerfile"
+    e2e:
+      matches:
+        - ".*test-upgrade$"
+    resources:
+      '*':
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: 100m
+          memory: 200Mi

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -5,9 +5,9 @@ config:
     main:
       openShiftVersions:
         - version: 4.13
-          cron: "0 4,16 * * *"
+          cron: "0 4 * * *"
         - version: 4.11
-          cron: "0 6,18 * * *"
+          cron: "0 6 * * *"
           onDemand: true
 
 repositories:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -4,20 +4,20 @@ config:
   branches:
     "release-v1.9":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
     "release-v1.12":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -4,20 +4,20 @@ config:
   branches:
     "release-v1.9":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
     "release-v1.12":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -4,28 +4,28 @@ config:
   branches:
     "release-v1.8":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.9":
       openShiftVersions:
-        - 4.13
-        - 4.10
+        - version: 4.13
+        - version: 4.10
     "release-v1.10":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
     "release-v1.11":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
     "release-v1.12":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
     "release-next":
       openShiftVersions:
-        - 4.14
-        - 4.11
+        - version: 4.14
+        - version: 4.11
 
 repositories:
   - org: openshift-knative

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -35,11 +35,9 @@ repositories:
       migrate: storage-version-migration
     slackChannel: "#knative-serving-ci"
     e2e:
-      matches:
-        - ".*e2e$"
-        - ".*e2e-tls$"
-      onDemand:
-        - "perf-tests$"
+      - regexp: ".*e2e$"
+      - regexp: ".*e2e-tls$"
+      - regexp: "perf-tests$"
     resources:
       '*':
         requests:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -38,6 +38,7 @@ repositories:
       - match: ".*e2e$"
       - match: ".*e2e-tls$"
       - match: "perf-tests$"
+        onDemand: true
     resources:
       '*':
         requests:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -35,9 +35,9 @@ repositories:
       migrate: storage-version-migration
     slackChannel: "#knative-serving-ci"
     e2e:
-      - regexp: ".*e2e$"
-      - regexp: ".*e2e-tls$"
-      - regexp: "perf-tests$"
+      - match: ".*e2e$"
+      - match: ".*e2e-tls$"
+      - match: "perf-tests$"
     resources:
       '*':
         requests:

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -64,7 +64,7 @@ func Main() {
 
 	for _, v := range inConfig.Config.Branches {
 		sort.Slice(v.OpenShiftVersions, func(i, j int) bool {
-			return semver.New(v.OpenShiftVersions[i] + ".0").LessThan(*semver.New(v.OpenShiftVersions[j] + ".0"))
+			return semver.New(v.OpenShiftVersions[i].Version + ".0").LessThan(*semver.New(v.OpenShiftVersions[j].Version + ".0"))
 		})
 	}
 

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -92,6 +92,7 @@ func Main() {
 			}
 
 			// Delete existing configuration for each configured branch.
+			// TODO. Have this optional?
 			for branch := range inConfig.Config.Branches {
 				if err := DeleteExistingReleaseBuildConfigurationForBranch(outConfig, repository, branch); err != nil {
 					return err

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -260,6 +260,9 @@ func alwaysRunInjector() JobConfigInjector {
 	return JobConfigInjector{
 		Type: PreSubmit,
 		Update: func(r *Repository, b *Branch, branchName string, jobConfig *prowconfig.JobConfig) error {
+			if err := GitCheckout(context.TODO(), *r, branchName); err != nil {
+				return fmt.Errorf("[%s] failed to checkout branch %s", r.RepositoryDirectory(), branchName)
+			}
 			tests, err := discoverE2ETests(*r)
 			if err != nil {
 				return fmt.Errorf("failed to discover tests: %w", err)

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -265,7 +265,7 @@ func alwaysRunInjector() JobConfigInjector {
 
 					for _, t := range tests {
 						name := ToName(*r, &t, ocpVersion)
-						if t.OnDemand && strings.Contains(jobConfig.PresubmitsStatic[k][i].Name, name) {
+						if (t.OnDemand || t.RunIfChanged != "") && strings.Contains(jobConfig.PresubmitsStatic[k][i].Name, name) {
 							jobConfig.PresubmitsStatic[k][i].AlwaysRun = false
 						}
 					}

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -15,13 +15,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"go/parser"
-	"go/token"
-	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -29,7 +25,6 @@ import (
 	gyaml "github.com/ghodss/yaml"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/util/sets"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 )

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -92,7 +92,6 @@ func Main() {
 			}
 
 			// Delete existing configuration for each configured branch.
-			// TODO. Have this optional?
 			for branch := range inConfig.Config.Branches {
 				if err := DeleteExistingReleaseBuildConfigurationForBranch(outConfig, repository, branch); err != nil {
 					return err

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -51,8 +51,9 @@ type Branch struct {
 }
 
 type OpenShift struct {
-	Version string `json:"version" yaml:"version"`
-	Cron    string `json:"cron" yaml:"cron"`
+	Version  string `json:"version" yaml:"version"`
+	Cron     string `json:"cron" yaml:"cron"`
+	OnDemand bool   `json:"onDemand" yaml:"onDemand"`
 }
 
 type CommonConfig struct {

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -37,8 +37,6 @@ type Dockerfiles struct {
 
 type Promotion struct {
 	Namespace string
-	Name      string
-	Tag       string
 }
 
 func (r Repository) RepositoryDirectory() string {
@@ -198,13 +196,9 @@ func withNamePromotion(r Repository, branchName string) ReleaseBuildConfiguratio
 		if r.Promotion.Namespace != "" {
 			ns = r.Promotion.Namespace
 		}
-		name := strings.ReplaceAll(strings.ReplaceAll(branchName, "release", "knative"), "next", "nightly"),
-		if r.Promotion.Name != "" {
-			name = r.Promotion.Name
-		}
 		cfg.PromotionConfiguration = &cioperatorapi.PromotionConfiguration{
 			Namespace: ns,
-			Name:      name,
+			Name:      strings.ReplaceAll(strings.ReplaceAll(branchName, "release", "knative"), "next", "nightly"),
 			AdditionalImages: map[string]string{
 				// Add source image
 				transformLegacyKnativeSourceImageName(r): "src",
@@ -220,13 +214,9 @@ func withTagPromotion(r Repository, branchName string) ReleaseBuildConfiguration
 		if r.Promotion.Namespace != "" {
 			ns = r.Promotion.Namespace
 		}
-		tag := strings.ReplaceAll(strings.ReplaceAll(branchName, "release", "knative"), "next", "nightly")
-		if r.Promotion.Name != "" {
-			tag = r.Promotion.Name
-		}
 		cfg.PromotionConfiguration = &cioperatorapi.PromotionConfiguration{
 			Namespace:   ns,
-			Tag:         tag,
+			Tag:         strings.ReplaceAll(strings.ReplaceAll(branchName, "release", "knative"), "next", "nightly"),
 			TagByCommit: false, // TODO: revisit this later
 			AdditionalImages: map[string]string{
 				// Add source image

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -46,8 +46,12 @@ func (r Repository) RepositoryDirectory() string {
 }
 
 type Branch struct {
-	OpenShiftVersions []string `json:"openShiftVersions" yaml:"openShiftVersions"`
-	Cron              string   `json:"cron" yaml:"cron"`
+	OpenShiftVersions []OpenShift `json:"openShiftVersions" yaml:"openShiftVersions"`
+}
+
+type OpenShift struct {
+	Version string `json:"version" yaml:"version"`
+	Cron    string `json:"cron" yaml:"cron"`
 }
 
 type CommonConfig struct {
@@ -84,7 +88,7 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 
 			log.Println(r.RepositoryDirectory(), "Generating config", branchName, "OpenShiftVersion", ov)
 
-			variant := strings.ReplaceAll(ov, ".", "")
+			variant := strings.ReplaceAll(ov.Version, ".", "")
 
 			images := make([]cioperatorapi.ProjectDirectoryImageBuildStepConfiguration, 0, len(r.Images))
 			for _, img := range r.Images {
@@ -151,7 +155,7 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 			options = append(
 				options,
 				DiscoverImages(r),
-				DiscoverTests(r, ov, &branch.Cron, fromImage),
+				DiscoverTests(r, ov, fromImage),
 			)
 
 			log.Println(r.RepositoryDirectory(), "Apply input options", len(options))

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -31,6 +31,7 @@ type E2ETest struct {
 	OnDemand     bool   `json:"onDemand" yaml:"onDemand"`
 	IgnoreError  bool   `json:"ignoreError" yaml:"ignoreError"`
 	RunIfChanged string `json:"runIfChanged" yaml:"runIfChanged"`
+	SkipCron     bool   `json:"skipCron" yaml:"skipCron"`
 }
 
 type Dockerfiles struct {

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -19,16 +19,18 @@ type Repository struct {
 	ImageNameOverrides    map[string]string                                           `json:"imageNameOverrides" yaml:"imageNameOverrides"`
 	SlackChannel          string                                                      `json:"slackChannel" yaml:"slackChannel"`
 	CanonicalGoRepository *string                                                     `json:"canonicalGoRepository" yaml:"canonicalGoRepository"`
-	E2ETests              E2ETests                                                    `json:"e2e" yaml:"e2e"`
+	E2ETests              []E2ETest                                                   `json:"e2e" yaml:"e2e"`
 	Dockerfiles           Dockerfiles                                                 `json:"dockerfiles" yaml:"dockerfiles"`
 	Images                []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration `json:"images" yaml:"images"`
 	Tests                 []cioperatorapi.TestStepConfiguration                       `json:"tests" yaml:"tests"`
 	Resources             cioperatorapi.ResourceConfiguration                         `json:"resources" yaml:"resources"`
 }
 
-type E2ETests struct {
-	Matches         []string `json:"matches" yaml:"matches"`
-	OnDemandMatches []string `json:"onDemand" yaml:"onDemand"`
+type E2ETest struct {
+	Regexp       string `json:"regexp" yaml:"regexp"`
+	OnDemand     bool   `json:"onDemand" yaml:"onDemand"`
+	IgnoreError  bool   `json:"ignoreError" yaml:"ignoreError"`
+	RunIfChanged string `json:"runIfChanged" yaml:"runIfChanged"`
 }
 
 type Dockerfiles struct {

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -28,7 +28,7 @@ type Repository struct {
 }
 
 type E2ETest struct {
-	Regexp       string `json:"regexp" yaml:"regexp"`
+	Match        string `json:"match" yaml:"match"`
 	OnDemand     bool   `json:"onDemand" yaml:"onDemand"`
 	IgnoreError  bool   `json:"ignoreError" yaml:"ignoreError"`
 	RunIfChanged string `json:"runIfChanged" yaml:"runIfChanged"`

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -21,6 +21,7 @@ type Repository struct {
 	CanonicalGoRepository *string                                                     `json:"canonicalGoRepository" yaml:"canonicalGoRepository"`
 	E2ETests              []E2ETest                                                   `json:"e2e" yaml:"e2e"`
 	Dockerfiles           Dockerfiles                                                 `json:"dockerfiles" yaml:"dockerfiles"`
+	IgnoreConfigs         IgnoreConfigs                                               `json:"ignoreConfigs" yaml:"ignoreConfigs"`
 	Images                []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration `json:"images" yaml:"images"`
 	Tests                 []cioperatorapi.TestStepConfiguration                       `json:"tests" yaml:"tests"`
 	Resources             cioperatorapi.ResourceConfiguration                         `json:"resources" yaml:"resources"`
@@ -35,6 +36,10 @@ type E2ETest struct {
 }
 
 type Dockerfiles struct {
+	Matches []string `json:"matches" yaml:"matches"`
+}
+
+type IgnoreConfigs struct {
 	Matches []string `json:"matches" yaml:"matches"`
 }
 

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -19,6 +19,7 @@ type Repository struct {
 	SlackChannel          string                                                      `json:"slackChannel" yaml:"slackChannel"`
 	CanonicalGoRepository *string                                                     `json:"canonicalGoRepository" yaml:"canonicalGoRepository"`
 	E2ETests              E2ETests                                                    `json:"e2e" yaml:"e2e"`
+	Dockerfiles           Dockerfiles                                                 `json:"dockerfiles" yaml:"dockerfiles"`
 	Images                []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration `json:"images" yaml:"images"`
 	Tests                 []cioperatorapi.TestStepConfiguration                       `json:"tests" yaml:"tests"`
 	Resources             cioperatorapi.ResourceConfiguration                         `json:"resources" yaml:"resources"`
@@ -27,6 +28,10 @@ type Repository struct {
 type E2ETests struct {
 	Matches         []string `json:"matches" yaml:"matches"`
 	OnDemandMatches []string `json:"onDemand" yaml:"onDemand"`
+}
+
+type Dockerfiles struct {
+	Matches []string `json:"matches" yaml:"matches"`
 }
 
 func (r Repository) RepositoryDirectory() string {

--- a/pkg/prowgen/prowgen_images_discovery.go
+++ b/pkg/prowgen/prowgen_images_discovery.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime/debug"
 	"sort"
 	"strings"
 

--- a/pkg/prowgen/prowgen_images_discovery.go
+++ b/pkg/prowgen/prowgen_images_discovery.go
@@ -119,10 +119,7 @@ func discoverDockerfiles(r Repository) ([]string, error) {
 		return nil
 	})
 	if err != nil {
-		log.Fatal(err, "\n", string(debug.Stack()))
-	}
-	for _, p := range dockerfiles.List() {
-		log.Println("Dockerfile path", p)
+		return nil, fmt.Errorf("failed while discovering container images: %w", err)
 	}
 
 	srcImageDockerfile, err := discoverSourceImageDockerfile(r)
@@ -198,7 +195,6 @@ func getPullStringsFromDockerfile(filename string) ([]string, error) {
 		match := registryRegex.FindString(line)
 		if match != "" {
 			images = append(images, match)
-			log.Println("Added match:", match)
 		}
 		if line == "FROM src" {
 			images = append(images, srcImage)

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -194,11 +194,11 @@ func createTest(r Repository, line string, e2e E2ETest, tests *[]Test, commands 
 	if strings.HasSuffix(line, ":") {
 		line := strings.TrimSuffix(line, ":")
 
-		log.Println(r.RepositoryDirectory(), "Comparing", line, "to match", e2e.Regexp)
+		log.Println(r.RepositoryDirectory(), "Comparing", line, "to match", e2e.Match)
 
-		matches, err := regexp.Match(e2e.Regexp, []byte(line))
+		matches, err := regexp.Match(e2e.Match, []byte(line))
 		if err != nil {
-			return fmt.Errorf("[%s] failed to match test %s: %w", r.RepositoryDirectory(), e2e.Regexp, err)
+			return fmt.Errorf("[%s] failed to match test %s: %w", r.RepositoryDirectory(), e2e.Match, err)
 		}
 		if matches && !commands.Has(line) {
 			*tests = append(*tests, Test{Command: line, OnDemand: e2e.OnDemand, IgnoreError: e2e.IgnoreError, RunIfChanged: e2e.RunIfChanged, SkipCron: e2e.SkipCron})

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -117,6 +117,8 @@ func DiscoverTests(r Repository, openShiftVersion string, cronOverride *string, 
 			}
 
 			preSubmitConfiguration := testConfiguration.DeepCopy()
+			preSubmitConfiguration.Optional = test.IgnoreError
+			preSubmitConfiguration.RunIfChanged = test.RunIfChanged
 			cfg.Tests = append(cfg.Tests, *preSubmitConfiguration)
 
 			cronTestConfiguration := testConfiguration.DeepCopy()
@@ -143,8 +145,10 @@ const (
 )
 
 type Test struct {
-	Command  string
-	OnDemand bool
+	Command      string
+	OnDemand     bool
+	IgnoreError  bool
+	RunIfChanged string
 }
 
 func (t *Test) HexSha() string {
@@ -170,13 +174,8 @@ func discoverE2ETests(r Repository) ([]Test, error) {
 	commands := sets.NewString()
 	for _, l := range lines {
 		l := strings.TrimSpace(l)
-		for _, match := range r.E2ETests.Matches {
-			if err := createTest(r, l, match, &targets, false, commands); err != nil {
-				return nil, err
-			}
-		}
-		for _, match := range r.E2ETests.OnDemandMatches {
-			if err := createTest(r, l, match, &targets, true, commands); err != nil {
+		for _, e2e := range r.E2ETests {
+			if err := createTest(r, l, e2e, &targets, commands); err != nil {
 				return nil, err
 			}
 		}
@@ -189,18 +188,18 @@ func discoverE2ETests(r Repository) ([]Test, error) {
 	return targets, nil
 }
 
-func createTest(r Repository, line string, shouldMatch string, tests *[]Test, onDemand bool, commands sets.String) error {
+func createTest(r Repository, line string, e2e E2ETest, tests *[]Test, commands sets.String) error {
 	if strings.HasSuffix(line, ":") {
 		line := strings.TrimSuffix(line, ":")
 
-		log.Println(r.RepositoryDirectory(), "Comparing", line, "to match", shouldMatch)
+		log.Println(r.RepositoryDirectory(), "Comparing", line, "to match", e2e.Regexp)
 
-		matches, err := regexp.Match(shouldMatch, []byte(line))
+		matches, err := regexp.Match(e2e.Regexp, []byte(line))
 		if err != nil {
-			return fmt.Errorf("[%s] failed to match test %s: %w", r.RepositoryDirectory(), shouldMatch, err)
+			return fmt.Errorf("[%s] failed to match test %s: %w", r.RepositoryDirectory(), e2e.Regexp, err)
 		}
 		if matches && !commands.Has(line) {
-			*tests = append(*tests, Test{Command: line, OnDemand: onDemand})
+			*tests = append(*tests, Test{Command: line, OnDemand: e2e.OnDemand, IgnoreError: e2e.IgnoreError, RunIfChanged: e2e.RunIfChanged})
 			commands.Insert(line)
 		}
 	}

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -21,13 +21,13 @@ func TestDiscoverTestsServing(t *testing.T) {
 		CanonicalGoRepository: pointer.String("knative.dev/serving"),
 		E2ETests: []E2ETest{
 			{
-				Regexp: "test-e2e$",
+				Match: "test-e2e$",
 			},
 			{
-				Regexp: "test-e2e-tls$",
+				Match: "test-e2e-tls$",
 			},
 			{
-				Regexp: "perf-tests$",
+				Match: "perf-tests$",
 			},
 		},
 	}
@@ -335,16 +335,16 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		CanonicalGoRepository: pointer.String("knative.dev/eventing"),
 		E2ETests: []E2ETest{
 			{
-				Regexp: ".*-conformance$",
+				Match: ".*-conformance$",
 			},
 			{
-				Regexp: "test-e2e$",
+				Match: "test-e2e$",
 			},
 			{
-				Regexp: "test-reconcile.*",
+				Match: "test-reconcile.*",
 			},
 			{
-				Regexp: "test-conformance.*",
+				Match: "test-conformance.*",
 			},
 		},
 	}

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -19,11 +19,15 @@ func TestDiscoverTestsServing(t *testing.T) {
 		ImagePrefix:           "knative-serving",
 		ImageNameOverrides:    map[string]string{"migrate": "storage-version-migration"},
 		CanonicalGoRepository: pointer.String("knative.dev/serving"),
-		E2ETests: E2ETests{
-			Matches: []string{
-				"test-e2e$",
-				"test-e2e-tls$",
-				"perf-tests$",
+		E2ETests: []E2ETest{
+			{
+				Regexp: "test-e2e$",
+			},
+			{
+				Regexp: "test-e2e-tls$",
+			},
+			{
+				Regexp: "perf-tests$",
 			},
 		},
 	}
@@ -329,12 +333,18 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		Repo:                  "eventing",
 		ImagePrefix:           "knative-eventing",
 		CanonicalGoRepository: pointer.String("knative.dev/eventing"),
-		E2ETests: E2ETests{
-			Matches: []string{
-				".*-conformance$",
-				"test-e2e$",
-				"test-reconcile.*",
-				"test-conformance.*",
+		E2ETests: []E2ETest{
+			{
+				Regexp: ".*-conformance$",
+			},
+			{
+				Regexp: "test-e2e$",
+			},
+			{
+				Regexp: "test-reconcile.*",
+			},
+			{
+				Regexp: "test-conformance.*",
 			},
 		},
 	}

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -37,7 +37,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 	servingSourceImage := "knative-serving-source-image"
 	options := []ReleaseBuildConfigurationOption{
 		DiscoverImages(r),
-		DiscoverTests(r, "4.12", cron, servingSourceImage),
+		DiscoverTests(r, OpenShift{Version: "4.12", Cron: *cron}, servingSourceImage),
 	}
 
 	dependencies := []cioperatorapi.StepDependency{
@@ -352,7 +352,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 	eventingSourceImage := "knative-eventing-source-image"
 	options := []ReleaseBuildConfigurationOption{
 		DiscoverImages(r),
-		DiscoverTests(r, "4.12", nil, eventingSourceImage),
+		DiscoverTests(r, OpenShift{Version: "4.12"}, eventingSourceImage),
 	}
 
 	dependencies := []cioperatorapi.StepDependency{

--- a/pkg/prowgen/testdata/serving/Makefile
+++ b/pkg/prowgen/testdata/serving/Makefile
@@ -13,3 +13,6 @@ test-e2e-local:
 
 perf-tests:
 	echo "Perf"
+
+ui-e2e:
+	echo "Ignore me"


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVCOM-2846

Should be merged after https://github.com/openshift-knative/serverless-operator/pull/2380

Features:
- Invividual tests can specify the following:
  - onDemand execution
  - ignoreError - this equals to "optional" in the final Prow job (tests don't have to pass before merging PR)
  - whether to generate Cron job for the test or not
  - runIfChanged pattern
- The repository can specify patterns for Dockerfiles instead of the default `openshift/ci-operator/knative-images.*` and `openshift/ci-operator/knative-test-images.*`. The serverless-operator repo has Dockerfiles in different locations.
- Individual OpenShift versions under branch can specify their own Cron pattern (previously it was for the whole branch)
- OnDemand jobs can also be enforced for all jobs related to given OpenShift versions (for s-o we want that because all jobs for older OpenShift version are on demand, we don't run them for every PR)
- It is possible to specify image promotion namespace in the config yaml

Example CI configs generated by the code from this branch can be found in https://github.com/openshift/release/pull/45448 (the tests won't pass until https://github.com/openshift-knative/serverless-operator/pull/2380 is merged but I previously executed the tests against my own branch in https://github.com/openshift/release/pull/45380)