### PR TITLE
tzdata is part of ubi8-minimal

### DIFF
--- a/cmd/generate/dockerfile-templates/DefaultDockerfile.template
+++ b/cmd/generate/dockerfile-templates/DefaultDockerfile.template
@@ -15,8 +15,10 @@ FROM $GO_RUNTIME
 
 ARG VERSION={{.version}}
 
-RUN microdnf install tzdata {{.additional_packages}}
+{{ if .additional_packages }}
+RUN microdnf install {{ .additional_packages }}
 
+{{ end }}
 COPY --from=builder /usr/bin/main {{.app_file}}
 
 USER 65532

--- a/cmd/generate/dockerfile-templates/FuncUtilDockerfile.template
+++ b/cmd/generate/dockerfile-templates/FuncUtilDockerfile.template
@@ -16,7 +16,7 @@ FROM $GO_RUNTIME
 
 ARG VERSION={{.version}}
 
-RUN microdnf install tzdata socat tar {{.additional_packages}}
+RUN microdnf install socat tar {{.additional_packages}}
 
 COPY --from=builder /usr/bin/main {{.app_file}}
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -15,7 +15,6 @@ FROM $GO_RUNTIME
 
 ARG VERSION=main
 
-RUN microdnf install tzdata 
 
 COPY --from=builder /usr/bin/main /usr/bin/discover
 


### PR DESCRIPTION
We don't need to install it:
```
pierdipi@pierdipi openshift-knative-hack (main) $ docker run -ti --rm registry.access.redhat.com/ubi8/ubi-minimal /bin/bash
Unable to find image 'registry.access.redhat.com/ubi8/ubi-minimal:latest' locally
latest: Pulling from ubi8/ubi-minimal
Digest: sha256:a47c89f02b39a98290f88204ed3d162845db0a0c464b319c2596cfd1e94b444e
Status: Downloaded newer image for registry.access.redhat.com/ubi8/ubi-minimal:latest
[root@552ae7b1786c /]# rpm -qa tzdata
tzdata-2024a-1.el8.noarch
```

Also noticed the current command is no-op:
```
[2/2] STEP 2/7: RUN microdnf install tzdata

(microdnf:5003): librhsm-WARNING **: 06:22:34.990: Found 0 entitlement certificates

(microdnf:5003): librhsm-WARNING **: 06:22:34.994: Found 0 entitlement certificates
Downloading metadata...
Downloading metadata...
Downloading metadata...
Nothing to do.
```

This helps with Hermetic builds https://github.com/openshift-knative/eventing/pull/793/checks?check_run_id=29859057727

