### PR TITLE
Remove old branches

### DIFF
--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -4,7 +4,7 @@ config:
   branches:
     "main":
       openShiftVersions:
-        - 4.14
+        - version: 4.14
 
 repositories:
   - org: openshift-knative

--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -4,7 +4,7 @@ config:
   branches:
     "main":
       openShiftVersions:
-        - version: 4.12
+        - 4.14
 
 repositories:
   - org: openshift-knative

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -2,10 +2,6 @@
 
 config:
   branches:
-    "release-v1.8":
-      openShiftVersions:
-        - version: 4.13
-        - version: 4.10
     "release-v1.9":
       openShiftVersions:
         - version: 4.13

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -2,18 +2,6 @@
 
 config:
   branches:
-    "release-v1.6":
-      openShiftVersions:
-        - version: 4.12
-        - version: 4.8
-    "release-v1.7":
-      openShiftVersions:
-        - version: 4.12
-        - version: 4.8
-    "release-v1.8":
-      openShiftVersions:
-        - version: 4.13
-        - version: 4.10
     "release-v1.9":
       openShiftVersions:
         - version: 4.13

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -2,18 +2,6 @@
 
 config:
   branches:
-    "release-v1.6":
-      openShiftVersions:
-        - version: 4.12
-        - version: 4.8
-    "release-v1.7":
-      openShiftVersions:
-        - version: 4.12
-        - version: 4.8
-    "release-v1.8":
-      openShiftVersions:
-        - version: 4.13
-        - version: 4.10
     "release-v1.9":
       openShiftVersions:
         - version: 4.13

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -2,10 +2,6 @@
 
 config:
   branches:
-    "release-v1.8":
-      openShiftVersions:
-        - version: 4.13
-        - version: 4.10
     "release-v1.9":
       openShiftVersions:
         - version: 4.13

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -1,0 +1,77 @@
+package prowgen
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type semVTest struct {
+	name     string
+	branches map[string]Branch
+	want     []string
+}
+
+func TestDeleteOldBranches(t *testing.T) {
+	tests := []semVTest{
+		{
+			name: "no previous minor, two previous majors",
+			branches: map[string]Branch{
+				"release-v3.1": {},
+				"release-v2.9": {},
+				"release-v2.0": {},
+			},
+			want: []string{
+				"release-v1",
+				"release-v0",
+			},
+		}, {
+			name: "minor and major",
+			branches: map[string]Branch{
+				"release-v3.1": {},
+				"release-v2.9": {},
+				"release-v2.2": {},
+			},
+			want: []string{
+				"release-v1",
+				"release-v0",
+				"release-v2.1",
+				"release-v2.0",
+			},
+		}, {
+			name: "only minors",
+			branches: map[string]Branch{
+				"release-v0.3": {},
+			},
+			want: []string{
+				"release-v0.2",
+				"release-v0.1",
+				"release-v0.0",
+			},
+		}, {
+			name: "only major, one previous major",
+			branches: map[string]Branch{
+				"release-v1.0": {},
+			},
+			want: []string{
+				"release-v0",
+			},
+		}, {
+			name: "no branch should be considered",
+			branches: map[string]Branch{
+				"main":         {},
+				"release-next": {},
+			},
+			want: nil,
+		}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getOldBranchCandidatePrefixes(tt.branches, "release-v")
+			diff := cmp.Diff(tt.want, got)
+			if diff != "" {
+				t.Errorf("Unexpected tests (-want, +got): \n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Fixes #48 for all repos besides S-O.
- Remove branches < 1.9 and variants < 4.11
- Creates the following changes:

> On branch sync-serverless-ci
> Your branch is up to date with 'master'.
> 
> Changes to be committed:
>   (use "git restore --staged <file>..." to unstage)
> 	renamed:    ci-operator/config/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main__412.yaml -> ci-operator/config/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main__414.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8__410.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8__413.yaml
> 	modified:   ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-next__411.yaml
> 	modified:   ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-next__413.yaml
> 	modified:   ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.11__411.yaml
> 	modified:   ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.11__413.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6__412.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6__48.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7__412.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7__48.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8__410.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8__413.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.6__412.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.6__48.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.7__412.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.7__48.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.8__410.yaml
> 	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.8__413.yaml
> 	deleted:    ci-operator/config/openshift-knative/serving/openshift-knative-serving-release-v1.8__410.yaml
> 	deleted:    ci-operator/config/openshift-knative/serving/openshift-knative-serving-release-v1.8__413.yaml
> 	modified:   ci-operator/jobs/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main-periodics.yaml
> 	modified:   ci-operator/jobs/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main-postsubmits.yaml
> 	modified:   ci-operator/jobs/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main-presubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8-periodics.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8-postsubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8-presubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6-periodics.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6-postsubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6-presubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7-periodics.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7-postsubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7-presubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8-periodics.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8-postsubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8-presubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.6-periodics.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.6-postsubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.6-presubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.7-periodics.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.7-postsubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.7-presubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.8-periodics.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.8-postsubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.8-presubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-periodics.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-postsubmits.yaml
> 	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-presubmits.yaml
> 	modified:   core-services/image-mirroring/knative/mapping_knative_knative-nightly_eventing-kafka-broker_quay
> 	modified:   core-services/image-mirroring/knative/mapping_knative_knative-v1.11_eventing-kafka-broker_quay
> 	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.6_eventing-kafka-broker_quay
> 	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.6_eventing_quay
> 	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.7_eventing-kafka-broker_quay
> 	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.7_eventing_quay
> 	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_eventing-istio_quay
> 	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_eventing-kafka-broker_quay
> 	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_eventing_quay
> 	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_serving_quay

