### PR TITLE
Random cron times for periodic jobs

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -2,10 +2,10 @@ config:
   branches:
     main:
       openShiftVersions:
-      - cron: 0 4 * * *
+      - cron: 0 3 * * *
         generateCustomConfigs: true
         version: "4.14"
-      - cron: 0 6 * * *
+      - cron: 0 5 * * *
         onDemand: true
         version: "4.12"
 repositories:

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -101,7 +101,7 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 	// Use the same seed to always get the same sequence of random
 	// numbers for tests within the given repository. It means the cron schedules
 	// for jobs will change less often when generating jobs.
-	random := rand.New(rand.NewSource(1))
+	random := rand.New(rand.NewSource(seed))
 
 	cfgs := make([]ReleaseBuildConfiguration, 0, len(cc.Branches)*2)
 

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
@@ -109,7 +110,16 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 		return nil, err
 	}
 
-	for branchName, branch := range cc.Branches {
+	branches := make([]string, 0, len(cc.Branches))
+	for k := range cc.Branches {
+		branches = append(branches, k)
+	}
+	// Make sure to iterate every time in the same order to keep
+	// cron times consistent between runs.
+	slices.Sort(branches)
+
+	for _, branchName := range branches {
+		branch := cc.Branches[branchName]
 
 		if err := GitCheckout(ctx, r, branchName); err != nil {
 			return nil, fmt.Errorf("[%s] failed to checkout branch %s", r.RepositoryDirectory(), branchName)

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,6 +98,10 @@ type ReleaseBuildConfiguration struct {
 }
 
 func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts ...ReleaseBuildConfigurationOption) ([]ReleaseBuildConfiguration, error) {
+	// Use the same seed to always get the same sequence of random
+	// numbers for tests within the given repository. It means the cron schedules
+	// for jobs will change less often when generating jobs.
+	random := rand.New(rand.NewSource(1))
 
 	cfgs := make([]ReleaseBuildConfiguration, 0, len(cc.Branches)*2)
 
@@ -209,7 +214,7 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 			options = append(
 				options,
 				DiscoverImages(r, branch.SkipDockerFilesMatches),
-				DiscoverTests(r, ov, fromImage, branch.SkipE2EMatches),
+				DiscoverTests(r, ov, fromImage, branch.SkipE2EMatches, random),
 			)
 
 			log.Println(r.RepositoryDirectory(), "Apply input options", len(options))

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	cronTemplate         = "0 %d * * 2,6"
+	cronTemplate         = "%d %d * * 2,6"
+	seed                 = 12345
 	devclusterBaseDomain = "serverless.devcluster.openshift.com"
 )
 
@@ -175,8 +176,11 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 				cronTestConfiguration := testConfiguration.DeepCopy()
 				cronTestConfiguration.As += "-c"
 				if openShift.Cron == "" {
-					// Make sure jobs run between 00:00 and 07:00 UTC by default.
-					nightlyCron := fmt.Sprintf(cronTemplate, random.Intn(7))
+					// Make sure jobs start between 00:00 and 06:00 UTC by default.
+					r := random.Intn(360)
+					hour := r / 60
+					minute := r % 60
+					nightlyCron := fmt.Sprintf(cronTemplate, minute, hour)
 					cronTestConfiguration.Cron = pointer.String(nightlyCron)
 				} else {
 					cronTestConfiguration.Cron = &openShift.Cron

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -2,6 +2,7 @@ package prowgen
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -62,10 +63,11 @@ func TestDiscoverTestsServing(t *testing.T) {
 
 	cron := pointer.String("0 8 * * 1-5")
 
+	random := rand.New(rand.NewSource(1))
 	servingSourceImage := "knative-serving-source-image"
 	options := []ReleaseBuildConfigurationOption{
 		DiscoverImages(r, []string{"skip-images/.*"}),
-		DiscoverTests(r, OpenShift{Version: "4.12", Cron: *cron}, servingSourceImage, []string{"skip-e2e$"}),
+		DiscoverTests(r, OpenShift{Version: "4.12", Cron: *cron}, servingSourceImage, []string{"skip-e2e$"}, random),
 	}
 
 	dependencies := []cioperatorapi.StepDependency{
@@ -385,10 +387,13 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 	}
 
+	// Use the same seed to always get the same sequence of random numbers.
+	random := rand.New(rand.NewSource(1))
+
 	eventingSourceImage := "knative-eventing-source-image"
 	options := []ReleaseBuildConfigurationOption{
 		DiscoverImages(r, nil),
-		DiscoverTests(r, OpenShift{Version: "4.12"}, eventingSourceImage, nil),
+		DiscoverTests(r, OpenShift{Version: "4.12"}, eventingSourceImage, nil, random),
 	}
 
 	dependencies := []cioperatorapi.StepDependency{
@@ -440,7 +445,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 		{
 			As:   "test-conformance-aws-412-c",
-			Cron: pointer.String("0 5 * * 2,6"),
+			Cron: pointer.String("0 6 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -503,7 +508,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 		{
 			As:   "test-conformance-long-lo-510e96a-aws-412-c",
-			Cron: pointer.String("0 5 * * 2,6"),
+			Cron: pointer.String("0 2 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -566,7 +571,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 		{
 			As:   "test-e2e-aws-412-c",
-			Cron: pointer.String("0 5 * * 2,6"),
+			Cron: pointer.String("0 1 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -629,7 +634,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 		{
 			As:   "test-reconciler-aws-412-c",
-			Cron: pointer.String("0 5 * * 2,6"),
+			Cron: pointer.String("0 0 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -388,7 +388,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 	}
 
 	// Use the same seed to always get the same sequence of random numbers.
-	random := rand.New(rand.NewSource(1))
+	random := rand.New(rand.NewSource(seed))
 
 	eventingSourceImage := "knative-eventing-source-image"
 	options := []ReleaseBuildConfigurationOption{
@@ -445,7 +445,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 		{
 			As:   "test-conformance-aws-412-c",
-			Cron: pointer.String("0 6 * * 2,6"),
+			Cron: pointer.String("23 1 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -508,7 +508,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 		{
 			As:   "test-conformance-long-lo-510e96a-aws-412-c",
-			Cron: pointer.String("0 2 * * 2,6"),
+			Cron: pointer.String("43 1 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -571,7 +571,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 		{
 			As:   "test-e2e-aws-412-c",
-			Cron: pointer.String("0 1 * * 2,6"),
+			Cron: pointer.String("4 1 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",
@@ -634,7 +634,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 		},
 		{
 			As:   "test-reconciler-aws-412-c",
-			Cron: pointer.String("0 0 * * 2,6"),
+			Cron: pointer.String("16 5 * * 2,6"),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      "4.12",


### PR DESCRIPTION
* Start periodic jobs between 00:00 and 6:00 UTC unless  the config specifies a different schedule
* Move s-o periodic jobs to not collide with busy hours

Related [Slack discussion](https://redhat-internal.slack.com/archives/CD87JDUB0/p1710498671704579?thread_ts=1710494486.769379&cid=CD87JDUB0)