### PR TITLE
Remove chmod on `/etc/passwd` in BuildImageDockerfile

### DIFF
--- a/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
+++ b/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
@@ -22,6 +22,3 @@ RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 # go install creates $GOPATH/.cache with root permissions, we delete it here
 # to avoid permission issues with the runtime users
 RUN rm -rf $GOPATH/.cache
-
-# Allow runtime users to add entries to /etc/passwd
-RUN chmod g+rw /etc/passwd

--- a/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
@@ -22,6 +22,3 @@ RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 # go install creates $GOPATH/.cache with root permissions, we delete it here
 # to avoid permission issues with the runtime users
 RUN rm -rf $GOPATH/.cache
-
-# Allow runtime users to add entries to /etc/passwd
-RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Seems not to be needed anymore ([slack](https://redhat-internal.slack.com/archives/CD87JDUB0/p1726045452787339)) and prevents OCP to add the user to /etc/passwd which causes issues on kn-plugin-func tests