### PR TITLE
Reset AlwaysRun to default before running AlwaysRunInjector

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -308,6 +308,10 @@ func AlwaysRunInjector() JobConfigInjector {
 						}
 					}
 
+					// Prevent sneaking in wrong settings from previous runs of "make jobs".
+					// Make sure we reset it to default.
+					jobConfig.PresubmitsStatic[k][i].AlwaysRun = true
+
 					for _, t := range tests {
 						name := ToName(*r, &t, ocpVersion)
 						if (t.OnDemand || t.RunIfChanged != "" || onDemandForOpenShift) && strings.Contains(jobConfig.PresubmitsStatic[k][i].Name, name) {


### PR DESCRIPTION
It might happen that "make jobs" re-uses some parts of configuration from previous runs as it tries to be smart. However, when bumping versions on our side where previously AlwaysRun was false (e.g. OCP 4.15 when 4.15 was still a candidate release), then "make jobs" will take the value to the newly generated Prow jobs. This is not desired as we might want to have 4.15 as the main test platform and run tests always.