### PR TITLE
Include branch name in Konflux components `metadata.name`

### DIFF
--- a/pkg/konfluxgen/dockerfile-component.template.yaml
+++ b/pkg/konfluxgen/dockerfile-component.template.yaml
@@ -6,7 +6,7 @@ metadata:
     appstudio.openshift.io/pac-provision: request
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build","bundle":"latest"}'
     build.appstudio.openshift.io/request: configure-pac
-  name: {{ truncate ( sanitize .ProjectDirectoryImageBuildStepConfiguration.To ) }}
+  name: {{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}
 spec:
   componentName: {{ .ProjectDirectoryImageBuildStepConfiguration.To }}
   application: {{ sanitize .ApplicationName }}


### PR DESCRIPTION
Including the components branch name into its metadata.name to be able to have the same component from different branches in different applications linked