### PR TITLE
Skip must-gather on success

### DIFF
--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -95,7 +95,7 @@ func DiscoverTests(r Repository, openShiftVersion string, cronOverride *string, 
 						},
 						{
 							LiteralTestStep: &cioperatorapi.LiteralTestStep{
-								As:          "gather-extra",
+								As:          "openshift-gather-extra",
 								From:        sourceImageName,
 								Commands:    `curl -skSL https://raw.githubusercontent.com/openshift/release/master/ci-operator/step-registry/gather/extra/gather-extra-commands.sh | /bin/bash -s`,
 								GracePeriod: &prowapi.Duration{Duration: 60 * time.Second},

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -90,6 +90,23 @@ func DiscoverTests(r Repository, openShiftVersion string, cronOverride *string, 
 								Cli:        "latest",
 							},
 						},
+						{
+							LiteralTestStep: &cioperatorapi.LiteralTestStep{
+								As:          "gather-extra",
+								From:        sourceImageName,
+								Commands:    `curl -skSL https://raw.githubusercontent.com/openshift/release/master/ci-operator/step-registry/gather/extra/gather-extra-commands.sh | /bin/bash -s`,
+								GracePeriod: &prowapi.Duration{Duration: 60 * time.Second},
+								Resources: cioperatorapi.ResourceRequirements{
+									Requests: cioperatorapi.ResourceList{
+										"cpu":    "300m",
+										"memory": "300Mi",
+									},
+								},
+								Timeout:    &prowapi.Duration{Duration: 20 * time.Minute},
+								BestEffort: pointer.Bool(true),
+								Cli:        "latest",
+							},
+						},
 					},
 					Workflow: pointer.String("generic-claim"),
 				},

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -291,7 +291,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 			},
 			cioperatorapi.TestStep{
 				LiteralTestStep: &cioperatorapi.LiteralTestStep{
-					As:          "gather-extra",
+					As:          "openshift-gather-extra",
 					From:        servingSourceImage,
 					Commands:    `curl -skSL https://raw.githubusercontent.com/openshift/release/master/ci-operator/step-registry/gather/extra/gather-extra-commands.sh | /bin/bash -s`,
 					GracePeriod: &prowapi.Duration{Duration: 60 * time.Second},
@@ -659,7 +659,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			},
 			cioperatorapi.TestStep{
 				LiteralTestStep: &cioperatorapi.LiteralTestStep{
-					As:          "gather-extra",
+					As:          "openshift-gather-extra",
 					From:        eventingSourceImage,
 					Commands:    `curl -skSL https://raw.githubusercontent.com/openshift/release/master/ci-operator/step-registry/gather/extra/gather-extra-commands.sh | /bin/bash -s`,
 					GracePeriod: &prowapi.Duration{Duration: 60 * time.Second},

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -249,7 +249,12 @@ func TestDiscoverTestsServing(t *testing.T) {
 
 	// Add must-gather step to each test as post step
 	for i := range expectedTests {
+		optionalOnSuccess := true
+		if expectedTests[i].Cron != nil {
+			optionalOnSuccess = false
+		}
 		expectedTests[i].MultiStageTestConfiguration.AllowBestEffortPostSteps = pointer.Bool(true)
+		expectedTests[i].MultiStageTestConfiguration.AllowSkipOnSuccess = pointer.Bool(true)
 		expectedTests[i].MultiStageTestConfiguration.Post = append(
 			expectedTests[i].MultiStageTestConfiguration.Post,
 			cioperatorapi.TestStep{
@@ -262,9 +267,10 @@ func TestDiscoverTestsServing(t *testing.T) {
 							"cpu": "100m",
 						},
 					},
-					Timeout:    &prowapi.Duration{Duration: 20 * time.Minute},
-					BestEffort: pointer.Bool(true),
-					Cli:        "latest",
+					Timeout:           &prowapi.Duration{Duration: 20 * time.Minute},
+					BestEffort:        pointer.Bool(true),
+					OptionalOnSuccess: &optionalOnSuccess,
+					Cli:               "latest",
 				},
 			},
 			cioperatorapi.TestStep{
@@ -277,9 +283,28 @@ func TestDiscoverTestsServing(t *testing.T) {
 							"cpu": "100m",
 						},
 					},
-					Timeout:    &prowapi.Duration{Duration: 20 * time.Minute},
-					BestEffort: pointer.Bool(true),
-					Cli:        "latest",
+					Timeout:           &prowapi.Duration{Duration: 20 * time.Minute},
+					BestEffort:        pointer.Bool(true),
+					OptionalOnSuccess: &optionalOnSuccess,
+					Cli:               "latest",
+				},
+			},
+			cioperatorapi.TestStep{
+				LiteralTestStep: &cioperatorapi.LiteralTestStep{
+					As:          "gather-extra",
+					From:        servingSourceImage,
+					Commands:    `curl -skSL https://raw.githubusercontent.com/openshift/release/master/ci-operator/step-registry/gather/extra/gather-extra-commands.sh | /bin/bash -s`,
+					GracePeriod: &prowapi.Duration{Duration: 60 * time.Second},
+					Resources: cioperatorapi.ResourceRequirements{
+						Requests: cioperatorapi.ResourceList{
+							"cpu":    "300m",
+							"memory": "300Mi",
+						},
+					},
+					Timeout:           &prowapi.Duration{Duration: 20 * time.Minute},
+					BestEffort:        pointer.Bool(true),
+					OptionalOnSuccess: &optionalOnSuccess,
+					Cli:               "latest",
 				},
 			},
 		)
@@ -592,7 +617,12 @@ func TestDiscoverTestsEventing(t *testing.T) {
 
 	// Add must-gather step to each test as post step
 	for i := range expectedTests {
+		optionalOnSuccess := true
+		if expectedTests[i].Cron != nil {
+			optionalOnSuccess = false
+		}
 		expectedTests[i].MultiStageTestConfiguration.AllowBestEffortPostSteps = pointer.Bool(true)
+		expectedTests[i].MultiStageTestConfiguration.AllowSkipOnSuccess = pointer.Bool(true)
 		expectedTests[i].MultiStageTestConfiguration.Post = append(
 			expectedTests[i].MultiStageTestConfiguration.Post,
 			cioperatorapi.TestStep{
@@ -605,9 +635,10 @@ func TestDiscoverTestsEventing(t *testing.T) {
 							"cpu": "100m",
 						},
 					},
-					Timeout:    &prowapi.Duration{Duration: 20 * time.Minute},
-					BestEffort: pointer.Bool(true),
-					Cli:        "latest",
+					Timeout:           &prowapi.Duration{Duration: 20 * time.Minute},
+					BestEffort:        pointer.Bool(true),
+					OptionalOnSuccess: &optionalOnSuccess,
+					Cli:               "latest",
 				},
 			},
 			cioperatorapi.TestStep{
@@ -620,9 +651,28 @@ func TestDiscoverTestsEventing(t *testing.T) {
 							"cpu": "100m",
 						},
 					},
-					Timeout:    &prowapi.Duration{Duration: 20 * time.Minute},
-					BestEffort: pointer.Bool(true),
-					Cli:        "latest",
+					Timeout:           &prowapi.Duration{Duration: 20 * time.Minute},
+					BestEffort:        pointer.Bool(true),
+					OptionalOnSuccess: &optionalOnSuccess,
+					Cli:               "latest",
+				},
+			},
+			cioperatorapi.TestStep{
+				LiteralTestStep: &cioperatorapi.LiteralTestStep{
+					As:          "gather-extra",
+					From:        eventingSourceImage,
+					Commands:    `curl -skSL https://raw.githubusercontent.com/openshift/release/master/ci-operator/step-registry/gather/extra/gather-extra-commands.sh | /bin/bash -s`,
+					GracePeriod: &prowapi.Duration{Duration: 60 * time.Second},
+					Resources: cioperatorapi.ResourceRequirements{
+						Requests: cioperatorapi.ResourceList{
+							"cpu":    "300m",
+							"memory": "300Mi",
+						},
+					},
+					Timeout:           &prowapi.Duration{Duration: 20 * time.Minute},
+					BestEffort:        pointer.Bool(true),
+					OptionalOnSuccess: &optionalOnSuccess,
+					Cli:               "latest",
 				},
 			},
 		)


### PR DESCRIPTION
This PR includes two changes:
* Run "gather-extra" after tests. This is useful for quick overview of resources in the cluster. Example from s-o:  [link](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/2384/pull-ci-openshift-knative-serverless-operator-release-1.31-4.13-upgrade-kitchensink-ocp-413/1722687677280555008/artifacts/upgrade-kitchensink-ocp-413/gather-extra/artifacts/)

* For periodic jobs, we'd be running must-gather always - on both test
failure/success. For pre-submit jobs, the must-gather would be run only on failure.

Background: Gathering artifacts on success is useful only rarely, e.g.
for comparing failed and successful runs. But one can look at the
periodic job to get an idea what the successful run looks like. There's
also another option - induce an (artificial) failure and re-run the pre-submit check.
Most of the time, we're not interested in must-gather logs if tests
pass. This option can save a lot of cloud resources (5-10 minutes for
every successful run).