### PR TITLE
Exclude 'rosa' configurations from konfluxgen for SO

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -3,6 +3,8 @@ config:
     main:
       konflux:
         enabled: true
+        excludes:
+          - ".*rosa.*"
         fbcImages:
         - .*serverless-index.*
       openShiftVersions:


### PR DESCRIPTION
As discussed here https://redhat-internal.slack.com/archives/CD87JDUB0/p1724832142056839?thread_ts=1724766012.729079&cid=CD87JDUB0, this causes duplicated components for the same dockerfile