### PR TITLE
increase hypershift node count

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -157,8 +157,8 @@ repositories:
           cluster_profile: aws-cspi-qe
           env:
             BASE_DOMAIN: cspilp.interop.ccitredhat.com
-            COMPUTE_NODE_REPLICAS: "5"
             HYPERSHIFT_BASE_DOMAIN: cspilp.interop.ccitredhat.com
+            HYPERSHIFT_NODE_COUNT: "5"
           test:
           - as: operator-e2e
             commands: make USER_MANAGEMENT_ALLOWED=false test-e2e-with-kafka


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-414-hypershift-e2e-hypershift-continuous/1766615200951177216  

shows it still creates hypershift with only 3 replicas 

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-414-hypershift-e2e-hypershift-continuous/1766615200951177216/artifacts/e2e-hypershift-continuous/create-hostedcluster/build-log.txt

(there are two clusters with hypershift - the control cluster and the actual hypershift cluster

The COMPUTE_NODE_REPLICAS configures number of nodes on the _control cluster_ ,  HYPERSHIFT_NODE_COUNT configures number of nodes on the hypershift cluster. )