### PR TITLE
Generate build-args from image overrides and version

### DIFF
--- a/pkg/konfluxgen/docker-build.yaml
+++ b/pkg/konfluxgen/docker-build.yaml
@@ -93,7 +93,14 @@ spec:
     description: Build a source image.
     name: build-source-image
     type: string
-  - default: ["VERSION={{{ .VersionLabel }}}"]
+  {{{- $buildArgsN := len .BuildArgs }}} {{{ if ne $buildArgsN 0 }}}
+  - default:
+    {{{- range $arg := .BuildArgs }}}
+    - "{{{- $arg }}}"
+    {{{- end }}}
+  {{{- else }}}
+  - default: []
+  {{{- end }}}
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -39,7 +39,7 @@ var PipelineFBCBuildTemplate embed.FS
 type Config struct {
 	OpenShiftReleasePath string
 	ApplicationName      string
-	VersionLabel         string
+	BuildArgs            []string
 	ComponentNameFunc    func(cfg cioperatorapi.ReleaseBuildConfiguration, ib cioperatorapi.ProjectDirectoryImageBuildStepConfiguration) string
 
 	Includes       []string

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -11,13 +11,19 @@ import (
 // Every project should have a file, usually called
 // project.yaml that contains such metadata.
 type Metadata struct {
-	Project Project `json:"project" yaml:"project"`
+	Project        Project `json:"project" yaml:"project"`
+	ImageOverrides []Image `json:"imageOverrides" yaml:"imageOverrides"`
 }
 
 type Project struct {
 	Tag         string `json:"tag" yaml:"tag"`
 	ImagePrefix string `json:"imagePrefix" yaml:"imagePrefix"`
 	Version     string `json:"version" yaml:"version"`
+}
+
+type Image struct {
+	Name     string `json:"name" yaml:"name"`
+	PullSpec string `json:"pullSpec" yaml:"pullSpec"`
 }
 
 func ReadMetadataFile(path string) (*Metadata, error) {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/SRVCOM-3255

When serverless-operator includes imageOverrides in this format:
```
project:
  version: 1.34.1
imageOverrides:
  - name: GO_BUILDER
    pullSpec: "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
  - name: GO_RUNTIME
    pullSpec: "registry.access.redhat.com/ubi8/ubi-minimal"
```
The following build-args will be generated for Buildah in .tekton/docker-build.yaml when generating Konflux configurations:
```
- default:
    - "GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
    - "GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal"
    - "VERSION=1.34.1"
  description: Array of --build-arg values ("arg=value" strings) for buildah
  name: build-args
  type: array
```
If Tekton pipelines are being generated for midstream branch that doesn't have a corresponding serverless-operator branch, the "guessed" branch will be used for the `VERSION` (e.g. at this point for `release-v1.15` of Eventing, the `VERSION` will be `release-1.35`

The imageOverrides can later specify production-ready base images that will replace the "CI" images when building with Konflux.