### PR TITLE
Fix: Move setting the user after post-build-instructions

### DIFF
--- a/cmd/generate/Dockerfile.template
+++ b/cmd/generate/Dockerfile.template
@@ -17,14 +17,14 @@ ARG VERSION={{.version}}
 
 RUN microdnf install tzdata {{.additional_packages}}
 
-USER 65532
-
 COPY --from=builder /usr/bin/main {{.app_file}}
 
 {{- if .post_build_instructions }}
 
 {{ .post_build_instructions }}
 {{- end }}
+
+USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-{{.project_dashcase}}{{.component_dashcase}}-rhel8-container" \

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -17,9 +17,9 @@ ARG VERSION=main
 
 RUN microdnf install tzdata 
 
-USER 65532
-
 COPY --from=builder /usr/bin/main /usr/bin/discover
+
+USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-knative-discover-rhel8-container" \


### PR DESCRIPTION
When we set the user too early, some post-build-instructions wont work correctly (for example symlinks - see https://redhat-internal.slack.com/archives/CKR568L8G/p1725551082332669?thread_ts=1725374750.726439&cid=CKR568L8G)