### PR TITLE
Make sure candidate OCP release is properly marked as onDemand

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -287,9 +287,20 @@ func alwaysRunInjector() JobConfigInjector {
 					variant := jobConfig.PresubmitsStatic[k][i].Labels["ci-operator.openshift.io/variant"]
 					ocpVersion := strings.ReplaceAll(strings.SplitN(variant, "-", 2)[0], ".", "")
 
+					var err error
+					openshiftVersions := b.OpenShiftVersions
+					// Add candidate release only for serverless-operator as openshift
+					// cluster profiles allow only this repository.
+					// See https://issues.redhat.com/browse/SRVCOM-2903
+					if strings.Contains(r.RepositoryDirectory(), "serverless-operator") {
+						openshiftVersions, err = addCandidateRelease(b.OpenShiftVersions)
+						if err != nil {
+							return err
+						}
+					}
 					// Individual OpenShift versions can enforce all their jobs to be on demand.
 					var onDemandForOpenShift bool
-					for _, v := range b.OpenShiftVersions {
+					for _, v := range openshiftVersions {
 						if strings.ReplaceAll(v.Version, ".", "") == ocpVersion {
 							onDemandForOpenShift = v.OnDemand
 						}


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift-knative/hack/commit/b8a83fb96e441615dd5fe081cc08565d9884f3b2
The Prow job injector needs to properly set the job as on-demand.