### PR TITLE
Add omitempty to Konflux config struct

### DIFF
--- a/pkg/action/update_action.go
+++ b/pkg/action/update_action.go
@@ -46,7 +46,7 @@ func UpdateAction(cfg Config) error {
 
 		for _, r := range inConfig.Repositories {
 			for branchName, b := range inConfig.Config.Branches {
-				if b.Konflux.Enabled {
+				if b.Konflux != nil && b.Konflux.Enabled {
 
 					// Special case "release-next"
 					targetBranch := branchName

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -71,13 +71,13 @@ type Branch struct {
 	OpenShiftVersions      []OpenShift `json:"openShiftVersions,omitempty" yaml:"openShiftVersions,omitempty"`
 	SkipE2EMatches         []string    `json:"skipE2EMatches,omitempty" yaml:"skipE2EMatches,omitempty"`
 	SkipDockerFilesMatches []string    `json:"skipDockerFilesMatches,omitempty" yaml:"skipDockerFilesMatches,omitempty"`
-	Konflux                Konflux     `json:"konflux,omitempty" yaml:"konflux,omitempty"`
+	Konflux                *Konflux    `json:"konflux,omitempty" yaml:"konflux,omitempty"`
 }
 
 type Konflux struct {
-	Enabled bool
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	Nudges []string
+	Nudges []string `json:"nudges,omitempty" yaml:"nudges,omitempty"`
 }
 
 type OpenShift struct {

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -16,7 +16,7 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, config *C
 
 	for _, r := range config.Repositories {
 		for branchName, b := range config.Config.Branches {
-			if b.Konflux.Enabled {
+			if b.Konflux != nil && b.Konflux.Enabled {
 
 				if err := GitMirror(ctx, r); err != nil {
 					return err


### PR DESCRIPTION
Fix for discover automation to avoid having empty or disabled Konflux configurations