### PR TITLE
Run on OCP 1.16 for Knative components 1.12 and following

### DIFF
--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -2,7 +2,7 @@ config:
   branches:
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -4,7 +4,7 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.10:
@@ -20,17 +20,17 @@ config:
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.15:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -4,7 +4,7 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.10:
@@ -19,17 +19,17 @@ config:
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.15:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -4,7 +4,7 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - version: "4.12"
     release-v1.10:
       openShiftVersions:
@@ -19,16 +19,16 @@ config:
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - version: "4.12"
     release-v1.15:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - version: "4.12"
 repositories:
 - dockerfiles: {}

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -3,7 +3,7 @@ config:
     main:
       openShiftVersions:
       - generateCustomConfigs: true
-        version: "4.15"
+        version: "4.16"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -9,17 +9,17 @@ config:
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.15:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -9,17 +9,17 @@ config:
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.15:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
 repositories:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -4,7 +4,7 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
       skipDockerFilesMatches:
@@ -21,19 +21,19 @@ config:
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
       skipE2EMatches:
       - .*e2e-tls$
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
     release-v1.15:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
       - onDemand: true
         version: "4.12"
 repositories:


### PR DESCRIPTION
According to our [SO release matrix](https://docs.google.com/spreadsheets/d/1HTxR37_MM03_JQImW-KmAFk1oEQ83fXzfGxdfWQSX6o/edit#gid=0), SO 1.33 components must be compatible with OCP 4.12 - 4.16.

/cc @pierDipi @ReToCode @aliok