### PR TITLE
Use kubectl and oc from ocp tools image

### DIFF
--- a/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
+++ b/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
@@ -1,6 +1,6 @@
 # DO NOT EDIT! Generated Dockerfile.
 
-FROM registry.ci.openshift.org/ocp/4.17:tools as tools
+FROM {{.ocpToolsImage}} as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
 FROM {{.builder}} as builder

--- a/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
+++ b/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
@@ -1,11 +1,15 @@
 # DO NOT EDIT! Generated Dockerfile.
 
-FROM {{.ocpToolsImage}} as tools
+FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
 FROM {{.builder}} as builder
 
-COPY --from=tools /usr/bin/oc /usr/bin/kubectl /usr/bin/
+ARG TARGETARCH
+
+COPY --from=tools /usr/share/openshift/linux_$TARGETARCH/oc.rhel8 /usr/bin/oc
+
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 RUN yum install -y httpd-tools
 

--- a/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
+++ b/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
@@ -1,16 +1,13 @@
 # DO NOT EDIT! Generated Dockerfile.
 
+FROM registry.ci.openshift.org/ocp/4.17:tools as tools
+
 # Dockerfile to bootstrap build and test in openshift-ci
 FROM {{.builder}} as builder
 
-RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "baseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "enabled=1" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "gpgcheck=1" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key" >> /etc/yum.repos.d/kubernetes.repo
+COPY --from=tools /usr/bin/oc /usr/bin/kubectl /usr/bin/
 
-RUN yum install -y kubectl httpd-tools
+RUN yum install -y httpd-tools
 
 RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 ./get-helm-3

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -31,6 +31,12 @@ const (
 	defaultAppFilename             = "main"
 	defaultDockerfileTemplateName  = "default"
 	funcUtilDockerfileTemplateName = "func-util"
+
+	ocpToolsImage = "registry.ci.openshift.org/ocp/4.17:tools"
+	// builderImageFmt defines the default pattern for the builder image.
+	// At the given places, the Go version from the projects go.mod will be inserted.
+	// Keep in mind to also update the ocpToolsImage, when the OCP version in the pattern gets updated.
+	builderImageFmt = "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"
 )
 
 //go:embed dockerfile-templates/DefaultDockerfile.template
@@ -90,7 +96,7 @@ func main() {
 	pflag.StringVar(&dockerfilesTestDir, "dockerfile-test-dir", "ci-operator/knative-test-images", "Dockerfiles output directory for test images relative to output flag")
 	pflag.StringVar(&output, "output", filepath.Join(wd, "openshift"), "Output directory")
 	pflag.StringVar(&projectFilePath, "project-file", filepath.Join(wd, "openshift", "project.yaml"), "Project metadata file path")
-	pflag.StringVar(&dockerfileImageBuilderFmt, "dockerfile-image-builder-fmt", "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17", "Dockerfile image builder format")
+	pflag.StringVar(&dockerfileImageBuilderFmt, "dockerfile-image-builder-fmt", builderImageFmt, "Dockerfile image builder format")
 	pflag.StringVar(&appFileFmt, "app-file-fmt", "/usr/bin/%s", "Target application binary path format")
 	pflag.StringVar(&registryImageFmt, "registry-image-fmt", "registry.ci.openshift.org/openshift/%s:%s", "Container registry image format")
 	pflag.StringArrayVar(&imagesFromRepositories, "images-from", nil, "Additional image references to be pulled from other midstream repositories matching the tag in project.yaml")
@@ -191,7 +197,8 @@ func main() {
 		}
 
 		d := map[string]interface{}{
-			"builder": builderImage,
+			"builder":       builderImage,
+			"ocpToolsImage": ocpToolsImage,
 		}
 		saveDockerfile(d, DockerfileBuildImageTemplate, output, dockerfilesBuildDir)
 		saveDockerfile(d, DockerfileSourceImageTemplate, output, dockerfilesSourceDir)

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -32,10 +32,10 @@ const (
 	defaultDockerfileTemplateName  = "default"
 	funcUtilDockerfileTemplateName = "func-util"
 
-	ocpToolsImage = "registry.ci.openshift.org/ocp/4.17:tools"
 	// builderImageFmt defines the default pattern for the builder image.
 	// At the given places, the Go version from the projects go.mod will be inserted.
-	// Keep in mind to also update the ocpToolsImage, when the OCP version in the pattern gets updated.
+	// Keep in mind to also update the tools image in the ImageBuilderDockerfile, when the OCP / RHEL
+	// version in the pattern gets updated (line 3 and 10).
 	builderImageFmt = "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"
 )
 
@@ -197,8 +197,7 @@ func main() {
 		}
 
 		d := map[string]interface{}{
-			"builder":       builderImage,
-			"ocpToolsImage": ocpToolsImage,
+			"builder": builderImage,
 		}
 		saveDockerfile(d, DockerfileBuildImageTemplate, output, dockerfilesBuildDir)
 		saveDockerfile(d, DockerfileSourceImageTemplate, output, dockerfilesSourceDir)

--- a/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
@@ -1,16 +1,13 @@
 # DO NOT EDIT! Generated Dockerfile.
 
+FROM registry.ci.openshift.org/ocp/4.17:tools as tools
+
 # Dockerfile to bootstrap build and test in openshift-ci
 FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
-RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "baseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "enabled=1" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "gpgcheck=1" >> /etc/yum.repos.d/kubernetes.repo && \
-    echo "gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key" >> /etc/yum.repos.d/kubernetes.repo
+COPY --from=tools /usr/bin/oc /usr/bin/kubectl /usr/bin/
 
-RUN yum install -y kubectl httpd-tools
+RUN yum install -y httpd-tools
 
 RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 ./get-helm-3

--- a/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
@@ -1,11 +1,15 @@
 # DO NOT EDIT! Generated Dockerfile.
 
-FROM registry.ci.openshift.org/ocp/4.17:tools as tools
+FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
 FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.17 as builder
 
-COPY --from=tools /usr/bin/oc /usr/bin/kubectl /usr/bin/
+ARG TARGETARCH
+
+COPY --from=tools /usr/share/openshift/linux_$TARGETARCH/oc.rhel8 /usr/bin/oc
+
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 RUN yum install -y httpd-tools
 


### PR DESCRIPTION
Saw this at [func](https://github.com/openshift-knative/kn-plugin-func/blob/f9f4ecd433329fed9cef7c3f298ef1df1faaf3c9/openshift/ci-operator/build-image/Dockerfile#L3) and liked the idea using it from the tools image (also provides oc - which oc seems to use in some tests)

@mgencur @pierDipi: opinions on using this?