### PR TITLE
Fix mesh-e2e match

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -304,7 +304,7 @@ repositories:
   - ignoreError: true
     match: ^upstream-e2e-kafka$
   - ignoreError: true
-    match: ^mesh-e2e$
+    match: ^mesh-e2e:.*$
     onDemand: true
     timeout: 4h0m0s
   - ignoreError: true


### PR DESCRIPTION
Make the mesh-e2e test match again. The makefile target now is:

`mesh-e2e: install-for-mesh-e2e`