### PR TITLE
ignore go.mod go micro version

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -160,6 +160,11 @@ func main() {
 		goMod := getGoMod(rootDir)
 		goVersion := goMod.Go.Version
 
+		// The builder images are distinguished by golang major.minor, so we ignore the rest of the goVersion
+		if strings.Count(goVersion, ".") > 1 {
+			goVersion = strings.Join(strings.Split(goVersion, ".")[0:2], ".")
+		}
+
 		builderImage := fmt.Sprintf(dockerfileImageBuilderFmt, goVersion)
 
 		goPackageToImageMapping := map[string]string{}


### PR DESCRIPTION
We use patterns such as registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17

As eventing declare go mod go version as "1.22.0", this doesn't work anymore, we actually want just "1.22", not "1.22.0" for the builder image go version