### PR TITLE
Remove unneeded empty line in output default Dockerfile

### DIFF
--- a/cmd/generate/dockerfile-templates/DefaultDockerfile.template
+++ b/cmd/generate/dockerfile-templates/DefaultDockerfile.template
@@ -15,10 +15,11 @@ FROM $GO_RUNTIME
 
 ARG VERSION={{.version}}
 
-{{ if .additional_packages }}
-RUN microdnf install {{ .additional_packages }}
+{{- if .additional_packages }}
 
-{{ end }}
+RUN microdnf install {{ .additional_packages }}
+{{- end }}
+
 COPY --from=builder /usr/bin/main {{.app_file}}
 
 USER 65532

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -15,7 +15,6 @@ FROM $GO_RUNTIME
 
 ARG VERSION=main
 
-
 COPY --from=builder /usr/bin/main /usr/bin/discover
 
 USER 65532


### PR DESCRIPTION
Only cosmetic, to not have two empty lines in generated Dockerfile. For example like [here](https://github.com/openshift-knative/serverless-operator/blob/d7aa65bbe31a518b8658a24047bceca757f9d249/knative-operator/Dockerfile#L16-L19)