### PR TITLE
Fix application name annotation in PipelineRun template

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -13,7 +13,7 @@ metadata:
       == "{{{ .ReleaseBuildConfiguration.Metadata.Branch }}}"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: {{{ truncate ( sanitize .ApplicationName ) }}}-{{{ .ReleaseBuildConfiguration.Metadata.Branch }}}
+    appstudio.openshift.io/application: {{{ truncate ( sanitize .ApplicationName ) }}}
     appstudio.openshift.io/component: {{{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}}
     pipelines.appstudio.openshift.io/type: build
   name: {{{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}}-on-{{{ .Event }}}


### PR DESCRIPTION
`.ApplicationName` has already the branch name