### PR TITLE
Ignore manually added lp-rosa-classic jobs

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -326,6 +326,7 @@ repositories:
     - .*main.yaml$
     - .*lp-interop.*
     - .*lp-interop.*
+    - .*lp-rosa-classic.*
   imageNameOverrides:
     serverless-operator: bundle
   imagePrefix: serverless


### PR DESCRIPTION
The jobs were added manually by INTEROP team and they're currently being removed in the openshift/release [pull request](https://github.com/openshift/release/pull/51840)