### PR TITLE
Update serving CI config

### DIFF
--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -15,11 +15,6 @@ config:
       - version: "4.15"
       - onDemand: true
         version: "4.12"
-    release-v1.13:
-      openShiftVersions:
-      - version: "4.15"
-      - onDemand: true
-        version: "4.12"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -16,11 +16,6 @@ config:
       - version: "4.15"
       - onDemand: true
         version: "4.12"
-    release-v1.13:
-      openShiftVersions:
-      - version: "4.15"
-      - onDemand: true
-        version: "4.12"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -26,11 +26,8 @@ config:
       - version: "4.15"
       - onDemand: true
         version: "4.12"
-    release-v1.13:
-      openShiftVersions:
-      - version: "4.15"
-      - onDemand: true
-        version: "4.12"
+      skipE2EMatches:
+        - .*e2e-tls
 repositories:
 - dockerfiles:
     matches:


### PR DESCRIPTION
# Changes
- Do not run tls tests for 1.12, as they will not work
- Drop CI for 1.13 (which are unused branches)
