### PR TITLE
Automate Konflux apply configurations for every repo and branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,13 @@ generate-action:
 	go run github.com/openshift-knative/hack/cmd/update-konflux-gen-action
 .PHONY: generate-action
 
+konflux-apply: clean konflux-apply-no-clean
+.PHONY: konflux-apply
+
+konflux-apply-no-clean:
+	go run github.com/openshift-knative/hack/cmd/konflux-apply
+.PHONY: konflux-apply-no-clean
+
 unit-tests:
 	go test ./pkg/...
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ CI tooling and hacks to improve CI
 - Create a PR to [https://github.com/openshift/release](https://github.com/openshift/release) (to be
   automated)
 
-To generate openshift/release config for a single repository, run the specific task in the `Makefile` or run individual commands in the `Makefile`, such as:
+To generate openshift/release config for a single repository, run the specific task in
+the `Makefile` or run individual commands in the `Makefile`, such as:
 
 ```shell
 go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing-hyperfoil-benchmark.yaml --remote <your_remote>
@@ -21,22 +22,38 @@ go run github.com/openshift-knative/hack/cmd/prowgen --config config/eventing-hy
 ```
 
 This generation works this way:
+
 - `openshift/relase` is cloned
 - The target repository is cloned
-- The makefile of the target repository is parsed to find the make targets that match the regex in the `config/<file.yaml>` files
+- The makefile of the target repository is parsed to find the make targets that match the regex in
+  the `config/<file.yaml>` files
 - For any matches, 2 `test`s are generated.
-  - One for the presubmit (that runs on PRs on the target repository)
-  - One for the periodics (that runs regularly)
+    - One for the presubmit (that runs on PRs on the target repository)
+    - One for the periodics (that runs regularly)
 - There are also CI job config generated, which use the tests above.
-- If the matching regex is specified in `onDemand` field, then the presubmit is marked as optional (`always_run: false`).
+- If the matching regex is specified in `onDemand` field, then the presubmit is marked as
+  optional (`always_run: false`).
 - Individual OpenShift versions can specify `generateCustomConfigs: true`.
-  The repository configuration should then list custom configurations under `customConfigs`. The `releaseBuildConfiguration` key should include at least `tests` key
+  The repository configuration should then list custom configurations under `customConfigs`.
+  The `releaseBuildConfiguration` key should include at least `tests` key
   with the list of tests to be run. For custom configurations, tests are not generated from Makefile
-  targets but rather taken directly from the configuration. The resulting build configuration is then
+  targets but rather taken directly from the configuration. The resulting build configuration is
+  then
   enriched with images, base images, and dependencies for test steps.
 
 Limitations:
+
 - It is not currently possible to disable periodics per job
+
+## Apply Konflux configurations
+
+1. Follow the instructions to access the Konflux instance
+   at [GitLab (VPN required)](https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/getting-access.md#accessing-konflux-via-cli)
+2. Set the `kubectl` context to use the `ocp-serverless` workspace
+    ```shell
+    kubectl config set-context konflux-ocp-serverless
+    ```
+3. Run `make konflux-apply`
 
 ## Run unit tests
 
@@ -46,11 +63,12 @@ make unit-tests
 
 ## Updating OpenShift versions
 
-CI configs use specific OpenShift versions. To change the version, you need to update the YAML files in the `config/` directory.
+CI configs use specific OpenShift versions. To change the version, you need to update the YAML files
+in the `config/` directory.
 
-When a new OpenShift version is released, wait until the cluster pool for OpenShift CI is available in 
+When a new OpenShift version is released, wait until the cluster pool for OpenShift CI is available
+in
 [https://docs.ci.openshift.org/docs/how-tos/cluster-claim/#existing-cluster-pools](https://docs.ci.openshift.org/docs/how-tos/cluster-claim/#existing-cluster-pools).
-
 
 ## Getting SO branch associated with upstream branch
 
@@ -75,9 +93,11 @@ error: gpg failed to sign the data
 fatal: failed to write commit object
 ```
 
-You need to configure GPG signing in your git config. See [https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key).
+You need to configure GPG signing in your git config.
+See [https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key).
 
 If you see this error, you need to update your Git to version 2.34 or later.
+
 ```
 error: unsupported value for gpg.format: ssh
 fatal: bad config variable 'gpg.format' in file '/Users/<you>/.gitconfig'

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Limitations:
    at [GitLab (VPN required)](https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/getting-access.md#accessing-konflux-via-cli)
 2. Set the `kubectl` context to use the `ocp-serverless` workspace
     ```shell
-    kubectl config set-context konflux-ocp-serverless
+    kubectl config use-context konflux-ocp-serverless
     ```
 3. Run `make konflux-apply`
 

--- a/cmd/konflux-apply/main.go
+++ b/cmd/konflux-apply/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+
+	"github.com/openshift-knative/hack/pkg/konfluxapply"
+)
+
+func main() {
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+
+	inputConfig := flag.String("config", filepath.Join("config"), "Specify repositories config")
+	konfluxDir := flag.String("konflux-dir", ".konflux", "Konflux directory containing applications, components, etc")
+	flag.Parse()
+
+	err := konfluxapply.Apply(ctx, konfluxapply.ApplyConfig{
+		InputConfigPath: *inputConfig,
+		KonfluxDir:      *konfluxDir,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/konfluxapply/konflux_apply.go
+++ b/pkg/konfluxapply/konflux_apply.go
@@ -1,0 +1,72 @@
+package konfluxapply
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift-knative/hack/pkg/prowgen"
+)
+
+type ApplyConfig struct {
+	InputConfigPath string
+
+	KonfluxDir string // default: `.konflux`
+}
+
+func Apply(ctx context.Context, cfg ApplyConfig) error {
+	err := filepath.Walk(cfg.InputConfigPath, func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		inConfig, err := prowgen.LoadConfig(path)
+		if err != nil {
+			return err
+		}
+
+		if err := apply(ctx, cfg, inConfig); err != nil {
+			return fmt.Errorf("failed to apply config: %v", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to walk filesystem path %q: %w", cfg.InputConfigPath, err)
+	}
+
+	return nil
+}
+
+func apply(ctx context.Context, cfg ApplyConfig, config *prowgen.Config) error {
+	for _, r := range config.Repositories {
+		if err := prowgen.GitMirror(ctx, r); err != nil {
+			return fmt.Errorf("failed to mirror repository %q: %w", r.RepositoryDirectory(), err)
+		}
+
+		for bn, b := range config.Config.Branches {
+			if b.Konflux == nil || !b.Konflux.Enabled {
+				continue
+			}
+
+			if err := prowgen.GitCheckout(ctx, r, bn); err != nil {
+				return fmt.Errorf("[%s] failed to checkout branch %q: %w", r.RepositoryDirectory(), bn, err)
+			}
+
+			if _, err := os.Stat(filepath.Join(r.RepositoryDirectory(), cfg.KonfluxDir)); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue // Skip repositories without Konflux components directory
+				}
+				return fmt.Errorf("[%s] failed to stat Konflux directory %q for branch %q: %w", r.RepositoryDirectory(), cfg.KonfluxDir, bn, err)
+			}
+
+			if _, err := prowgen.Run(ctx, r, "oc", "apply", "-Rf", cfg.KonfluxDir); err != nil {
+				return fmt.Errorf("[%s] failed to apply branch %q: %w", r.RepositoryDirectory(), bn, err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/konflux-apply/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/konflux-apply/Dockerfile
@@ -1,0 +1,20 @@
+# DO NOT EDIT! Generated Dockerfile for cmd/konflux-apply.
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
+
+COPY . .
+
+RUN mkdir -p /var/run/ko && \
+    mkdir -p cmd/konflux-apply/kodata && \
+    go build -o /usr/bin/main ./cmd/konflux-apply && \
+    cp -r cmd/konflux-apply/kodata /var/run/ko
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+# install the missing zoneinfo to ubi-minimal
+RUN microdnf install tzdata
+
+USER 65532
+
+COPY --from=builder /usr/bin/main /usr/bin/main
+COPY --from=builder /var/run/ko /var/run/ko
+ENTRYPOINT ["/usr/bin/main"]

--- a/pkg/project/testoutput/openshift/images.yaml
+++ b/pkg/project/testoutput/openshift/images.yaml
@@ -1,5 +1,6 @@
 github.com/openshift-knative/hack/cmd/discover: registry.ci.openshift.org/openshift/knative-discover:main
 github.com/openshift-knative/hack/cmd/generate: hello
+github.com/openshift-knative/hack/cmd/konflux-apply: registry.ci.openshift.org/openshift/knative-konflux-apply:main
 github.com/openshift-knative/hack/cmd/prowcopy: registry.ci.openshift.org/openshift/knative-prowcopy:main
 github.com/openshift-knative/hack/cmd/prowgen: registry.ci.openshift.org/openshift/knative-prowgen:main
 github.com/openshift-knative/hack/cmd/sobranch: registry.ci.openshift.org/openshift/knative-sobranch:main

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -192,13 +192,13 @@ func LoadConfig(path string) (*Config, error) {
 func PushBranch(ctx context.Context, release Repository, remote *string, branch string, commitMsg string) error {
 
 	// Ignore error since remote and branch might be already there
-	_, _ = run(ctx, release, "git", "checkout", "-b", branch)
-	_, _ = run(ctx, release, "git", "checkout", branch)
+	_, _ = Run(ctx, release, "git", "checkout", "-b", branch)
+	_, _ = Run(ctx, release, "git", "checkout", branch)
 
-	if _, err := run(ctx, release, "git", "add", "."); err != nil {
+	if _, err := Run(ctx, release, "git", "add", "."); err != nil {
 		return err
 	}
-	if _, err := run(ctx, release, "git", "commit", "-m", commitMsg); err != nil {
+	if _, err := Run(ctx, release, "git", "commit", "-m", commitMsg); err != nil {
 		// Ignore error since we could have nothing to commit
 		log.Println("Ignored error", err)
 	}
@@ -209,8 +209,8 @@ func PushBranch(ctx context.Context, release Repository, remote *string, branch 
 
 	log.Println("Pushing branch", branch, "to", *remote)
 
-	_, _ = run(ctx, release, "git", "remote", "add", "fork", *remote)
-	if _, err := run(ctx, release, "git", "push", "fork", branch, "-f"); err != nil {
+	_, _ = Run(ctx, release, "git", "remote", "add", "fork", *remote)
+	if _, err := Run(ctx, release, "git", "push", "fork", branch, "-f"); err != nil {
 		return err
 	}
 
@@ -295,7 +295,7 @@ func copyOwnersFileIfNotPresent(dir string) error {
 }
 
 func RunOpenShiftReleaseGenerator(ctx context.Context, openShiftRelease Repository) error {
-	if _, err := run(ctx, openShiftRelease, "make", "-f", "Makefile.legacy", "ci-operator-config", "jobs"); err != nil {
+	if _, err := Run(ctx, openShiftRelease, "make", "-f", "Makefile.legacy", "ci-operator-config", "jobs"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/prowgen/prowgen_cmd.go
+++ b/pkg/prowgen/prowgen_cmd.go
@@ -30,7 +30,7 @@ func runNoRepo(ctx context.Context, name string, args ...string) ([]byte, error)
 	return buf.Bytes(), nil
 }
 
-func run(ctx context.Context, r Repository, name string, args ...string) ([]byte, error) {
+func Run(ctx context.Context, r Repository, name string, args ...string) ([]byte, error) {
 	var buf bytes.Buffer
 
 	select {

--- a/pkg/prowgen/prowgen_git.go
+++ b/pkg/prowgen/prowgen_git.go
@@ -14,7 +14,7 @@ import (
 )
 
 func GitCheckout(ctx context.Context, r Repository, branch string) error {
-	_, err := run(ctx, r, "git", "checkout", branch)
+	_, err := Run(ctx, r, "git", "checkout", branch)
 	return err
 }
 
@@ -32,7 +32,7 @@ func Branches(ctx context.Context, r Repository) ([]string, error) {
 	}
 
 	// git --no-pager branch --list "release-v*"
-	branchesBytes, err := run(ctx, r, "git", "--no-pager", "branch", "--list", "release-*")
+	branchesBytes, err := Run(ctx, r, "git", "--no-pager", "branch", "--list", "release-*")
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func gitClone(ctx context.Context, r Repository, mirror bool) error {
 		if _, err := runNoRepo(ctx, "git", "clone", "--mirror", remoteRepo, filepath.Join(r.RepositoryDirectory(), ".git")); err != nil {
 			return fmt.Errorf("[%s] failed to clone repository: %w", r.RepositoryDirectory(), err)
 		}
-		if _, err := run(ctx, r, "git", "config", "--bool", "core.bare", "false"); err != nil {
+		if _, err := Run(ctx, r, "git", "config", "--bool", "core.bare", "false"); err != nil {
 			return fmt.Errorf("[%s] failed to set config for repository: %w", r.RepositoryDirectory(), err)
 		}
 	} else {
@@ -125,18 +125,18 @@ func gitClone(ctx context.Context, r Repository, mirror bool) error {
 }
 
 func GitMerge(ctx context.Context, r Repository, sha string) error {
-	_, err := run(ctx, r, "git", "merge", sha, "--no-ff", "-m", "Merge "+sha)
+	_, err := Run(ctx, r, "git", "merge", sha, "--no-ff", "-m", "Merge "+sha)
 	return err
 }
 
 func GitFetch(ctx context.Context, r Repository, sha string) error {
 	remoteRepo := fmt.Sprintf("https://github.com/%s/%s.git", r.Org, r.Repo)
-	_, err := run(ctx, r, "git", "fetch", remoteRepo, sha)
+	_, err := Run(ctx, r, "git", "fetch", remoteRepo, sha)
 	return err
 }
 
 func GitDiffNameOnly(ctx context.Context, r Repository, sha string) ([]string, error) {
-	out, err := run(ctx, r, "git", "diff", "--name-only", sha)
+	out, err := Run(ctx, r, "git", "diff", "--name-only", sha)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow with a single command to apply every application, component, and image repository for every repo and branch

See `Apply Konflux configurations` in `README.md` for details on how it can be used

Tested with:

```shell
$ make konflux-apply
rm -rf openshift openshift-knative
go run github.com/openshift-knative/hack/cmd/konflux-apply
2024/08/06 16:02:00 Mirroring repository openshift-knative/backstage-plugins
Cloning into bare repository 'openshift-knative/backstage-plugins/.git'...
remote: Enumerating objects: 7665, done.
remote: Counting objects: 100% (1009/1009), done.
remote: Compressing objects: 100% (400/400), done.
remote: Total 7665 (delta 752), reused 609 (delta 609), pack-reused 6656
Receiving objects: 100% (7665/7665), 9.51 MiB | 7.96 MiB/s, done.
Resolving deltas: 100% (3136/3136), done.
2024/08/06 16:02:03 Mirroring repository openshift-knative/eventing-hyperfoil-benchmark
Cloning into bare repository 'openshift-knative/eventing-hyperfoil-benchmark/.git'...
remote: Enumerating objects: 16704, done.
remote: Counting objects: 100% (775/775), done.
remote: Compressing objects: 100% (116/116), done.
remote: Total 16704 (delta 679), reused 735 (delta 653), pack-reused 15929
Receiving objects: 100% (16704/16704), 3.37 MiB | 1.30 MiB/s, done.
Resolving deltas: 100% (15878/15878), done.
2024/08/06 16:02:06 Mirroring repository openshift-knative/eventing-istio
Cloning into bare repository 'openshift-knative/eventing-istio/.git'...
remote: Enumerating objects: 18496, done.
remote: Counting objects: 100% (3405/3405), done.
remote: Compressing objects: 100% (1486/1486), done.
remote: Total 18496 (delta 1841), reused 3076 (delta 1699), pack-reused 15091
Receiving objects: 100% (18496/18496), 18.90 MiB | 10.75 MiB/s, done.
Resolving deltas: 100% (9336/9336), done.
Switched to branch 'release-next'
2024/08/06 16:02:10 Mirroring repository openshift-knative/eventing-kafka-broker
Cloning into bare repository 'openshift-knative/eventing-kafka-broker/.git'...
remote: Enumerating objects: 87485, done.
remote: Counting objects: 100% (4936/4936), done.
remote: Compressing objects: 100% (2385/2385), done.
remote: Total 87485 (delta 2262), reused 4349 (delta 1940), pack-reused 82549
Receiving objects: 100% (87485/87485), 49.17 MiB | 14.38 MiB/s, done.
Resolving deltas: 100% (49224/49224), done.
Switched to branch 'release-next'
2024/08/06 16:02:17 Mirroring repository openshift-knative/eventing
Cloning into bare repository 'openshift-knative/eventing/.git'...
remote: Enumerating objects: 129400, done.
remote: Counting objects: 100% (503/503), done.
remote: Compressing objects: 100% (403/403), done.
remote: Total 129400 (delta 256), reused 288 (delta 85), pack-reused 128897
Receiving objects: 100% (129400/129400), 82.57 MiB | 12.64 MiB/s, done.
Resolving deltas: 100% (84584/84584), done.
Switched to branch 'release-next'
imagerepository.appstudio.redhat.com/knative-eventing-apiserver-receive-adapter-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-appender-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-channel-controller-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-channel-dispatcher-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-controller-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-event-display-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-filter-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-heartbeats-receiver-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-heartbeats-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-ingress-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-jobsink-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-migrate-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-mtchannel-broker-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-mtping-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-pong-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-schema-release-next configured
imagerepository.appstudio.redhat.com/knative-eventing-webhook-release-next configured
component.appstudio.redhat.com/knative-eventing-apiserver-receive-adapter-release-next configured
component.appstudio.redhat.com/knative-eventing-appender-release-next configured
component.appstudio.redhat.com/knative-eventing-channel-controller-release-next configured
component.appstudio.redhat.com/knative-eventing-channel-dispatcher-release-next configured
component.appstudio.redhat.com/knative-eventing-controller-release-next configured
component.appstudio.redhat.com/knative-eventing-event-display-release-next configured
component.appstudio.redhat.com/knative-eventing-filter-release-next configured
component.appstudio.redhat.com/knative-eventing-heartbeats-receiver-release-next configured
component.appstudio.redhat.com/knative-eventing-heartbeats-release-next configured
component.appstudio.redhat.com/knative-eventing-ingress-release-next configured
component.appstudio.redhat.com/knative-eventing-jobsink-release-next configured
component.appstudio.redhat.com/knative-eventing-migrate-release-next configured
component.appstudio.redhat.com/knative-eventing-mtchannel-broker-release-next configured
component.appstudio.redhat.com/knative-eventing-mtping-release-next configured
component.appstudio.redhat.com/knative-eventing-pong-release-next configured
component.appstudio.redhat.com/knative-eventing-schema-release-next configured
component.appstudio.redhat.com/knative-eventing-webhook-release-next configured
application.appstudio.redhat.com/serverless-operator-release-next unchanged
2024/08/06 16:02:49 Mirroring repository openshift-knative/serverless-operator
Cloning into bare repository 'openshift-knative/serverless-operator/.git'...
remote: Enumerating objects: 122334, done.
remote: Counting objects: 100% (4249/4249), done.
remote: Compressing objects: 100% (1929/1929), done.
remote: Total 122334 (delta 2144), reused 3936 (delta 1998), pack-reused 118085
Receiving objects: 100% (122334/122334), 82.21 MiB | 14.09 MiB/s, done.
Resolving deltas: 100% (71329/71329), done.
2024/08/06 16:02:58 Mirroring repository openshift-knative/net-istio
Cloning into bare repository 'openshift-knative/net-istio/.git'...
remote: Enumerating objects: 44164, done.
remote: Counting objects: 100% (4791/4791), done.
remote: Compressing objects: 100% (1546/1546), done.
remote: Total 44164 (delta 3267), reused 4349 (delta 3041), pack-reused 39373
Receiving objects: 100% (44164/44164), 37.08 MiB | 12.46 MiB/s, done.
Resolving deltas: 100% (27974/27974), done.
2024/08/06 16:03:04 Mirroring repository openshift-knative/net-kourier
Cloning into bare repository 'openshift-knative/net-kourier/.git'...
remote: Enumerating objects: 51722, done.
remote: Counting objects: 100% (1335/1335), done.
remote: Compressing objects: 100% (650/650), done.
remote: Total 51722 (delta 667), reused 1242 (delta 585), pack-reused 50387
Receiving objects: 100% (51722/51722), 47.96 MiB | 12.42 MiB/s, done.
Resolving deltas: 100% (30080/30080), done.
2024/08/06 16:03:10 Mirroring repository openshift-knative/serving
Cloning into bare repository 'openshift-knative/serving/.git'...
remote: Enumerating objects: 169193, done.
remote: Counting objects: 100% (13564/13564), done.
remote: Compressing objects: 100% (790/790), done.
remote: Total 169193 (delta 13084), reused 12792 (delta 12772), pack-reused 155629
Receiving objects: 100% (169193/169193), 95.84 MiB | 14.86 MiB/s, done.
Resolving deltas: 100% (114261/114261), done.
Switched to branch 'release-next'
```