### PR TITLE
Add possibility to specify GOFLAGS for go build

### DIFF
--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -9,7 +9,7 @@ COPY . .
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
 
-RUN go build -tags strictfipsruntime -o /usr/bin/main ./{{.main}}
+RUN {{ if .go_flags }}{{.go_flags}} {{ end }}go build -tags strictfipsruntime -o /usr/bin/main ./{{.main}}
 
 FROM $GO_RUNTIME
 

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -64,6 +64,7 @@ func main() {
 		imagesFromRepositoriesURLFmt string
 		additionalPackages           []string
 		symLinkNames                 []string
+		goFlags                      []string
 	)
 
 	defaultIncludes := []string{
@@ -92,6 +93,7 @@ func main() {
 	pflag.StringVar(&imagesFromRepositoriesURLFmt, "images-from-url-format", "https://raw.githubusercontent.com/openshift-knative/%s/%s/openshift/images.yaml", "Additional images to be pulled from other midstream repositories matching the tag in project.yaml")
 	pflag.StringArrayVar(&additionalPackages, "additional-packages", nil, "Additional packages to be installed in the image")
 	pflag.StringArrayVar(&symLinkNames, "sym-link-names", nil, "Symbolic link names to the binary")
+	pflag.StringArrayVar(&goFlags, "go-flags", nil, "Go flags for the build")
 	pflag.Parse()
 
 	if rootDir == "" {
@@ -222,6 +224,11 @@ func main() {
 				}
 
 				d["post_build_instructions"] = sb.String()
+			}
+
+			if len(goFlags) > 0 {
+				// allow empty values too (GOFLAGS='')
+				d["go_flags"] = fmt.Sprintf("GOFLAGS='%s'", strings.Join(goFlags, " "))
 			}
 
 			t, err := template.ParseFS(DockerfileTemplate, "*.template")


### PR DESCRIPTION
Allow to specify GOFLAGS via the `go-flags` parameters.