### PR TITLE
Make Serving perf tests run on demand

### DIFF
--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -38,6 +38,7 @@ repositories:
       matches:
         - ".*e2e$"
         - ".*e2e-tls$"
+      onDemand:
         - "perf-tests$"
     resources:
       '*':


### PR DESCRIPTION
- Let's not run them on every PR by default all the time.
- Verified locally that this generates pre-submits with `always_run: false`.