### PR TITLE
Prowgen will propagate OWNERS to openshift/release

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -233,6 +233,26 @@ func SaveReleaseBuildConfiguration(outConfig *string, cfg ReleaseBuildConfigurat
 	if err := os.WriteFile(filepath.Join(*outConfig, cfg.Path), out, os.ModePerm); err != nil {
 		return err
 	}
+
+	owners, err := os.ReadFile("OWNERS")
+	if err != nil {
+		// Log just a warning
+		log.Printf("failed to read file: %v", err)
+		return nil
+	}
+	ownerAliases, err := os.ReadFile("OWNERS_ALIASES")
+	if err != nil {
+		// Log just a warning
+		log.Printf("failed to read file: %v", err)
+		return nil
+	}
+	if err := os.WriteFile(filepath.Join(dir, "OWNERS"), owners, os.ModePerm); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "OWNERS_ALIASES"), ownerAliases, os.ModePerm); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This is to fix errors like this:

```
ERROR: This check enforces that component configuration files are accompanied by OWNERS
ERROR: files so that the appropriate team is able to self-service further configuration
ERROR: change pull requests.
ERROR: Please copy and paste the OWNERS files from the component repositories.
ERROR: If the target repository does not contain an OWNERS file, it will need to be created manually.
ERROR: See https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md for details.
ERROR: The following component config directories do not have OWNERS files:
ci-operator/config/openshift-knative/backstage-plugins
ci-operator/jobs/openshift-knative/backstage-plugins
```

on https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50459/pull-ci-openshift-release-master-owners/1775156737733562368 