### PR TITLE
Fix onDemand defined for certain OpenShift version

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -275,12 +275,12 @@ func alwaysRunInjector() JobConfigInjector {
 					}
 
 					variant := jobConfig.PresubmitsStatic[k][i].Labels["ci-operator.openshift.io/variant"]
-					ocpVersion := strings.SplitN(variant, "-", 2)[0]
+					ocpVersion := strings.ReplaceAll(strings.SplitN(variant, "-", 2)[0], ".", "")
 
 					// Individual OpenShift versions can enforce all their jobs to be on demand.
 					var onDemandForOpenShift bool
 					for _, v := range b.OpenShiftVersions {
-						if v.Version == ocpVersion {
+						if strings.ReplaceAll(v.Version, ".", "") == ocpVersion {
 							onDemandForOpenShift = v.OnDemand
 						}
 					}


### PR DESCRIPTION
The variant might be e.g. "4.13-ovn" or "411" for auto-generated jobs. We need to remove the dots to match the versions properly.
