### PR TITLE
Use go.mod to get Go version in actions

### DIFF
--- a/.github/workflows/go-unit-tests.yaml
+++ b/.github/workflows/go-unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -3,6 +3,7 @@ name: Multiarch KO builds
 on:
   workflow_call:
     inputs:
+      # Deprecated, left for backward compatibility but it is unused
       goversion:
         description: A version of Go
         default: 1.21.x
@@ -36,7 +37,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ inputs.goversion }}
+          go-version-file: go.mod
 
       - name: Setup ko
         uses: imjasonh/setup-ko@v0.6

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Install prerequisites
         env:

--- a/.github/workflows/run-command-repository.yaml
+++ b/.github/workflows/run-command-repository.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21.x
+          go-version-file: go.mod
 
       - name: Install prerequisites
         env:


### PR DESCRIPTION
We don't need to maintain Go versions in actions anymore as it will pick up the version in go.mod

Documentation https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file