### PR TITLE
Use regex to find makefile targets

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -304,7 +304,7 @@ repositories:
   - ignoreError: true
     match: ^upstream-e2e-kafka$
   - ignoreError: true
-    match: ^mesh-e2e:.*$
+    match: ^mesh-e2e$
     onDemand: true
     timeout: 4h0m0s
   - ignoreError: true


### PR DESCRIPTION
# Changes
- Use regex to find makefile targets
- Local generation results in https://github.com/openshift/release/compare/master...ReToCode:release:sync-serverless-ci which now has the missing tests

PTAL:
/assign @mgencur 
/assign @pierDipi 