### PR TITLE
Use at least OCP 4.13 for Knative 1.14 components and later

### DIFF
--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -9,7 +9,7 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -6,7 +6,7 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
@@ -27,14 +27,14 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -6,7 +6,7 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
@@ -26,14 +26,14 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -5,7 +5,7 @@ config:
         enabled: true
       openShiftVersions:
       - version: "4.15"
-      - version: "4.12"
+      - version: "4.13"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
@@ -25,13 +25,13 @@ config:
     release-v1.14:
       openShiftVersions:
       - version: "4.15"
-      - version: "4.12"
+      - version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
       - version: "4.15"
-      - version: "4.12"
+      - version: "4.13"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -11,7 +11,7 @@ config:
       - generateCustomConfigs: true
         version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
 repositories:
 - customConfigs:
   - name: aws-ovn

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -16,14 +16,14 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -16,14 +16,14 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -6,7 +6,7 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
       skipDockerFilesMatches:
       - openshift/ci-operator/knative-perf-images.*
       skipE2EMatches:
@@ -30,14 +30,14 @@ config:
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true
-        version: "4.12"
+        version: "4.13"
 repositories:
 - dockerfiles:
     matches:


### PR DESCRIPTION
-  Similar to [this](https://github.com/openshift-knative/hack/pull/126)
