### PR TITLE
Add shared setup-go action

### DIFF
--- a/actions/setup-go/action.yaml
+++ b/actions/setup-go/action.yaml
@@ -1,0 +1,18 @@
+name: 'Setup Go'
+description: |
+  Shared Golang setup to maitain same version across actions
+
+inputs:
+  go-version:
+    description: |
+      Override default Go version
+
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: setup go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version || '1.22' }}


### PR DESCRIPTION
Per same principal as action in `knative/actions`. This PR adds a sharable setup-go definition.

/cc @pierDipi @ReToCode @skonto @mgencur 
