### PR TITLE
Use serverless-ci cluster pool

### DIFF
--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -2,7 +2,7 @@ config:
   branches:
     main:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -2,28 +2,28 @@ config:
   branches:
     release-next:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.13:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -2,27 +2,27 @@ config:
   branches:
     release-next:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.13:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -2,27 +2,27 @@ config:
   branches:
     release-next:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - version: "4.12"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.13:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -4,7 +4,7 @@ config:
       openShiftVersions:
       - cron: 0 3 * * *
         generateCustomConfigs: true
-        version: "4.14"
+        version: "4.15"
       - cron: 0 5 * * *
         onDemand: true
         version: "4.12"
@@ -137,18 +137,18 @@ repositories:
     releaseBuildConfiguration:
       base_images:
         hypershift-operator:
-          name: "4.14"
+          name: "4.15"
           namespace: ocp
           tag: hypershift-operator
         upi-installer:
-          name: "4.14"
+          name: "4.15"
           namespace: ocp
           tag: upi-installer
       releases:
         latest:
           integration:
             include_built_images: true
-            name: "4.14"
+            name: "4.15"
             namespace: ocp
       tests:
       - as: e2e-hypershift-continuous
@@ -207,7 +207,7 @@ repositories:
           cluster_profile: osd-ephemeral
           env:
             CLUSTER_DURATION: "10800"
-            CLUSTER_VERSION: "4.14"
+            CLUSTER_VERSION: "4.15"
             COMPUTE_NODES: "4"
           post:
           - chain: gather
@@ -266,7 +266,7 @@ repositories:
     releaseBuildConfiguration:
       base_images:
         upi-installer:
-          name: "4.14"
+          name: "4.15"
           namespace: ocp
           tag: upi-installer
       tests:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -2,22 +2,22 @@ config:
   branches:
     release-v1.10:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.13:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -3,22 +3,22 @@ config:
     release-v1.10:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.13:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -2,7 +2,7 @@ config:
   branches:
     release-next:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
       skipDockerFilesMatches:
@@ -13,22 +13,22 @@ config:
     release-v1.10:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.15"
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
     release-v1.13:
       openShiftVersions:
-      - version: "4.14"
+      - version: "4.15"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -188,14 +188,6 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 							},
 						}},
 				}
-			} else if ov.Version != clusterPoolVersion {
-				releases = map[string]cioperatorapi.UnresolvedRelease{
-					"latest": {
-						Release: &cioperatorapi.Release{
-							Version: ov.Version,
-							Channel: "stable",
-						}},
-				}
 			}
 
 			cfg := cioperatorapi.ReleaseBuildConfiguration{

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -188,7 +188,16 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 							},
 						}},
 				}
+			} else if ov.Version != clusterPoolVersion {
+				releases = map[string]cioperatorapi.UnresolvedRelease{
+					"latest": {
+						Release: &cioperatorapi.Release{
+							Version: ov.Version,
+							Channel: "stable",
+						}},
+				}
 			}
+
 			cfg := cioperatorapi.ReleaseBuildConfiguration{
 				Metadata: metadata,
 				InputConfiguration: cioperatorapi.InputConfiguration{

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -24,9 +24,10 @@ const (
 	cronTemplate         = "%d %d * * 2,6"
 	seed                 = 12345
 	devclusterBaseDomain = "serverless.devcluster.openshift.com"
-	// Holds version of the cluster pool dedicated to OpenShift Serverless in CI.
+	// Holds version of the existing cluster pool dedicated to OpenShift Serverless in CI.
 	// See https://docs.ci.openshift.org/docs/how-tos/cluster-claim/#existing-cluster-pools
-	clusterPoolVersion = "4.15"
+	clusterPoolVersion       = "4.15"
+	serverlessClusterProfile = "aws-serverless"
 )
 
 func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, skipE2ETestMatch []string, random *rand.Rand) ReleaseBuildConfigurationOption {
@@ -71,7 +72,7 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 				}
 				workflow = pointer.String("generic-claim")
 			} else {
-				clusterProfile = "aws-serverless"
+				clusterProfile = serverlessClusterProfile
 				env = map[string]string{
 					"BASE_DOMAIN": devclusterBaseDomain,
 				}

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -192,7 +192,9 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 				}
 				// Periodic jobs gather artifacts on both failure/success.
 				for _, postStep := range cronTestConfiguration.MultiStageTestConfiguration.Post {
-					postStep.OptionalOnSuccess = pointer.Bool(false)
+					if postStep.LiteralTestStep != nil && strings.Contains(postStep.LiteralTestStep.As, "gather") {
+						postStep.OptionalOnSuccess = pointer.Bool(false)
+					}
 				}
 				cfg.Tests = append(cfg.Tests, *cronTestConfiguration)
 			}

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -327,10 +327,9 @@ func TestDiscoverTestsServingClusterClaim(t *testing.T) {
 		},
 	}
 
-	variant := strings.ReplaceAll(clusterPoolVersion, ".", "")
 	expectedTests := []cioperatorapi.TestStepConfiguration{
 		{
-			As: fmt.Sprintf("perf-tests-aws-%s", variant),
+			As: fmt.Sprintf("perf-tests-aws-%s", strings.ReplaceAll(clusterPoolVersion, ".", "")),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
 				Version:      clusterPoolVersion,


### PR DESCRIPTION
Depends on https://github.com/openshift/release/pull/49904

Related to https://issues.redhat.com/browse/SRVCOM-3056

* Bump OCP 4.14 to 4.15 as the PR above introduces a cluster pool for 4.15 that will be used
* Run all tests for 4.15 (both periodic and pre-submit) on the existing cluster pool
* Run tests for 4.14 and older by starting a new cluster from scratch, i.e. migrating off the openshift-ci cluster pool. Previously, tests for all versions were running on various cluster pools (4.12 - 4.14) owned by OpenShift team.
* Tests on specific platforms (Azure, vSphere, Hypershift) will be staring clusters from scratch regardless of the OCP version because the existing cluster pool is a simple variant (IPI, AWS).

/hold