### PR TITLE
Use single availability zone and spot instances

### DIFF
--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -88,7 +88,8 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 				env = map[string]string{
 					"BASE_DOMAIN": devclusterBaseDomain,
 					// Use single zone to save costs. See https://red.ht/3Y8g7Ar
-					"ZONES_COUNT": "1",
+					"ZONES_COUNT":    "1",
+					"SPOT_INSTANCES": "true",
 				}
 				workflow = pointer.String("ipi-aws")
 			}

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -87,6 +87,8 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 				clusterProfile = serverlessClusterProfile
 				env = map[string]string{
 					"BASE_DOMAIN": devclusterBaseDomain,
+					// Use single zone to save costs. See https://red.ht/3Y8g7Ar
+					"ZONES_COUNT": "1",
 				}
 				workflow = pointer.String("ipi-aws")
 			}

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -255,7 +255,9 @@ func TestDiscoverTestsServing(t *testing.T) {
 			optionalOnSuccess = false
 		}
 		expectedTests[i].MultiStageTestConfiguration.Environment = cioperatorapi.TestEnvironment{
-			"BASE_DOMAIN": devclusterBaseDomain,
+			"BASE_DOMAIN":    devclusterBaseDomain,
+			"SPOT_INSTANCES": "true",
+			"ZONES_COUNT":    "1",
 		}
 		expectedTests[i].MultiStageTestConfiguration.AllowBestEffortPostSteps = pointer.Bool(true)
 		expectedTests[i].MultiStageTestConfiguration.AllowSkipOnSuccess = pointer.Bool(true)
@@ -640,7 +642,9 @@ func TestDiscoverTestsEventing(t *testing.T) {
 			optionalOnSuccess = false
 		}
 		expectedTests[i].MultiStageTestConfiguration.Environment = cioperatorapi.TestEnvironment{
-			"BASE_DOMAIN": devclusterBaseDomain,
+			"BASE_DOMAIN":    devclusterBaseDomain,
+			"SPOT_INSTANCES": "true",
+			"ZONES_COUNT":    "1",
 		}
 		expectedTests[i].MultiStageTestConfiguration.AllowBestEffortPostSteps = pointer.Bool(true)
 		expectedTests[i].MultiStageTestConfiguration.AllowSkipOnSuccess = pointer.Bool(true)


### PR DESCRIPTION
Partially fixes https://issues.redhat.com/browse/SRVCOM-2911

Proposed Changes

*    Following the tutorial for setting up spot instances and single availability zone from https://docs.google.com/document/d/1qEQEggDJhJY9IzymwmbmekZZpbLtT2fK34L986QphRk/edit

Spot instances:
>   They cost 70-90% less than On-Demand VMs. (NB: Spot instances do not receive discounts from Savings Plans)
>     AWS may reclaim the capacity at any time (though in practice 95% of instances last at least 2 hours, and 90% last longer than 8 hours). AWS gives a 2-minute warning before an interruption happens, so that the instance may cleanly terminate/hibernate.

