### PR TITLE
generate: Add possibility to install additional packages in image

### DIFF
--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -16,7 +16,13 @@ FROM $GO_RUNTIME
 ARG VERSION={{.version}}
 
 # Install zoneinfo.
-RUN microdnf install tzdata {{.additional_packages}}
+RUN microdnf install tzdata
+
+{{- if .additional_packages}}
+
+# Install additional packages
+RUN microdnf install {{.additional_packages}}
+{{- end}}
 
 USER 65532
 

--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -16,13 +16,7 @@ FROM $GO_RUNTIME
 ARG VERSION={{.version}}
 
 # Install zoneinfo.
-RUN microdnf install tzdata
-
-{{- if .additional_packages}}
-
-# Install additional packages
-RUN microdnf install {{.additional_packages}}
-{{- end}}
+RUN microdnf install tzdata {{.additional_packages}}
 
 USER 65532
 

--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -15,7 +15,6 @@ FROM $GO_RUNTIME
 
 ARG VERSION={{.version}}
 
-# Install zoneinfo.
 RUN microdnf install tzdata {{.additional_packages}}
 
 USER 65532

--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -16,7 +16,7 @@ FROM $GO_RUNTIME
 ARG VERSION={{.version}}
 
 # Install zoneinfo.
-RUN microdnf install tzdata
+RUN microdnf install tzdata {{.additional_packages}}
 
 USER 65532
 

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -60,6 +60,7 @@ func main() {
 		registryImageFmt             string
 		imagesFromRepositories       []string
 		imagesFromRepositoriesURLFmt string
+		additionalPackages           []string
 	)
 
 	defaultIncludes := []string{
@@ -85,6 +86,7 @@ func main() {
 	pflag.StringVar(&registryImageFmt, "registry-image-fmt", "registry.ci.openshift.org/openshift/%s:%s", "Container registry image format")
 	pflag.StringArrayVar(&imagesFromRepositories, "images-from", nil, "Additional image references to be pulled from other midstream repositories matching the tag in project.yaml")
 	pflag.StringVar(&imagesFromRepositoriesURLFmt, "images-from-url-format", "https://raw.githubusercontent.com/openshift-knative/%s/%s/openshift/images.yaml", "Additional images to be pulled from other midstream repositories matching the tag in project.yaml")
+	pflag.StringArrayVar(&additionalPackages, "additional-packages", nil, "Additional packages to be installed in the image")
 	pflag.Parse()
 
 	if rootDir == "" {
@@ -192,13 +194,14 @@ func main() {
 				projectDashCaseWithSep = projectName + "-"
 			}
 			d := map[string]interface{}{
-				"main":               p,
-				"builder":            builderImage,
-				"version":            metadata.Project.Tag,
-				"project":            projectWithSep,
-				"project_dashcase":   projectDashCaseWithSep,
-				"component":          capitalize(p),
-				"component_dashcase": dashcase(p),
+				"main":                p,
+				"builder":             builderImage,
+				"version":             metadata.Project.Tag,
+				"project":             projectWithSep,
+				"project_dashcase":    projectDashCaseWithSep,
+				"component":           capitalize(p),
+				"component_dashcase":  dashcase(p),
+				"additional_packages": strings.Join(additionalPackages, " "),
 			}
 
 			t, err := template.ParseFS(DockerfileTemplate, "*.template")

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -16,7 +16,7 @@ FROM $GO_RUNTIME
 ARG VERSION=main
 
 # Install zoneinfo.
-RUN microdnf install tzdata 
+RUN microdnf install tzdata
 
 USER 65532
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -16,7 +16,7 @@ FROM $GO_RUNTIME
 ARG VERSION=main
 
 # Install zoneinfo.
-RUN microdnf install tzdata
+RUN microdnf install tzdata 
 
 USER 65532
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -15,7 +15,6 @@ FROM $GO_RUNTIME
 
 ARG VERSION=main
 
-# Install zoneinfo.
 RUN microdnf install tzdata 
 
 USER 65532


### PR DESCRIPTION
Adds the `additional-packages` arg, which allows to specify additional packages which should be installed into the image.
This can be helpful for migrating the kn-plugin-func utils [Dockerfile](https://github.com/openshift-knative/kn-plugin-func/blob/serverless-1.33/Dockerfile.utils), which needs additional packages.