### PR TITLE
prowcopy runs injectors configured from source branch

### DIFF
--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -12,6 +12,7 @@ import (
 
 	gyaml "github.com/ghodss/yaml"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/utils/pointer"
 
 	"github.com/openshift-knative/hack/pkg/prowgen"
@@ -45,11 +46,10 @@ func Main() error {
 	flag.StringVar(&c.Tag, "tag", "", "Target promotion name or tag")
 	flag.BoolVar(&c.RemovePeriodic, "remove-periodic-tests", true, "Remove periodic tests")
 	flag.StringVar(&c.Remote, "remote", "", "Git remote URL")
-	flag.StringVar(&c.Config, "config", filepath.Join("config", "repositories.yaml"), "Specify repositories config"))
+	flag.StringVar(&c.Config, "config", filepath.Join("config", "repositories.yaml"), "Specify repositories config")
 	flag.Parse()
 
-
-	inConfig, err := prowgen.LoadConfig(c.Config)
+	prowgenConfig, err := prowgen.LoadConfig(c.Config)
 	if err != nil {
 		log.Fatalln("Failed to load config", err)
 	}
@@ -89,10 +89,31 @@ func Main() error {
 		log.Fatalln("Failed to run openshift/release generator:", err)
 	}
 
-	if err := runProwCopyInjectors(inConfig, openShiftRelease); err != nil {
+	if err := mirrorRepositories(ctx, prowgenConfig); err != nil {
+		log.Fatalln("Failed to mirror repositories", err)
+	}
+
+	if err := runProwCopyInjectors(&c, prowgenConfig, openShiftRelease); err != nil {
 		log.Fatalln("Failed to run Prow job injectors", err)
 	}
 
+	return nil
+}
+
+func mirrorRepositories(ctx context.Context, inConfig *prowgen.Config) error {
+	repositoryMirrors, generatorsCtx := errgroup.WithContext(ctx)
+	for _, r := range inConfig.Repositories {
+		r := r
+		repositoryMirrors.Go(func() error {
+			if err := prowgen.GitMirror(generatorsCtx, r); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	if err := repositoryMirrors.Wait(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -188,9 +209,50 @@ func getJobConfig(match string, c Config) (*prowgen.ReleaseBuildConfiguration, e
 	return jobConfig, nil
 }
 
-func runProwCopyInjectors(inConfig *prowgen.Config, openShiftRelease prowgen.Repository) error {
-	injectors := prowgen.JobConfigInjectors{
+// JobConfigCopiedInjectors are configured from the base branch. They're applied to
+// generated Prow jobs for the target branch.
+type JobConfigCopiedInjectors []prowgen.JobConfigInjector
+
+func (jcis JobConfigCopiedInjectors) Inject(prowcopyCfg *Config, prowgenCfg *prowgen.Config, openShiftRelease prowgen.Repository) error {
+	for _, jci := range jcis {
+		sourceBranchName, targetBranch := prowcopyCfg.FromBranch, prowcopyCfg.Branch
+		var sourceBranch *prowgen.Branch
+		// Injectors need to be applied to the new branch in the same way as they were applied
+		// to the source branch when its config was generated.
+		for branchName, branch := range prowgenCfg.Config.Branches {
+			if branchName == sourceBranchName {
+				sourceBranch = &branch
+			}
+		}
+
+		for _, r := range prowgenCfg.Repositories {
+			generatedOutputDir := "ci-operator/jobs"
+			glob := filepath.Join(openShiftRelease.RepositoryDirectory(), generatedOutputDir, r.RepositoryDirectory(), "*"+targetBranch+"*"+string(jci.Type)+"*")
+			matches, err := filepath.Glob(glob)
+			if err != nil {
+				return err
+			}
+			for _, match := range matches {
+				jobConfig, err := prowgen.GetJobConfig(match)
+				if err != nil {
+					return err
+				}
+				if err := jci.Update(&r, sourceBranch, sourceBranchName, jobConfig); err != nil {
+					return err
+				}
+				if err := prowgen.SaveJobConfig(match, jobConfig); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func runProwCopyInjectors(config *Config, inConfig *prowgen.Config, openShiftRelease prowgen.Repository) error {
+	injectors := JobConfigCopiedInjectors{
 		prowgen.AlwaysRunInjector(),
 	}
-	return injectors.Inject(inConfig, openShiftRelease)
+	return injectors.Inject(config, inConfig, openShiftRelease)
 }

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -51,20 +51,9 @@ func Main() {
 
 	log.Println(*inputConfig, *outConfig)
 
-	// Going directly from YAML raw input produces unexpected configs (due to missing YAML tags),
-	// so we convert YAML to JSON and unmarshal the struct from the JSON object.
-	y, err := os.ReadFile(*inputConfig)
+	inConfig, err := LoadConfig(*inputConfig)
 	if err != nil {
-		log.Fatalln(err)
-	}
-	j, err := gyaml.YAMLToJSON(y)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	inConfig := &Config{}
-	if err := json.Unmarshal(j, inConfig); err != nil {
-		log.Fatalln("Unmarshal input config", err)
+		log.Fatalln("Failed to load config", err)
 	}
 
 	for _, v := range inConfig.Config.Branches {
@@ -140,6 +129,24 @@ func Main() {
 	if err := PushBranch(ctx, openShiftRelease, remote, *branch, *inputConfig); err != nil {
 		log.Fatalln("Failed to push branch to openshift/release fork", *remote, err)
 	}
+}
+
+func LoadConfig(path string) (*Config, error) {
+	// Going directly from YAML raw input produces unexpected configs (due to missing YAML tags),
+	// so we convert YAML to JSON and unmarshal the struct from the JSON object.
+	y, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	j, err := gyaml.YAMLToJSON(y)
+	if err != nil {
+		return nil, err
+	}
+	inConfig := &Config{}
+	if err := json.Unmarshal(j, inConfig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshall config: %w", err)
+	}
+	return inConfig, nil
 }
 
 func PushBranch(ctx context.Context, release Repository, remote *string, branch string, config string) error {
@@ -238,7 +245,7 @@ func RunOpenShiftReleaseGenerator(ctx context.Context, openShiftRelease Reposito
 
 func runJobConfigInjectors(inConfig *Config, openShiftRelease Repository) error {
 	injectors := JobConfigInjectors{
-		alwaysRunInjector(),
+		AlwaysRunInjector(),
 		slackInjector(),
 	}
 	return injectors.Inject(inConfig, openShiftRelease)
@@ -266,7 +273,7 @@ func slackInjector() JobConfigInjector {
 	}
 }
 
-func alwaysRunInjector() JobConfigInjector {
+func AlwaysRunInjector() JobConfigInjector {
 	return JobConfigInjector{
 		Type: PreSubmit,
 		Update: func(r *Repository, b *Branch, branchName string, jobConfig *prowconfig.JobConfig) error {


### PR DESCRIPTION
When copying CI config from the source branch and generating the Prow jobs again, it is necessary to apply the same injectors to the generated Prow jobs as for the source branch.

* Removed the `Inject` function on individual injectors because it makes them less versatile (and they're too complex) like in this case where I need to pass the old branch. I left the Inject function only on the group of injectors.