### PR TITLE
Fix injector to work with all repos under openshift-knative

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -289,14 +289,9 @@ func alwaysRunInjector() JobConfigInjector {
 
 					var err error
 					openshiftVersions := b.OpenShiftVersions
-					// Add candidate release only for serverless-operator as openshift
-					// cluster profiles allow only this repository.
-					// See https://issues.redhat.com/browse/SRVCOM-2903
-					if strings.Contains(r.RepositoryDirectory(), "serverless-operator") {
-						openshiftVersions, err = addCandidateRelease(b.OpenShiftVersions)
-						if err != nil {
-							return err
-						}
+					openshiftVersions, err = addCandidateRelease(b.OpenShiftVersions)
+					if err != nil {
+						return err
 					}
 					// Individual OpenShift versions can enforce all their jobs to be on demand.
 					var onDemandForOpenShift bool


### PR DESCRIPTION
This is required to properly mark jobs as `always_run: false` when running e.g. with candidate OCP release. So far it was only working for s-o.