### PR TITLE
Prowgen: support passing directory to make the generation faster

### DIFF
--- a/.github/workflows/release-generate-ci-template.yaml
+++ b/.github/workflows/release-generate-ci-template.yaml
@@ -65,7 +65,7 @@ jobs:
         run: make generate-ci-no-clean ARGS=--branch=master
 
       - name: Create Pull Request
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||  github.event_name == 'schedule') && github.ref_name == 'main' }}
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -54,7 +54,7 @@ jobs:
         # Use master, see https://github.com/peter-evans/create-pull-request/issues/2108
         run: make generate-ci-no-clean ARGS=--branch=master
       - name: Create Pull Request
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||  github.event_name == 'schedule') && github.ref_name == 'main' }}
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -67,7 +67,7 @@ jobs:
           delete-branch: true
           body: |
             Sync Serverless CI using openshift-knative/hack.
-      - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}
+      - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[eventing - release-next] Create Konflux PR'
         uses: peter-evans/create-pull-request@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@
 # replacing reference images via env variable.
 include pkg/project/testdata/env
 
-generate-ci: clean generate-eventing-ci generate-serving-ci
+generate-ci: clean generate-ci-no-clean
 .PHONY: generate-ci
 
-generate-ci-no-clean: generate-eventing-ci generate-serving-ci generate-serverless-operator-ci
+generate-ci-no-clean:
+	go run github.com/openshift-knative/hack/cmd/prowgen --config config/
 .PHONY: generate-ci-no-clean
 
 generate-eventing-ci:

--- a/pkg/action/update_action.go
+++ b/pkg/action/update_action.go
@@ -58,7 +58,7 @@ func UpdateAction(cfg Config) error {
 
 					steps = append(steps, map[string]interface{}{
 						"name": fmt.Sprintf("[%s - %s] Create Konflux PR", r.Repo, branchName),
-						"if":   "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}",
+						"if":   "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}",
 						"uses": "peter-evans/create-pull-request@v5",
 						"with": map[string]interface{}{
 							"token":          "${{ secrets.SERVERLESS_QE_ROBOT }}",

--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -59,7 +59,7 @@ func Main() error {
 		Org:  "openshift",
 		Repo: "release",
 	}
-	if err := prowgen.InitializeOpenShiftReleaseRepository(ctx, openShiftRelease, &prowgen.Config{}, pointer.String("")); err != nil {
+	if err := prowgen.InitializeOpenShiftReleaseRepository(ctx, openShiftRelease, nil, pointer.String("")); err != nil {
 		return err
 	}
 

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -12,54 +12,56 @@ const (
 	KonfluxBranchPrefix = "sync-konflux/"
 )
 
-func GenerateKonflux(ctx context.Context, openshiftRelease Repository, config *Config) error {
+func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs []*Config) error {
 
-	for _, r := range config.Repositories {
-		for branchName, b := range config.Config.Branches {
-			if b.Konflux != nil && b.Konflux.Enabled {
+	for _, config := range configs {
+		for _, r := range config.Repositories {
+			for branchName, b := range config.Config.Branches {
+				if b.Konflux != nil && b.Konflux.Enabled {
 
-				if err := GitMirror(ctx, r); err != nil {
-					return err
-				}
+					if err := GitMirror(ctx, r); err != nil {
+						return err
+					}
 
-				if err := GitCheckout(ctx, r, branchName); err != nil {
-					return err
-				}
+					if err := GitCheckout(ctx, r, branchName); err != nil {
+						return err
+					}
 
-				// Special case "release-next"
-				targetBranch := branchName
-				upstreamVersion := "release-next"
-				if branchName == "release-next" {
-					targetBranch = "main"
-				} else {
-					upstreamVersion = sobranch.FromUpstreamVersion(branchName)
-				}
+					// Special case "release-next"
+					targetBranch := branchName
+					upstreamVersion := "release-next"
+					if branchName == "release-next" {
+						targetBranch = "main"
+					} else {
+						upstreamVersion = sobranch.FromUpstreamVersion(branchName)
+					}
 
-				cfg := konfluxgen.Config{
-					OpenShiftReleasePath: openshiftRelease.RepositoryDirectory(),
-					ApplicationName:      fmt.Sprintf("serverless-operator %s", upstreamVersion),
-					Includes: []string{
-						fmt.Sprintf("ci-operator/config/%s/.*%s.*.yaml", r.RepositoryDirectory(), branchName),
-					},
-					Excludes: nil,
-					ExcludesImages: []string{
-						".*source.*",
-						".*test.*",
-					},
-					ResourcesOutputPath: fmt.Sprintf("%s/.konflux", r.RepositoryDirectory()),
-					PipelinesOutputPath: fmt.Sprintf("%s/.tekton", r.RepositoryDirectory()),
-					Nudges:              b.Konflux.Nudges,
-				}
+					cfg := konfluxgen.Config{
+						OpenShiftReleasePath: openshiftRelease.RepositoryDirectory(),
+						ApplicationName:      fmt.Sprintf("serverless-operator %s", upstreamVersion),
+						Includes: []string{
+							fmt.Sprintf("ci-operator/config/%s/.*%s.*.yaml", r.RepositoryDirectory(), branchName),
+						},
+						Excludes: nil,
+						ExcludesImages: []string{
+							".*source.*",
+							".*test.*",
+						},
+						ResourcesOutputPath: fmt.Sprintf("%s/.konflux", r.RepositoryDirectory()),
+						PipelinesOutputPath: fmt.Sprintf("%s/.tekton", r.RepositoryDirectory()),
+						Nudges:              b.Konflux.Nudges,
+					}
 
-				if err := konfluxgen.Generate(cfg); err != nil {
-					return fmt.Errorf("failed to generate Konflux configurations for %s (%s): %w", r.RepositoryDirectory(), branchName, err)
-				}
+					if err := konfluxgen.Generate(cfg); err != nil {
+						return fmt.Errorf("failed to generate Konflux configurations for %s (%s): %w", r.RepositoryDirectory(), branchName, err)
+					}
 
-				pushBranch := fmt.Sprintf("%s%s", KonfluxBranchPrefix, branchName)
-				commitMsg := fmt.Sprintf("[%s] Sync Konflux configurations", targetBranch)
+					pushBranch := fmt.Sprintf("%s%s", KonfluxBranchPrefix, branchName)
+					commitMsg := fmt.Sprintf("[%s] Sync Konflux configurations", targetBranch)
 
-				if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
-					return err
+					if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
"Generate CI" step takes between 20 to 30 minutes to run. (https://github.com/openshift-knative/hack/actions/runs/9567605982/job/26375754744)

This should speed up the `make generate-ci` command as we won't run `make ci-operator-config jobs` multiple times (twice per file vs just twice)

Edit: now it takes only 5 minutes :tada:  https://github.com/openshift-knative/hack/actions/runs/9569059982/job/26380732319?pr=167

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>