### PR TITLE
Use openshift-4.17 as based builder image for Go 1.22

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -81,7 +81,7 @@ func main() {
 	pflag.StringVar(&dockerfilesTestDir, "dockerfile-test-dir", "ci-operator/knative-test-images", "Dockerfiles output directory for test images relative to output flag")
 	pflag.StringVar(&output, "output", filepath.Join(wd, "openshift"), "Output directory")
 	pflag.StringVar(&projectFilePath, "project-file", filepath.Join(wd, "openshift", "project.yaml"), "Project metadata file path")
-	pflag.StringVar(&dockerfileImageBuilderFmt, "dockerfile-image-builder-fmt", "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.16", "Dockerfile image builder format")
+	pflag.StringVar(&dockerfileImageBuilderFmt, "dockerfile-image-builder-fmt", "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17", "Dockerfile image builder format")
 	pflag.StringVar(&registryImageFmt, "registry-image-fmt", "registry.ci.openshift.org/openshift/%s:%s", "Container registry image format")
 	pflag.StringArrayVar(&imagesFromRepositories, "images-from", nil, "Additional image references to be pulled from other midstream repositories matching the tag in project.yaml")
 	pflag.StringVar(&imagesFromRepositoriesURLFmt, "images-from-url-format", "https://raw.githubusercontent.com/openshift-knative/%s/%s/openshift/images.yaml", "Additional images to be pulled from other midstream repositories matching the tag in project.yaml")

--- a/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
@@ -1,7 +1,7 @@
 # DO NOT EDIT! Generated Dockerfile.
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
 RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/discover.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
 COPY . .
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/generate/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/generate/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/generate.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
 COPY . .
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/prowcopy/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/prowcopy/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/prowcopy.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
 COPY . .
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/prowgen/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/prowgen/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/prowgen.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
 COPY . .
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/sobranch/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/sobranch/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/sobranch.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
 COPY . .
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-test-images/testselect/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-test-images/testselect/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/testselect.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
 COPY . .
 


### PR DESCRIPTION
Fix for https://github.com/openshift-knative/eventing-istio/pull/266