### PR TITLE
Fix OCP version for hypefoil repo and skip cron

### DIFF
--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -2,14 +2,13 @@ config:
   branches:
     main:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.14"
+        skipCron: true
 repositories:
 - dockerfiles: {}
   e2e:
-  - match: .*test-kafka-broker-upstream-.*
-  - match: .*test-kafka-broker-namespaced-midstream-.*
+  - match: test.*
     onDemand: true
-  ignoreConfigs: {}
   imagePrefix: knative-eventing-hyperfoil-benchmark
   org: openshift-knative
   promotion: {}


### PR DESCRIPTION
- We cannot yet use 4.15 as AMQ Stream doesn't support it yet
- Remove periodic and pre-submite run for hypefoil tests (to be intentional at running those tests when needed as they are heavy)
- Improve match regex