### PR TITLE
generate: Add possibility to add symlinks pointing to binary

### DIFF
--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -21,9 +21,9 @@ USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main
 
-{{- if .sym_links }}
+{{- if .post_build_instructions }}
 
-CMD {{ .sym_links }}
+{{ .post_build_instructions }}
 {{- end }}
 
 LABEL \

--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -21,6 +21,11 @@ USER 65532
 
 COPY --from=builder /usr/bin/main /usr/bin/main
 
+{{- if .sym_links }}
+
+CMD {{ .sym_links }}
+{{- end }}
+
 LABEL \
       com.redhat.component="openshift-serverless-1-{{.project_dashcase}}{{.component_dashcase}}-rhel8-container" \
       name="openshift-serverless-1/{{.project_dashcase}}{{.component_dashcase}}-rhel8" \

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -208,6 +208,7 @@ func main() {
 
 			if len(symLinkNames) > 0 {
 				sb := strings.Builder{}
+				sb.WriteString("RUN ")
 				for i, name := range symLinkNames {
 					sb.WriteString(fmt.Sprintf("ln -s /usr/bin/main %s", name))
 					if i < len(symLinkNames)-1 {
@@ -215,7 +216,7 @@ func main() {
 					}
 				}
 
-				d["sym_links"] = sb.String()
+				d["post_build_instructions"] = sb.String()
 			}
 
 			t, err := template.ParseFS(DockerfileTemplate, "*.template")


### PR DESCRIPTION
Adds the `sym-link-names` arg, which allows to specify symbolic link names which should point to the built binary in the image.
This can be helpful for migrating the kn-plugin-func utils [Dockerfile](https://github.com/knative/func/blob/a13056e4ee5b7e9d9571a97a9867292ac5c7f71b/Dockerfile.utils#L23-L25), which has symlinks.