### PR TITLE
Add annotations to configure components to use a custom build pipeline.

### DIFF
--- a/pkg/konfluxgen/dockerfile-component.template.yaml
+++ b/pkg/konfluxgen/dockerfile-component.template.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     image.redhat.com/generate: "true"
     appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build","bundle":"latest"}'
+    build.appstudio.openshift.io/request: configure-pac
   name: {{ truncate ( sanitize .ProjectDirectoryImageBuildStepConfiguration.To ) }}
 spec:
   componentName: {{ .ProjectDirectoryImageBuildStepConfiguration.To }}


### PR DESCRIPTION
Before openshift-knative/serverless-operator/pull/2702 we had the issue, that Konflux did not run any build pipeline for a component, when the component CR got applied directly in a new workspace. This was addressed for the PoC in openshift-knative/serverless-operator/pull/2702 and the `build.appstudio.openshift.io/request: configure-pac` annotation added on components, to tell Konflux to use the custom build pipeline when components are configured via code. 

This PR adds this annotations for the template too.

View [Configuration as Code](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuration-as-code/proc_configuration_as_code/#creating-your-base-component) (or [proc_configuration_as_code.adoc](https://github.com/redhat-appstudio/docs.appstudio.io/blob/ec0e3f3f7b9e79ae4d95fc232b348e90e3309f19/docs/modules/ROOT/pages/how-to-guides/configuration-as-code/proc_configuration_as_code.adoc?plain=1#L81)) for details.

It also adds the `build.appstudio.openshift.io/pipeline` annotation to fix an issue in the UI, when the components are created via the CLI (see https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1717785914904439)