### PR TITLE
Support patch version promotion update in prowcopy

### DIFF
--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -63,9 +63,11 @@ func Main() error {
 		return err
 	}
 
-	outConfig := filepath.Join(openShiftRelease.Org, openShiftRelease.Repo, "ci-operator", "config")
-	if err := prowgen.DeleteExistingReleaseBuildConfigurationForBranch(&outConfig, prowgen.Repository{Org: c.Org, Repo: c.Repo}, c.Branch); err != nil {
-		return err
+	if c.FromBranch != c.Branch {
+		outConfig := filepath.Join(openShiftRelease.Org, openShiftRelease.Repo, "ci-operator", "config")
+		if err := prowgen.DeleteExistingReleaseBuildConfigurationForBranch(&outConfig, prowgen.Repository{Org: c.Org, Repo: c.Repo}, c.Branch); err != nil {
+			return err
+		}
 	}
 
 	files, err := discoverJobConfigs(openShiftRelease, c)
@@ -94,8 +96,10 @@ func Main() error {
 		log.Fatalln("Failed to mirror repositories", err)
 	}
 
-	if err := runProwCopyInjectors(&c, prowgenConfig, openShiftRelease); err != nil {
-		log.Fatalln("Failed to run Prow job injectors", err)
+	if c.FromBranch != c.Branch {
+		if err := runProwCopyInjectors(&c, prowgenConfig, openShiftRelease); err != nil {
+			log.Fatalln("Failed to run Prow job injectors", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When from branch and target branch are equal
- Skip Deleting configuration 
- Skip running injectors

Tested with:
```
go run ./cmd/prowcopy --from-branch "release-1.33" --branch "release-1.33" --tag "1.33.1" --config config/serverless-operator.yaml --config-branch main
```

and I get the expected diff:
```diff
pierdipi@pierdipi release (master) $ git diff
diff --git a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.33__412.yaml b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.33__412.yaml
index cf733c871e2..705869b971d 100755
--- a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.33__412.yaml
+++ b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.33__412.yaml
@@ -102,7 +102,7 @@ promotion:
   to:
   - additional_images:
       serverless-operator-src: src
-    name: release-1.33
+    name: 1.33.1
     namespace: knative
 releases:
   latest:
diff --git a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.33__415.yaml b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.33__415.yaml
index c65373b759e..73099f8190c 100755
--- a/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.33__415.yaml
+++ b/ci-operator/config/openshift-knative/serverless-operator/openshift-knative-serverless-operator-release-1.33__415.yaml
@@ -103,7 +103,7 @@ promotion:
   - additional_images:
       serverless-operator-src: src
     namespace: knative
-    tag: release-1.33
+    tag: 1.33.1
 releases:
   latest:
     release:
```