### PR TITLE
increase timeout to 5h from the default 4h for mesh jobs

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -45,6 +45,7 @@ repositories:
       - match: "^mesh-e2e$"
         onDemand: true
         ignoreError: true
+        timeout: 4h0m0s
       - match: "^mesh-upgrade$"
         onDemand: true
         ignoreError: true

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
 type Repository struct {
@@ -29,12 +30,13 @@ type Repository struct {
 }
 
 type E2ETest struct {
-	Match        string   `json:"match" yaml:"match"`
-	OnDemand     bool     `json:"onDemand" yaml:"onDemand"`
-	IgnoreError  bool     `json:"ignoreError" yaml:"ignoreError"`
-	RunIfChanged string   `json:"runIfChanged" yaml:"runIfChanged"`
-	SkipCron     bool     `json:"skipCron" yaml:"skipCron"`
-	SkipImages   []string `json:"skipImages" yaml:"skipImages"`
+	Match        string            `json:"match" yaml:"match"`
+	OnDemand     bool              `json:"onDemand" yaml:"onDemand"`
+	IgnoreError  bool              `json:"ignoreError" yaml:"ignoreError"`
+	RunIfChanged string            `json:"runIfChanged" yaml:"runIfChanged"`
+	SkipCron     bool              `json:"skipCron" yaml:"skipCron"`
+	SkipImages   []string          `json:"skipImages" yaml:"skipImages"`
+	Timeout      *prowapi.Duration `json:"timeout" yaml:"timeout"`
 }
 
 type Dockerfiles struct {


### PR DESCRIPTION
In runs like https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-411-mesh-e2e-aws-ocp-411-continuous/1735540469623951360  , the tests actually finish in time, but the must-gathers are terminated because of the overall job 4h timeout.

tried rehearsing here: https://github.com/openshift/release/pull/46314 