### PR TITLE
Add static-images as default Dockerfile includes pattern

### DIFF
--- a/pkg/prowgen/prowgen_images_discovery.go
+++ b/pkg/prowgen/prowgen_images_discovery.go
@@ -25,6 +25,7 @@ var (
 	defaultDockerfileIncludes = []string{
 		"openshift/ci-operator/knative-images.*",
 		"openshift/ci-operator/knative-test-images.*",
+		"openshift/ci-operator/static-images.*",
 	}
 )
 


### PR DESCRIPTION
To avoid breaking EKB we need to add a new pattern `openshift/ci-operator/static-images.*` for repositories that want to define Dockerfiles that are not generated by `hack/cmd/generate` (like EKB).