### PR TITLE
Create ImageRepository CRs

### DIFF
--- a/pkg/konfluxgen/imagerepository.template.yaml
+++ b/pkg/konfluxgen/imagerepository.template.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     appstudio.redhat.com/application: {{ sanitize .ApplicationName }}
     appstudio.redhat.com/component: {{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}
-  name: imagerepository-for-{{ sanitize .ApplicationName }}-{{ .ProjectDirectoryImageBuildStepConfiguration.To }}
+  name: {{ sanitize .ApplicationName }}-{{ .ProjectDirectoryImageBuildStepConfiguration.To }}
 spec:
   image:
     name: {{ sanitize .ApplicationName }}/{{ .ProjectDirectoryImageBuildStepConfiguration.To }}

--- a/pkg/konfluxgen/imagerepository.template.yaml
+++ b/pkg/konfluxgen/imagerepository.template.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ImageRepository
+metadata:
+  annotations:
+    image-controller.appstudio.redhat.com/update-component-image: "true"
+  labels:
+    appstudio.redhat.com/application: {{ sanitize .ApplicationName }}
+    appstudio.redhat.com/component: {{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}
+  name: imagerepository-for-{{ sanitize .ApplicationName }}-{{ .ProjectDirectoryImageBuildStepConfiguration.To }}
+spec:
+  image:
+    name: {{ sanitize .ApplicationName }}/{{ .ProjectDirectoryImageBuildStepConfiguration.To }}
+    visibility: public


### PR DESCRIPTION
Update konflux-gen to add the ImageRepository CRs too, as we use "custom" repostory paths. 

See discussion in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1719859165070619?thread_ts=1716460799.553839&cid=C04PZ7H0VA8 and current pipeline failures in the clone-repository task:

```
STEP-CLONE

INFO: Using mounted CA bundle: /mnt/trusted-ca/ca-bundle.crt
{"level":"info","ts":1722867555.762302,"caller":"git/git.go:176","msg":"Successfully cloned https://github.com/openshift-knative/eventing @ 07aaaec233da0150d04851f3d411b3b040d96059 (grafted, HEAD) in path /var/workdir/source"}
{"level":"info","ts":1722867555.8133812,"caller":"git/git.go:215","msg":"Successfully initialized and updated submodules in path /var/workdir/source"}
STEP-SYMLINK-CHECK

Running symlink check
STEP-CREATE-TRUSTED-ARTIFACT

Prepared artifact from /var/workdir/source (sha256:0fee2c8f6ddf2c4bc3bf41b15cdb5ad8d076d17a445f0a845c4f45bcdf0ac880)
Token not found for quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-release-next/knative-eventing-controller
Error response from registry: recognizable error message not found: HEAD "https://quay.io/v2/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-release-next/knative-eventing-controller/manifests/sha256:67d11feea2815a6dace9ba2e6a2d2368c7d4d5bf9fe3b6cbd7f2bb197bd6e33e": response status code 401: Unauthorized
Command exited with non-zero status 1
```
as konflux only creates the `ocp-serverless-tenant/serverless-operator-release-next/knative-eventing-controller-release-next` quay repo by default (<application>/<component>) and not `ocp-serverless-tenant/serverless-operator-release-next/knative-eventing-controller` (without `release-next` suffix on component name).

With having the ImageRepo CR created, the clone-repository task [succeeds](https://console.redhat.com/application-pipeline/workspaces/ocp-serverless/applications/serverless-operator-release-next/pipelineruns/knative-eventing-controller-release-next-on-pull-request-8829v)