### PR TITLE
Increase timeout for cluster pool to 2 hours

### DIFF
--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -78,7 +78,7 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 					Architecture: cioperatorapi.ReleaseArchitectureAMD64,
 					Cloud:        cioperatorapi.CloudAWS,
 					Owner:        clusterPoolOwner,
-					Timeout:      &prowapi.Duration{Duration: time.Hour},
+					Timeout:      &prowapi.Duration{Duration: 2 * time.Hour},
 				}
 				workflow = pointer.String("generic-claim")
 			} else {

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -336,7 +336,7 @@ func TestDiscoverTestsServingClusterClaim(t *testing.T) {
 				Architecture: cioperatorapi.ReleaseArchitectureAMD64,
 				Cloud:        cioperatorapi.CloudAWS,
 				Owner:        "serverless-ci",
-				Timeout:      &prowapi.Duration{Duration: time.Hour},
+				Timeout:      &prowapi.Duration{Duration: 2 * time.Hour},
 			},
 			MultiStageTestConfiguration: &cioperatorapi.MultiStageTestConfiguration{
 				Test: []cioperatorapi.TestStep{


### PR DESCRIPTION
Should be more reliable during rush hours.
