### PR TITLE
Fix hack repo create PR step

### DIFF
--- a/.github/workflows/release-generate-ci-template.yaml
+++ b/.github/workflows/release-generate-ci-template.yaml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
         with:
-          branch: 'master'
+          ref: 'master'
           repository: 'openshift/release'
           path: ./src/github.com/openshift-knative/hack/openshift/release
 
@@ -63,7 +63,7 @@ jobs:
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         uses: actions/checkout@v4
         with:
-          branch: 'master'
+          ref: 'master'
           repository: 'openshift/release'
           path: ./src/github.com/openshift-knative/hack/openshift/release
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -98,6 +98,6 @@ jobs:
           set -x
           git remote add fork "https://github.com/serverless-qe/hack.git"
           git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" sync-konflux/main:sync-konflux/main -f
-          gh pr create --base main --head serverless-qe:sync-konflux/main --fill-verbose || true
+          gh pr create --base main --head serverless-qe:sync-konflux/main --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         # Use the repository cloned by the prowgen tool
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/hack

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -109,14 +109,14 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
         with:
-          branch: 'master'
+          ref: 'master'
           repository: 'openshift/release'
           path: ./src/github.com/openshift-knative/hack/openshift/release
       - name: Checkout openshift/release
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         uses: actions/checkout@v4
         with:
-          branch: 'master'
+          ref: 'master'
           repository: 'openshift/release'
           path: ./src/github.com/openshift-knative/hack/openshift/release
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -147,7 +147,7 @@ jobs:
           set -x
           git remote add fork "https://github.com/serverless-qe/hack.git"
           git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" sync-konflux/main:sync-konflux/main -f
-          gh pr create --base main --head serverless-qe:sync-konflux/main --fill-verbose || true
+          gh pr create --base main --head serverless-qe:sync-konflux/main --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         # Use the repository cloned by the prowgen tool
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/hack
       - env:


### PR DESCRIPTION
Fix error

```
+ gh pr create --base main --head serverless-qe:sync-konflux/main --fill-verbose
could not compute title or body defaults: failed to run git: fatal: ambiguous argument 'origin/main...sync-konflux/main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
https://github.com/openshift-knative/hack/actions/runs/10613401043/job/29417114694