### PR TITLE
Use at least OCP 4.12 for Knative 1.11 components and later

### DIFF
--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -3,7 +3,7 @@ config:
     release-next:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.10:
       openShiftVersions:
       - version: "4.14"
@@ -11,15 +11,15 @@ config:
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -3,7 +3,7 @@ config:
     release-next:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.10:
       openShiftVersions:
       - version: "4.14"
@@ -11,15 +11,15 @@ config:
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -3,7 +3,7 @@ config:
     release-next:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.10:
       openShiftVersions:
       - version: "4.14"
@@ -11,15 +11,15 @@ config:
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -7,7 +7,7 @@ config:
         version: "4.14"
       - cron: 0 6 * * *
         onDemand: true
-        version: "4.11"
+        version: "4.12"
 repositories:
 - customConfigs:
   - name: aws-ovn

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -7,15 +7,15 @@ config:
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -7,15 +7,15 @@ config:
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -3,7 +3,7 @@ config:
     release-next:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
       skipDockerFilesMatches:
       - openshift/ci-operator/knative-perf-images.*
       skipE2EMatches:
@@ -16,15 +16,15 @@ config:
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
-      - version: "4.11"
+      - version: "4.12"
 repositories:
 - dockerfiles:
     matches:


### PR DESCRIPTION
Following our discussions in https://redhat-internal.slack.com/archives/CD87JDUB0/p1708939958945279?thread_ts=1708937353.127009&cid=CD87JDUB0, we drop support for OCP 4.11 with SO 1.32 (Knative 1.11 components).