### PR TITLE
Enable konflux on all release-next branches

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -142,10 +142,32 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
+        name: '[eventing-istio - release-next] Create Konflux PR'
+        run: |
+          set -x
+          git remote add fork "https://github.com/serverless-qe/eventing-istio.git" || true # ignore: already exists errors
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing-istio.git" sync-konflux/release-next:sync-konflux/release-next -f
+          gh pr create --base main --head serverless-qe:sync-konflux/release-next --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
+      - env:
+          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
+        name: '[eventing-kafka-broker - release-next] Create Konflux PR'
+        run: |
+          set -x
+          git remote add fork "https://github.com/serverless-qe/eventing-kafka-broker.git" || true # ignore: already exists errors
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing-kafka-broker.git" sync-konflux/release-next:sync-konflux/release-next -f
+          gh pr create --base main --head serverless-qe:sync-konflux/release-next --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
+      - env:
+          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[eventing - release-next] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/eventing.git"
+          git remote add fork "https://github.com/serverless-qe/eventing.git" || true # ignore: already exists errors
           git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing.git" sync-konflux/release-next:sync-konflux/release-next -f
           gh pr create --base main --head serverless-qe:sync-konflux/release-next --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
@@ -153,10 +175,10 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[eventing - release-v1.15] Create Konflux PR'
+        name: '[serving - release-next] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/eventing.git"
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
-          gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
+          git remote add fork "https://github.com/serverless-qe/serving.git" || true # ignore: already exists errors
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/serving.git" sync-konflux/release-next:sync-konflux/release-next -f
+          gh pr create --base main --head serverless-qe:sync-konflux/release-next --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -1,6 +1,8 @@
 config:
   branches:
     release-next:
+      konflux:
+        enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -1,6 +1,8 @@
 config:
   branches:
     release-next:
+      konflux:
+        enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -27,8 +27,6 @@ config:
       - version: "4.15"
       - version: "4.12"
     release-v1.15:
-      konflux:
-        enabled: true
       openShiftVersions:
       - version: "4.15"
       - version: "4.12"

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -1,6 +1,8 @@
 config:
   branches:
     release-next:
+      konflux:
+        enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true

--- a/pkg/action/update_action.go
+++ b/pkg/action/update_action.go
@@ -84,7 +84,7 @@ func UpdateAction(cfg Config) error {
 						},
 						"working-directory": fmt.Sprintf("./src/github.com/openshift-knative/hack/%s", r.RepositoryDirectory()),
 						"run": fmt.Sprintf(`set -x
-git remote add fork "https://github.com/serverless-qe/%s.git"
+git remote add fork "https://github.com/serverless-qe/%s.git" || true # ignore: already exists errors
 git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/%s.git" %s:%s -f
 gh pr create --base %s --head %s --title "[%s] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
 `,


### PR DESCRIPTION
It works on eventing core, so enabling more repositories https://github.com/openshift-knative/eventing/pull/623

Also fixed error in https://github.com/openshift-knative/hack/actions/runs/10261906421