### PR TITLE
Older OCP version (4.12,4.11) are run on demand for all repos

### DIFF
--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -4,22 +4,27 @@ config:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.10:
       openShiftVersions:
       - version: "4.14"
       - version: "4.11"
+        onDemand: true
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -4,22 +4,27 @@ config:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.10:
       openShiftVersions:
       - version: "4.14"
       - version: "4.11"
+        onDemand: true
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -8,18 +8,22 @@ config:
       openShiftVersions:
       - version: "4.14"
       - version: "4.11"
+        onDemand: true
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -4,18 +4,22 @@ config:
       openShiftVersions:
       - version: "4.14"
       - version: "4.11"
+        onDemand: true
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -4,18 +4,22 @@ config:
       openShiftVersions:
       - version: "4.14"
       - version: "4.11"
+        onDemand: true
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -4,6 +4,7 @@ config:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
       skipDockerFilesMatches:
       - openshift/ci-operator/knative-perf-images.*
       skipE2EMatches:
@@ -13,18 +14,22 @@ config:
       openShiftVersions:
       - version: "4.14"
       - version: "4.11"
+        onDemand: true
     release-v1.11:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.12:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
     release-v1.13:
       openShiftVersions:
       - version: "4.14"
       - version: "4.12"
+        onDemand: true
 repositories:
 - dockerfiles:
     matches:


### PR DESCRIPTION
Slack discussion [link](https://redhat-internal.slack.com/archives/CD87JDUB0/p1709821371810199)

The goal is to reduce cloud resource spending.