### PR TITLE
Bump actions/setup-go to v5

### DIFF
--- a/.github/workflows/go-unit-tests.yaml
+++ b/.github/workflows/go-unit-tests.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -33,7 +33,7 @@ jobs:
           path: ./src/github.com/openshift-knative/hack
 
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: ./src/github.com/openshift-knative/hack/go.mod
 

--- a/.github/workflows/run-command-repository.yaml
+++ b/.github/workflows/run-command-repository.yaml
@@ -32,7 +32,7 @@ jobs:
           ref: "${{ inputs.branch }}"
 
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
- Bump actions/setup-go to v5
- With v2 the `go-version-file` is not working, [example here](https://github.com/openshift-knative/serving/actions/runs/7784168673)

/assign @pierDipi 