### PR TITLE
Add branch name to pipelinerun filename to align with component name

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -50,6 +50,10 @@ func Generate(cfg Config) error {
 		return fmt.Errorf("failed to remove %q directory: %w", cfg.ResourcesOutputPath, err)
 	}
 
+	if err := os.RemoveAll(cfg.PipelinesOutputPath); err != nil {
+		return fmt.Errorf("failed to remove %q directory: %w", cfg.PipelinesOutputPath, err)
+	}
+
 	includes, err := toRegexp(cfg.Includes)
 	if err != nil {
 		return fmt.Errorf("failed to create regular expressions for %+v: %w", cfg.Includes, err)

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -160,8 +160,8 @@ func Generate(cfg Config) error {
 
 			buf.Reset()
 
-			pipelineRunPRPath := filepath.Join(cfg.PipelinesOutputPath, fmt.Sprintf("%s-pull-request.yaml", config.ProjectDirectoryImageBuildStepConfiguration.To))
-			pipelineRunPushPath := filepath.Join(cfg.PipelinesOutputPath, fmt.Sprintf("%s-push.yaml", config.ProjectDirectoryImageBuildStepConfiguration.To))
+			pipelineRunPRPath := filepath.Join(cfg.PipelinesOutputPath, fmt.Sprintf("%s-%s-pull-request.yaml", config.ProjectDirectoryImageBuildStepConfiguration.To, sanitize(config.ReleaseBuildConfiguration.Metadata.Branch)))
+			pipelineRunPushPath := filepath.Join(cfg.PipelinesOutputPath, fmt.Sprintf("%s-%s-push.yaml", config.ProjectDirectoryImageBuildStepConfiguration.To, sanitize(config.ReleaseBuildConfiguration.Metadata.Branch)))
 
 			config.Event = PullRequestEvent
 			if err := pipelineRunTemplate.Execute(buf, config); err != nil {

--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -16,7 +16,7 @@ metadata:
     appstudio.openshift.io/application: {{{ truncate ( sanitize .ApplicationName ) }}}
     appstudio.openshift.io/component: {{{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}}
     pipelines.appstudio.openshift.io/type: build
-  name: {{{ truncate ( sanitize .ProjectDirectoryImageBuildStepConfiguration.To ) }}}-on-{{{ replace .Event "_" "-" }}}
+  name: {{{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}}-on-{{{ replace .Event "_" "-" }}}
   namespace: ocp-serverless-tenant
 spec:
   params:


### PR DESCRIPTION
Seems konflux wants the full component name included in the pipelinerun filename and also on the pipelinerun `.metadata.name`. E.g. https://github.com/openshift-knative/eventing/pull/681/files