### PR TITLE
increase hypershift node count to 6

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -162,7 +162,7 @@ repositories:
           env:
             BASE_DOMAIN: cspilp.interop.ccitredhat.com
             HYPERSHIFT_BASE_DOMAIN: cspilp.interop.ccitredhat.com
-            HYPERSHIFT_NODE_COUNT: "5"
+            HYPERSHIFT_NODE_COUNT: "6"
           test:
           - as: operator-e2e
             commands: make USER_MANAGEMENT_ALLOWED=false test-e2e-with-kafka


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-415-hypershift-e2e-hypershift-continuous/1829983318683160576

as hypershift job is also running EKB tests that normally use 6 workers ( https://github.com/openshift-knative/serverless-operator/blob/main/Makefile#L178  )