### PR TITLE
Fix ImageRepository name and component for SO

### DIFF
--- a/pkg/konfluxgen/imagerepository.template.yaml
+++ b/pkg/konfluxgen/imagerepository.template.yaml
@@ -5,8 +5,8 @@ metadata:
     image-controller.appstudio.redhat.com/update-component-image: "true"
   labels:
     appstudio.redhat.com/application: {{ sanitize .ApplicationName }}
-    appstudio.redhat.com/component: {{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}
-  name: {{ truncate ( sanitize ( print .ProjectDirectoryImageBuildStepConfiguration.To "-" .ReleaseBuildConfiguration.Metadata.Branch ) ) }}
+    appstudio.redhat.com/component: {{ sanitize .ComponentName }}
+  name: {{ sanitize .ComponentName }}
 spec:
   image:
     name: {{ sanitize .ApplicationName }}/{{ .ProjectDirectoryImageBuildStepConfiguration.To }}


### PR DESCRIPTION
Noticed here https://github.com/openshift-knative/hack/pull/219

Tested that other components produce the same name as currently

