### PR TITLE
Shorter generated suffixes 

### DIFF
--- a/pkg/prowgen/prowgen_command_name_mapping.go
+++ b/pkg/prowgen/prowgen_command_name_mapping.go
@@ -16,8 +16,8 @@ const (
 func ToName(r Repository, test *Test, openShiftVersion string) string {
 
 	variant := strings.ReplaceAll(openShiftVersion, ".", "")
-	suffix := fmt.Sprintf("-aws-ocp-%s", variant)
-	continuousSuffix := "-continuous"
+	suffix := fmt.Sprintf("-aws-%s", variant)
+	continuousSuffix := "-c"
 
 	maxCommandLength := maxNameLength - len(suffix) - len(continuousSuffix)
 	if len(test.Command) > maxCommandLength {

--- a/pkg/prowgen/prowgen_command_name_mapping_test.go
+++ b/pkg/prowgen/prowgen_command_name_mapping_test.go
@@ -9,8 +9,8 @@ import (
 func TestToName(t *testing.T) {
 
 	openshiftVersion := "4.11"
-	suffix := "-aws-ocp-411"
-	continuousSuffix := "-continuous"
+	suffix := "-aws-411"
+	continuousSuffix := "-c"
 
 	tests := []struct {
 		name             string
@@ -35,7 +35,7 @@ func TestToName(t *testing.T) {
 				Command: strings.Repeat("a", maxNameLength-len(suffix)-len(continuousSuffix)+1),
 			},
 			openShiftVersion: openshiftVersion,
-			want:             fmt.Sprintf("%s-%s%s", strings.Repeat("a", maxNameLength-len(suffix)-len(continuousSuffix)-shaLength-1) /* hex sha1 */, "38666b8", suffix),
+			want:             fmt.Sprintf("%s-%s%s", strings.Repeat("a", maxNameLength-len(suffix)-len(continuousSuffix)-shaLength-1) /* hex sha1 */, "2368a1a", suffix),
 		},
 		{
 			name: fmt.Sprintf("%d length name", maxNameLength-len(suffix)-len(continuousSuffix)),
@@ -62,7 +62,7 @@ func TestToName(t *testing.T) {
 				Command: "test-kafka-broker-upstream-nightly",
 			},
 			openShiftVersion: openshiftVersion,
-			want:             fmt.Sprintf("%s%s", "test-kafka-fbbddbf", suffix),
+			want:             fmt.Sprintf("%s%s", "test-kafka-broker-upstre-fbbddbf", suffix),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -146,7 +146,7 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 
 			if !test.SkipCron && !openShift.CandidateRelease {
 				cronTestConfiguration := testConfiguration.DeepCopy()
-				cronTestConfiguration.As += "-continuous"
+				cronTestConfiguration.As += "-c"
 				if openShift.Cron == "" {
 					cronTestConfiguration.Cron = pointer.String(defaultCron)
 				} else {

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -96,7 +96,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 
 	expectedTests := []cioperatorapi.TestStepConfiguration{
 		{
-			As: "perf-tests-aws-ocp-412",
+			As: "perf-tests-aws-412",
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -127,7 +127,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 			},
 		},
 		{
-			As: "test-e2e-aws-ocp-412",
+			As: "test-e2e-aws-412",
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -159,7 +159,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 			},
 		},
 		{
-			As:   "test-e2e-aws-ocp-412-continuous",
+			As:   "test-e2e-aws-412-c",
 			Cron: cron,
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
@@ -191,7 +191,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 			},
 		},
 		{
-			As: "test-e2e-tls-aws-ocp-412",
+			As: "test-e2e-tls-aws-412",
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -222,7 +222,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 			},
 		},
 		{
-			As:   "test-e2e-tls-aws-ocp-412-continuous",
+			As:   "test-e2e-tls-aws-412-c",
 			Cron: cron,
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
@@ -254,7 +254,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 			},
 		},
 		{
-			As: "ui-e2e-aws-ocp-412",
+			As: "ui-e2e-aws-412",
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -408,7 +408,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 
 	expectedTests := []cioperatorapi.TestStepConfiguration{
 		{
-			As: "test-conformance-aws-ocp-412",
+			As: "test-conformance-aws-412",
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -439,7 +439,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			},
 		},
 		{
-			As:   "test-conformance-aws-ocp-412-continuous",
+			As:   "test-conformance-aws-412-c",
 			Cron: pointer.String("0 5 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
@@ -471,7 +471,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			},
 		},
 		{
-			As: "test-confor-2627121-aws-ocp-412",
+			As: "test-conformance-long-lo-510e96a-aws-412",
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -486,7 +486,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 						LiteralTestStep: &cioperatorapi.LiteralTestStep{
 							As:       "test",
 							From:     eventingSourceImage,
-							Commands: formatCommand("make test-conformance-long-command"),
+							Commands: formatCommand("make test-conformance-long-long-long-command"),
 							Resources: cioperatorapi.ResourceRequirements{
 								Requests: cioperatorapi.ResourceList{
 									"cpu": "100m",
@@ -502,7 +502,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			},
 		},
 		{
-			As:   "test-confor-2627121-aws-ocp-412-continuous",
+			As:   "test-conformance-long-lo-510e96a-aws-412-c",
 			Cron: pointer.String("0 5 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
@@ -518,7 +518,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 						LiteralTestStep: &cioperatorapi.LiteralTestStep{
 							As:       "test",
 							From:     eventingSourceImage,
-							Commands: formatCommand("make test-conformance-long-command"),
+							Commands: formatCommand("make test-conformance-long-long-long-command"),
 							Resources: cioperatorapi.ResourceRequirements{
 								Requests: cioperatorapi.ResourceList{
 									"cpu": "100m",
@@ -534,7 +534,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			},
 		},
 		{
-			As: "test-e2e-aws-ocp-412",
+			As: "test-e2e-aws-412",
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -565,7 +565,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			},
 		},
 		{
-			As:   "test-e2e-aws-ocp-412-continuous",
+			As:   "test-e2e-aws-412-c",
 			Cron: pointer.String("0 5 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
@@ -597,7 +597,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			},
 		},
 		{
-			As: "test-reconciler-aws-ocp-412",
+			As: "test-reconciler-aws-412",
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -628,7 +628,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			},
 		},
 		{
-			As:   "test-reconciler-aws-ocp-412-continuous",
+			As:   "test-reconciler-aws-412-c",
 			Cron: pointer.String("0 5 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,

--- a/pkg/prowgen/testdata/eventing/Makefile
+++ b/pkg/prowgen/testdata/eventing/Makefile
@@ -8,5 +8,5 @@ test-conformance:
 test-e2e:
 	echo "Hello"
 
-test-conformance-long-command:
+test-conformance-long-long-long-command:
 	echo "Hello"


### PR DESCRIPTION
This will allow having less tests job generated with sha
as they are hard to map to the actual running tests.

Instead of `-continuous`, just use `-c`, and `ocp` is omitted as it's redundant for now.