### PR TITLE
Widen the regular expression for ignored configs

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -326,7 +326,7 @@ repositories:
     - .*main.yaml$
     - .*lp-interop.*
     - .*lp-interop.*
-    - .*lp-rosa-classic.*
+    - .*rosa-classic.*
   imageNameOverrides:
     serverless-operator: bundle
   imagePrefix: serverless


### PR DESCRIPTION
We have a number of configs including "rosa", currently: 
```
openshift-knative-serverless-operator-main__ocp4.14-lp-rosa-classic.yaml
openshift-knative-serverless-operator-main__ocp4.15-lp-rosa-classic.yaml
openshift-knative-serverless-operator-main__serverless-p2p-rosa-classic.yaml
openshift-knative-serverless-operator-release-1.33__ocp4.14-lp-rosa-classic.yaml
openshift-knative-serverless-operator-release-1.33__ocp4.15-lp-rosa-classic.yaml
```

The serverless-p2p-rosa-classic is new.