### PR TITLE
Add Debug info to run command repository workflow

### DIFF
--- a/.github/workflows/run-command-repository.yaml
+++ b/.github/workflows/run-command-repository.yaml
@@ -65,3 +65,10 @@ jobs:
           delete-branch: true
           body: |
             Run `make ${{ inputs.command }}` using openshift-knative/hack.
+
+      - name: Debug
+        if: always()
+        working-directory: "./src/github.com/${{ inputs.repository }}"
+        run: |
+          tree
+          git --no-pager diff


### PR DESCRIPTION
Sometimes codegen is generated correctly in the correct directories, trying to debug 

https://github.com/openshift-knative/hack/actions/runs/10179052057/job/28153966988

```
  Error: knative.dev/eventing/pkg/client/clientset/versioned: pkg/client/injection/client/client.go:25:2: cannot find module providing package knative.dev/eventing/pkg/client/clientset/versioned: import lookup disabled by -mod=vendor
  	(Go version in go.mod is at least 1.14 and vendor directory exists.)
```