### PR TITLE
Skip 1.12 in SO branch name calculation

### DIFF
--- a/cmd/sobranch/sobranch.go
+++ b/cmd/sobranch/sobranch.go
@@ -3,9 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/openshift-knative/hack/pkg/sobranch"
 	"strings"
-
-	"github.com/coreos/go-semver/semver"
 )
 
 func main() {
@@ -21,10 +20,7 @@ func main() {
 		*upstreamVersion = *upstreamVersion + ".0"
 	}
 
-	upstream := semver.New(*upstreamVersion)
-	for i := 0; i < 21; i++ { // Example 1.11 -> 1.32
-		upstream.BumpMinor()
-	}
+	soBranch := sobranch.FromUpstreamVersion(*upstreamVersion)
 
-	fmt.Printf("release-%d.%d", upstream.Major, upstream.Minor)
+	fmt.Printf(soBranch)
 }

--- a/pkg/sobranch/version.go
+++ b/pkg/sobranch/version.go
@@ -1,0 +1,23 @@
+package sobranch
+
+import (
+	"fmt"
+	"github.com/coreos/go-semver/semver"
+)
+
+func FromUpstreamVersion(upstream string) string {
+	soVersion := semver.New(upstream)
+	for i := 0; i < 21; i++ { // Example 1.11 -> 1.32
+		soVersion.BumpMinor()
+	}
+
+	upstreamVersion := semver.New(upstream)
+	if upstreamVersion.Compare(*semver.New("1.13.0")) >= 0 {
+		// As 1.12 was actually 1.13
+		// 1.12 -> 1.33
+		// 1.14 -> 1.34
+		soVersion.Minor -= 1
+	}
+
+	return fmt.Sprintf("release-%d.%d", soVersion.Major, soVersion.Minor)
+}

--- a/pkg/sobranch/version_test.go
+++ b/pkg/sobranch/version_test.go
@@ -1,0 +1,41 @@
+package sobranch
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFromUpstreamVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		upstream string
+		want     string
+	}{
+		{
+			upstream: "1.11.0",
+			want:     "release-1.32",
+		}, {
+			upstream: "1.12.0",
+			want:     "release-1.33",
+		}, {
+			upstream: "1.12.1",
+			want:     "release-1.33",
+		}, {
+			upstream: "1.13.0",
+			want:     "release-1.33",
+		}, {
+			upstream: "1.13.1",
+			want:     "release-1.33",
+		}, {
+			upstream: "1.14.0",
+			want:     "release-1.34",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q -> %q", tt.upstream, tt.want), func(t *testing.T) {
+			if got := FromUpstreamVersion(tt.upstream); got != tt.want {
+				t.Errorf("FromUpstreamVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As we kind of skipped the upstream 1.12 branch name (1.12 was actually upstream 1.13), we should reflect this in the SO branch name generation.

So we have:
* 1.12 (& 1.13) -> 1.33
* 1.14 -> 1.34