### PR TITLE
Add image dep skip rule

### DIFF
--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -39,6 +39,19 @@ repositories:
       - match: ".*e2e-tls$"
       - match: "perf-tests$"
         onDemand: true
+        filterImages:
+          "perf-test":
+            - "knative-serving-load-test"
+            - "knative-serving-dataplane-probe"
+            - "knative-serving-real-traffic-test"
+            - "knative-serving-reconciliation-delay"
+            - "knative-serving-rollout-probe"
+            - "knative-serving-scale-from-zero"
+    dockerfiles:
+      matches:
+        - "openshift/ci-operator/knative-images.*",
+        - "openshift/ci-operator/knative-test-images.*",
+        - "openshift/ci-operator/knative-perf-images.*",
     resources:
       '*':
         requests:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -36,22 +36,28 @@ repositories:
     slackChannel: "#knative-serving-ci"
     e2e:
       - match: ".*e2e$"
-      - match: ".*e2e-tls$"
-      - match: "perf-tests$"
-        onDemand: true
-        filterImages:
-          "perf-test":
+        skipImages:
             - "knative-serving-load-test"
             - "knative-serving-dataplane-probe"
             - "knative-serving-real-traffic-test"
             - "knative-serving-reconciliation-delay"
             - "knative-serving-rollout-probe"
             - "knative-serving-scale-from-zero"
+      - match: ".*e2e-tls$"
+        skipImages:
+            - "knative-serving-load-test"
+            - "knative-serving-dataplane-probe"
+            - "knative-serving-real-traffic-test"
+            - "knative-serving-reconciliation-delay"
+            - "knative-serving-rollout-probe"
+            - "knative-serving-scale-from-zero"
+      - match: "perf-tests$"
+        onDemand: true
     dockerfiles:
       matches:
-        - "openshift/ci-operator/knative-images.*",
-        - "openshift/ci-operator/knative-test-images.*",
-        - "openshift/ci-operator/knative-perf-images.*",
+        - "openshift/ci-operator/knative-images.*"
+        - "openshift/ci-operator/knative-test-images.*"
+        - "openshift/ci-operator/knative-perf-images.*"
     resources:
       '*':
         requests:

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -28,11 +28,12 @@ type Repository struct {
 }
 
 type E2ETest struct {
-	Match        string `json:"match" yaml:"match"`
-	OnDemand     bool   `json:"onDemand" yaml:"onDemand"`
-	IgnoreError  bool   `json:"ignoreError" yaml:"ignoreError"`
-	RunIfChanged string `json:"runIfChanged" yaml:"runIfChanged"`
-	SkipCron     bool   `json:"skipCron" yaml:"skipCron"`
+	Match        string              `json:"match" yaml:"match"`
+	OnDemand     bool                `json:"onDemand" yaml:"onDemand"`
+	IgnoreError  bool                `json:"ignoreError" yaml:"ignoreError"`
+	RunIfChanged string              `json:"runIfChanged" yaml:"runIfChanged"`
+	SkipCron     bool                `json:"skipCron" yaml:"skipCron"`
+	FilterImages map[string][]string `json:"filterImages" yaml:"filterImages"`
 }
 
 type Dockerfiles struct {

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -28,12 +28,12 @@ type Repository struct {
 }
 
 type E2ETest struct {
-	Match        string              `json:"match" yaml:"match"`
-	OnDemand     bool                `json:"onDemand" yaml:"onDemand"`
-	IgnoreError  bool                `json:"ignoreError" yaml:"ignoreError"`
-	RunIfChanged string              `json:"runIfChanged" yaml:"runIfChanged"`
-	SkipCron     bool                `json:"skipCron" yaml:"skipCron"`
-	FilterImages map[string][]string `json:"filterImages" yaml:"filterImages"`
+	Match        string   `json:"match" yaml:"match"`
+	OnDemand     bool     `json:"onDemand" yaml:"onDemand"`
+	IgnoreError  bool     `json:"ignoreError" yaml:"ignoreError"`
+	RunIfChanged string   `json:"runIfChanged" yaml:"runIfChanged"`
+	SkipCron     bool     `json:"skipCron" yaml:"skipCron"`
+	SkipImages   []string `json:"skipImages" yaml:"skipImages"`
 }
 
 type Dockerfiles struct {

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -226,7 +226,7 @@ func dependenciesFromImages(r Repository, images []cioperatorapi.ProjectDirector
 	return deps
 }
 
-// Skip an image if it is in the skip image list
+// Accept an image if it is not the skip image list
 func shouldAcceptImage(testName string, skipImages []string, image string) bool {
 	return slices.Index(skipImages, image) < 0
 }

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -215,7 +215,7 @@ func dependenciesFromImages(r Repository, images []cioperatorapi.ProjectDirector
 	deps := make([]cioperatorapi.StepDependency, 0, len(images))
 	for _, image := range images {
 		imageFinal := strings.ReplaceAll(string(image.To), "_", "-")
-		if shouldSkipImage(testName, skipImages, imageFinal) {
+		if shouldAcceptImage(testName, skipImages, imageFinal) {
 			dep := cioperatorapi.StepDependency{
 				Name: imageFinal,
 				Env:  strings.ToUpper(strings.ReplaceAll(string(image.To), "-", "_")),
@@ -227,6 +227,6 @@ func dependenciesFromImages(r Repository, images []cioperatorapi.ProjectDirector
 }
 
 // Skip an image if it is in the skip image list
-func shouldSkipImage(testName string, skipImages []string, image string) bool {
+func shouldAcceptImage(testName string, skipImages []string, image string) bool {
 	return slices.Index(skipImages, image) < 0
 }

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -215,7 +215,7 @@ func dependenciesFromImages(r Repository, images []cioperatorapi.ProjectDirector
 	deps := make([]cioperatorapi.StepDependency, 0, len(images))
 	for _, image := range images {
 		imageFinal := strings.ReplaceAll(string(image.To), "_", "-")
-		if shouldAcceptImage(testName, skipImages, imageFinal) {
+		if shouldSkipImage(testName, skipImages, imageFinal) {
 			dep := cioperatorapi.StepDependency{
 				Name: imageFinal,
 				Env:  strings.ToUpper(strings.ReplaceAll(string(image.To), "-", "_")),
@@ -227,6 +227,6 @@ func dependenciesFromImages(r Repository, images []cioperatorapi.ProjectDirector
 }
 
 // Skip an image if it is in the skip image list
-func shouldAcceptImage(testName string, skipImages []string, image string) bool {
+func shouldSkipImage(testName string, skipImages []string, image string) bool {
 	return slices.Index(skipImages, image) < 0
 }

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -56,7 +56,7 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string) Re
 									},
 								},
 								Timeout:      &prowapi.Duration{Duration: 4 * time.Hour},
-								Dependencies: dependenciesFromImages(r, cfg.Images, as, test.FilterImages),
+								Dependencies: dependenciesFromImages(r, cfg.Images, as, test.SkipImages),
 								Cli:          "latest",
 							},
 						},
@@ -152,7 +152,7 @@ type Test struct {
 	IgnoreError  bool
 	RunIfChanged string
 	SkipCron     bool
-	FilterImages map[string][]string
+	SkipImages   []string
 }
 
 func (t *Test) HexSha() string {
@@ -203,7 +203,7 @@ func createTest(r Repository, line string, e2e E2ETest, tests *[]Test, commands 
 			return fmt.Errorf("[%s] failed to match test %s: %w", r.RepositoryDirectory(), e2e.Match, err)
 		}
 		if matches && !commands.Has(line) {
-			*tests = append(*tests, Test{Command: line, OnDemand: e2e.OnDemand, IgnoreError: e2e.IgnoreError, RunIfChanged: e2e.RunIfChanged, SkipCron: e2e.SkipCron, FilterImages: e2e.FilterImages})
+			*tests = append(*tests, Test{Command: line, OnDemand: e2e.OnDemand, IgnoreError: e2e.IgnoreError, RunIfChanged: e2e.RunIfChanged, SkipCron: e2e.SkipCron, SkipImages: e2e.SkipImages})
 			commands.Insert(line)
 		}
 	}
@@ -211,11 +211,11 @@ func createTest(r Repository, line string, e2e E2ETest, tests *[]Test, commands 
 	return nil
 }
 
-func dependenciesFromImages(r Repository, images []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration, testName string, filterImages map[string][]string) []cioperatorapi.StepDependency {
+func dependenciesFromImages(r Repository, images []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration, testName string, skipImages []string) []cioperatorapi.StepDependency {
 	deps := make([]cioperatorapi.StepDependency, 0, len(images))
 	for _, image := range images {
 		imageFinal := strings.ReplaceAll(string(image.To), "_", "-")
-		if shouldAcceptImage(testName, filterImages, imageFinal) {
+		if shouldAcceptImage(testName, skipImages, imageFinal) {
 			dep := cioperatorapi.StepDependency{
 				Name: imageFinal,
 				Env:  strings.ToUpper(strings.ReplaceAll(string(image.To), "-", "_")),
@@ -226,16 +226,7 @@ func dependenciesFromImages(r Repository, images []cioperatorapi.ProjectDirector
 	return deps
 }
 
-// If an image is found to be part of a filtering rule and the test name does not satisfy the prefix condition
-// the image is rejected. In any other case it is accepted.
-func shouldAcceptImage(testName string, filters map[string][]string, image string) bool {
-	for testPrefix, imageNames := range filters {
-		idx := slices.Index(imageNames, image)
-		if idx >= 0 {
-			if !strings.HasPrefix(testName, testPrefix) {
-				return false
-			}
-		}
-	}
-	return true
+// Skip an image if it is in the skip image list
+func shouldAcceptImage(testName string, skipImages []string, image string) bool {
+	return slices.Index(skipImages, image) < 0
 }

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -32,27 +32,24 @@ func TestDiscoverTestsServing(t *testing.T) {
 			{
 				Match:       "test-e2e$",
 				IgnoreError: true,
-				FilterImages: map[string][]string{
-					"perf-test": {"knative-serving-scale-from-zero"},
+				SkipImages: []string{
+					"knative-serving-scale-from-zero",
 				},
 			},
 			{
 				Match: "test-e2e-tls$",
-				FilterImages: map[string][]string{
-					"perf-test": {"knative-serving-scale-from-zero"},
+				SkipImages: []string{
+					"knative-serving-scale-from-zero",
 				},
 			},
 			{
-				Match: "perf-tests$",
-				FilterImages: map[string][]string{
-					"perf-test": {"knative-serving-scale-from-zero"},
-				},
+				Match:    "perf-tests$",
 				SkipCron: true, // The "-continuous" variant should not be generated.
 			},
 			{
 				Match: "ui-e2e$",
-				FilterImages: map[string][]string{
-					"perf-test": {"knative-serving-scale-from-zero"},
+				SkipImages: []string{
+					"knative-serving-scale-from-zero",
 				},
 				RunIfChanged: "test/ui",
 				SkipCron:     true,


### PR DESCRIPTION
- Allows to skip images per test pattern:
```     
      SkipImages:
          - "knative-serving-load-test"
```          
- Tested locally, here is a [sample diff](https://gist.github.com/skonto/ac5e0b68e96002759b685301c6756b40) and files affected:
```
 git diff  c4d61ca90a6bbba57ec77196a00a596fb4b49b35 --stat .../openshift-knative-serving-release-next__411.yaml |  64 +++++
 .../openshift-knative-serving-release-next__414.yaml |  64 +++++
 ...openshift-knative-serving-release-v1.10__411.yaml |  64 +++++
 ...openshift-knative-serving-release-v1.10__414.yaml |  64 +++++
 ...openshift-knative-serving-release-v1.11__411.yaml | 315 +++++++++++++++++++--
 ...openshift-knative-serving-release-v1.11__414.yaml | 315 +++++++++++++++++++--
 ...openshift-knative-serving-release-v1.12__411.yaml | 315 +++++++++++++++++++--
 ...openshift-knative-serving-release-v1.12__414.yaml | 315 +++++++++++++++++++--
 .../openshift-knative-serving-release-v1.8__410.yaml |  64 +++++
 .../openshift-knative-serving-release-v1.8__413.yaml |  64 +++++
 .../openshift-knative-serving-release-v1.9__410.yaml |  64 +++++
 .../openshift-knative-serving-release-v1.9__413.yaml |  64 +++++
 ...hift-knative-serving-release-v1.11-periodics.yaml | 160 +++++++++++
 ...ift-knative-serving-release-v1.11-presubmits.yaml | 142 ++++++++++
 ...hift-knative-serving-release-v1.12-periodics.yaml | 160 +++++++++++
 ...ift-knative-serving-release-v1.12-presubmits.yaml | 142 ++++++++++
 16 files changed, 2264 insertions(+), 112 deletions(-)

```
Only 1.11 and 1.12 midstream branches have perf tests at the moment.
- See https://github.com/openshift/release/pull/45498 for a run of test-e2e-aws-ocp-411 without perf images build as they are not included in its deps.