### PR TITLE
Skip tracing on SNO

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -252,7 +252,7 @@ repositories:
           cluster_profile: gcp
           test:
           - as: operator-e2e
-            commands: make HA=false test-e2e-with-kafka
+            commands: make HA=false test-e2e-with-kafka-no-tracing
             from: serverless-source-image
             resources:
               limits:


### PR DESCRIPTION
Skip tracing install on Single-node OpenShift, as we're memory constrained.