### PR TITLE
Skip tests/dockerfiles per branch

### DIFF
--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -19,6 +19,10 @@ config:
         - version: 4.14
         - version: 4.11
     "release-next":
+      skipE2EMatches:
+        - "perf-tests$"
+      skipDockerFilesMatches:
+        - "openshift/ci-operator/knative-perf-images.*"
       openShiftVersions:
         - version: 4.14
         - version: 4.11

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -268,7 +268,7 @@ func alwaysRunInjector() JobConfigInjector {
 			if err := GitCheckout(context.TODO(), *r, branchName); err != nil {
 				return fmt.Errorf("[%s] failed to checkout branch %s", r.RepositoryDirectory(), branchName)
 			}
-			tests, err := discoverE2ETests(*r)
+			tests, err := discoverE2ETests(*r, b.SkipE2EMatches)
 			if err != nil {
 				return fmt.Errorf("failed to discover tests: %w", err)
 			}

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -53,7 +53,9 @@ func (r Repository) RepositoryDirectory() string {
 }
 
 type Branch struct {
-	OpenShiftVersions []OpenShift `json:"openShiftVersions" yaml:"openShiftVersions"`
+	OpenShiftVersions      []OpenShift `json:"openShiftVersions" yaml:"openShiftVersions"`
+	SkipE2EMatches         []string    `json:"skipE2EMatches" yaml:"skipE2EMatches"`
+	SkipDockerFilesMatches []string    `json:"skipDockerFilesMatches" yaml:"skipDockerFilesMatches"`
 }
 
 type OpenShift struct {
@@ -162,8 +164,8 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 
 			options = append(
 				options,
-				DiscoverImages(r),
-				DiscoverTests(r, ov, fromImage),
+				DiscoverImages(r, branch.SkipDockerFilesMatches),
+				DiscoverTests(r, ov, fromImage, branch.SkipE2EMatches),
 			)
 
 			log.Println(r.RepositoryDirectory(), "Apply input options", len(options))

--- a/pkg/prowgen/prowgen_images_discovery_test.go
+++ b/pkg/prowgen/prowgen_images_discovery_test.go
@@ -17,7 +17,7 @@ func TestDiscoverImages(t *testing.T) {
 		CanonicalGoRepository: pointer.String("knative.dev/eventing"),
 	}
 
-	options := DiscoverImages(r)
+	options := DiscoverImages(r, nil)
 
 	expectedImages := []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration{
 		{

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -25,6 +25,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 				"knative-perf-images/.*",
 				"knative-images/.*",
 				"knative-test-images/.*",
+				"skip-images/.*",
 			},
 		},
 
@@ -47,6 +48,9 @@ func TestDiscoverTestsServing(t *testing.T) {
 				SkipCron: true, // The "-continuous" variant should not be generated.
 			},
 			{
+				Match: "skip-e2e$",
+			},
+			{
 				Match: "ui-e2e$",
 				SkipImages: []string{
 					"knative-serving-scale-from-zero",
@@ -60,8 +64,8 @@ func TestDiscoverTestsServing(t *testing.T) {
 
 	servingSourceImage := "knative-serving-source-image"
 	options := []ReleaseBuildConfigurationOption{
-		DiscoverImages(r),
-		DiscoverTests(r, OpenShift{Version: "4.12", Cron: *cron}, servingSourceImage),
+		DiscoverImages(r, []string{"skip-images/.*"}),
+		DiscoverTests(r, OpenShift{Version: "4.12", Cron: *cron}, servingSourceImage, []string{"skip-e2e$"}),
 	}
 
 	dependencies := []cioperatorapi.StepDependency{
@@ -383,8 +387,8 @@ func TestDiscoverTestsEventing(t *testing.T) {
 
 	eventingSourceImage := "knative-eventing-source-image"
 	options := []ReleaseBuildConfigurationOption{
-		DiscoverImages(r),
-		DiscoverTests(r, OpenShift{Version: "4.12"}, eventingSourceImage),
+		DiscoverImages(r, nil),
+		DiscoverTests(r, OpenShift{Version: "4.12"}, eventingSourceImage, nil),
 	}
 
 	dependencies := []cioperatorapi.StepDependency{

--- a/pkg/prowgen/testdata/serving/Makefile
+++ b/pkg/prowgen/testdata/serving/Makefile
@@ -16,3 +16,6 @@ perf-tests:
 
 ui-e2e:
 	echo "Ignore me"
+
+skip-e2e:
+	echo "Ignore me"


### PR DESCRIPTION
- We have a case where we don't want to run perf tests for the `release-next` branch but we want to have the targets and the dockerfiles available so when a new release branch is cut to use them (they are under ./openshift dir by convention and they affect release-next).
- Tested in unit test. Also tested with the setting:
 ```
    "release-v1.11":
      openShiftVersions:
        - version: 4.14
        - version: 4.11
      skipE2EMatches:
        - "perf-tests$"
      skipDockerFilesMatches:
        - "openshift/ci-operator/knative-perf-images.*"
      openShiftVersions:
        - version: 4.14
        - version: 4.11
```
The above setting generates the following git diff:
```
	modified:   ci-operator/config/openshift-knative/serving/openshift-knative-serving-release-v1.11__411.yaml
	modified:   ci-operator/config/openshift-knative/serving/openshift-knative-serving-release-v1.11__414.yaml
	deleted:    ci-operator/config/openshift-knative/serving/openshift-knative-serving-release-v1.8__410.yaml
	deleted:    ci-operator/config/openshift-knative/serving/openshift-knative-serving-release-v1.8__413.yaml
	modified:   ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.11-periodics.yaml
	modified:   ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.11-presubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-periodics.yaml
	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-postsubmits.yaml
	deleted:    ci-operator/jobs/openshift-knative/serving/openshift-knative-serving-release-v1.8-presubmits.yaml
	modified:   core-services/image-mirroring/knative/mapping_knative_knative-v1.11_serving_quay
	deleted:    core-services/image-mirroring/knative/mapping_knative_knative-v1.8_serving_quay
```
Actual diff contents [here](https://gist.githubusercontent.com/skonto/13d149cb6e3a5b46aeb288baf47a4f0b/raw/7ddfaba9d7d122539ca743487ff5e9881f1cc975/gistfile1.txt).