### PR TITLE
Fix Konflux component and Tekton filenames to not include org and repo name

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -187,7 +187,7 @@ func Generate(cfg Config) error {
 				Tags:                          append(cfg.Tags, "latest"),
 				BuildArgs:                     cfg.BuildArgs,
 			}
-			applications[appKey][dockerfileComponentKey(cfg.ComponentNameFunc, c.ReleaseBuildConfiguration, ib)] = r
+			applications[appKey][Truncate(Sanitize(cfg.ComponentNameFunc(c.ReleaseBuildConfiguration, ib)))] = r
 		}
 	}
 
@@ -403,10 +403,6 @@ func toRegexp(rawRegexps []string) ([]*regexp.Regexp, error) {
 		regexps = append(regexps, r)
 	}
 	return regexps, nil
-}
-
-func dockerfileComponentKey(componentNameFunc func(cfg cioperatorapi.ReleaseBuildConfiguration, ib cioperatorapi.ProjectDirectoryImageBuildStepConfiguration) string, cfg cioperatorapi.ReleaseBuildConfiguration, ib cioperatorapi.ProjectDirectoryImageBuildStepConfiguration) string {
-	return fmt.Sprintf("%s-%s-%s", cfg.Metadata.Org, cfg.Metadata.Repo, Truncate(Sanitize(componentNameFunc(cfg, ib))))
 }
 
 func Sanitize(input interface{}) string {


### PR DESCRIPTION
Currently we have super long filenames for the Konflux component files like `openshift-knative-eventing-kafka-broker-release-next-knative-eventing-kafka-broker-dispatcher.yaml` (see https://github.com/openshift-knative/eventing-kafka-broker/tree/44d049d60faf4bf5d1186ba5bbf6e8f5cf0ffd1c/.konflux/applications/serverless-operator-release-next/components).

This PR addresses it and uses only the component name as the file name.

This should also help with the issues from https://github.com/openshift-knative/eventing-kafka-broker/pull/1187, where Konflux does not recognize the existing pipeline files (`openshift-knative-eventing-kafka-broker-knative-eventing-kafka-broker-heartbeats-115-pull-request.yaml` already exists for heartbeats)