### PR TITLE
Remove old branches

### DIFF
--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -4,7 +4,7 @@ config:
   branches:
     "main":
       openShiftVersions:
-        - version: 4.12
+        - version: 4.14
 
 repositories:
   - org: openshift-knative

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -2,10 +2,6 @@
 
 config:
   branches:
-    "release-v1.8":
-      openShiftVersions:
-        - version: 4.13
-        - version: 4.10
     "release-v1.9":
       openShiftVersions:
         - version: 4.13
@@ -26,6 +22,8 @@ config:
 repositories:
   - org: openshift-knative
     repo: eventing-istio
+    promotion:
+      namespace: openshift
     imagePrefix: knative-eventing-istio
     slackChannel: "#knative-eventing-ci"
     e2e:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -2,18 +2,6 @@
 
 config:
   branches:
-    "release-v1.6":
-      openShiftVersions:
-        - version: 4.12
-        - version: 4.8
-    "release-v1.7":
-      openShiftVersions:
-        - version: 4.12
-        - version: 4.8
-    "release-v1.8":
-      openShiftVersions:
-        - version: 4.13
-        - version: 4.10
     "release-v1.9":
       openShiftVersions:
         - version: 4.13
@@ -34,6 +22,8 @@ config:
 repositories:
   - org: openshift-knative
     repo: eventing-kafka-broker
+    promotion:
+      namespace: openshift
     imagePrefix: knative-eventing-kafka-broker
     slackChannel: "#knative-eventing-ci"
     e2e:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -2,18 +2,6 @@
 
 config:
   branches:
-    "release-v1.6":
-      openShiftVersions:
-        - version: 4.12
-        - version: 4.8
-    "release-v1.7":
-      openShiftVersions:
-        - version: 4.12
-        - version: 4.8
-    "release-v1.8":
-      openShiftVersions:
-        - version: 4.13
-        - version: 4.10
     "release-v1.9":
       openShiftVersions:
         - version: 4.13
@@ -34,6 +22,8 @@ config:
 repositories:
   - org: openshift-knative
     repo: eventing
+    promotion:
+      namespace: openshift
     imagePrefix: knative-eventing
     slackChannel: "#knative-eventing-ci"
     e2e:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -22,5 +22,7 @@ config:
 repositories:
   - org: openshift-knative
     repo: net-istio
+    promotion:
+      namespace: openshift
     imagePrefix: net-istio
     slackChannel: "#knative-serving-ci"

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -22,5 +22,7 @@ config:
 repositories:
   - org: openshift-knative
     repo: net-kourier
+    promotion:
+      namespace: openshift
     imagePrefix: net-kourier
     slackChannel: "#knative-serving-ci"

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -2,10 +2,6 @@
 
 config:
   branches:
-    "release-v1.8":
-      openShiftVersions:
-        - version: 4.13
-        - version: 4.10
     "release-v1.9":
       openShiftVersions:
         - version: 4.13
@@ -30,6 +26,8 @@ config:
 repositories:
   - org: openshift-knative
     repo: serving
+    promotion:
+      namespace: openshift
     imagePrefix: knative-serving
     imageNameOverrides:
       migrate: storage-version-migration


### PR DESCRIPTION
- replace #90 
- output:
```
 git status
On branch sync-serverless-ci
Your branch is up to date with 'master'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	renamed:    ci-operator/config/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main__412.yaml -> ci-operator/config/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main__414.yaml
	deleted:    ci-operator/config/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8__410.yaml
	deleted:    ci-operator/config/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8__413.yaml
	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6__412.yaml
	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6__48.yaml
	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7__412.yaml
	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7__48.yaml
	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8__410.yaml
	deleted:    ci-operator/config/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8__413.yaml
	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.6__412.yaml
	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.6__48.yaml
	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.7__412.yaml
	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.7__48.yaml
	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.8__410.yaml
	deleted:    ci-operator/config/openshift-knative/eventing/openshift-knative-eventing-release-v1.8__413.yaml
	deleted:    ci-operator/config/openshift-knative/net-istio/openshift-knative-net-istio-release-1.8.yaml
	deleted:    ci-operator/config/openshift-knative/net-kourier/openshift-knative-net-kourier-release-1.8.yaml
	deleted:    ci-operator/config/openshift-knative/serving/openshift-knative-serving-release-v1.8__410.yaml
	deleted:    ci-operator/config/openshift-knative/serving/openshift-knative-serving-release-v1.8__413.yaml
	modified:   ci-operator/jobs/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main-periodics.yaml
	modified:   ci-operator/jobs/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main-postsubmits.yaml
	modified:   ci-operator/jobs/openshift-knative/eventing-hyperfoil-benchmark/openshift-knative-eventing-hyperfoil-benchmark-main-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-istio/openshift-knative-eventing-istio-release-v1.8-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.6-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.7-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing-kafka-broker/openshift-knative-eventing-kafka-broker-release-v1.8-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.6-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.6-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.6-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.7-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.7-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.7-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.8-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.8-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/eventing/openshift-knative-eventing-release-v1.8-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/net-istio/openshift-knative-net-istio-release-1.8-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/net-istio/openshift-knative-net-istio-release-1.8-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/net-kourier/openshift-knative-net-kourier-release-1.8-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/net-kourier/openshift-knative-net-kourier-release-1.8-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-presubmits.yaml
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.6_eventing-kafka-broker_quay
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.6_eventing_quay
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.7_eventing-kafka-broker_quay
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.7_eventing_quay
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_eventing-istio_quay
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_eventing-kafka-broker_quay
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_eventing_quay
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_serving_quay


```