### PR TITLE
Disable konflux on release next branches

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -154,17 +154,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[eventing-istio - release-next] Create Konflux PR'
-        run: |
-          set -x
-          git remote add fork "https://github.com/serverless-qe/eventing-istio.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing-istio.git" sync-konflux/release-next:sync-konflux/release-next -f
-          gh pr create --base main --head serverless-qe:sync-konflux/release-next --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[eventing-istio - release-v1.15] Create Konflux PR'
         run: |
           set -x
@@ -176,17 +165,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[eventing-kafka-broker - release-next] Create Konflux PR'
-        run: |
-          set -x
-          git remote add fork "https://github.com/serverless-qe/eventing-kafka-broker.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing-kafka-broker.git" sync-konflux/release-next:sync-konflux/release-next -f
-          gh pr create --base main --head serverless-qe:sync-konflux/release-next --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[eventing-kafka-broker - release-v1.15] Create Konflux PR'
         run: |
           set -x
@@ -194,17 +172,6 @@ jobs:
           git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing-kafka-broker.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
           gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[eventing - release-next] Create Konflux PR'
-        run: |
-          set -x
-          git remote add fork "https://github.com/serverless-qe/eventing.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing.git" sync-konflux/release-next:sync-konflux/release-next -f
-          gh pr create --base main --head serverless-qe:sync-konflux/release-next --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -249,17 +216,6 @@ jobs:
           git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/net-kourier.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
           gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[serving - release-next] Create Konflux PR'
-        run: |
-          set -x
-          git remote add fork "https://github.com/serverless-qe/serving.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/serving.git" sync-konflux/release-next:sync-konflux/release-next -f
-          gh pr create --base main --head serverless-qe:sync-konflux/release-next --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -1,8 +1,6 @@
 config:
   branches:
     release-next:
-      konflux:
-        enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -1,8 +1,6 @@
 config:
   branches:
     release-next:
-      konflux:
-        enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -1,8 +1,6 @@
 config:
   branches:
     release-next:
-      konflux:
-        enabled: true
       openShiftVersions:
       - version: "4.15"
       - version: "4.13"

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -1,8 +1,6 @@
 config:
   branches:
     release-next:
-      konflux:
-        enabled: true
       openShiftVersions:
       - version: "4.15"
       - onDemand: true

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -42,41 +42,13 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 			for branchName, b := range config.Config.Branches {
 				if b.Konflux != nil && b.Konflux.Enabled {
 
-					if err := GitMirror(ctx, r); err != nil {
-						return err
-					}
-
-					resourcesOutputPath := fmt.Sprintf("%s/.konflux", r.RepositoryDirectory())
-					pipelinesOutputPath := fmt.Sprintf("%s/.tekton", r.RepositoryDirectory())
-
+					// Special case "release-next"
+					targetBranch := branchName
+					downstreamVersion := "release-next"
 					if branchName == "release-next" {
-						// tmp: remove .tekton and .konflux folders on release next
-						if err := GitCheckout(ctx, r, "main"); err != nil {
-							return err
-						}
-
-						if err := os.RemoveAll(resourcesOutputPath); err != nil {
-							return fmt.Errorf("failed to remove konflux resources output directory: %w", err)
-						}
-
-						if err := os.RemoveAll(pipelinesOutputPath); err != nil {
-							return fmt.Errorf("failed to remove tekton resources output directory: %w", err)
-						}
-
-						pushBranch := fmt.Sprintf("%s%s", KonfluxBranchPrefix, branchName)
-						commitMsg := "[main] Sync Konflux configurations"
-
-						if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
-							return err
-						}
-
-						continue
-					}
-
-					downstreamVersion := sobranch.FromUpstreamVersion(branchName)
-
-					if err := GitCheckout(ctx, r, branchName); err != nil {
-						return err
+						targetBranch = "main"
+					} else {
+						downstreamVersion = sobranch.FromUpstreamVersion(branchName)
 					}
 
 					// Checkout s-o to get the right release version from project.yaml (e.g. 1.34.1)
@@ -107,6 +79,14 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 					log.Println("Version label:", versionLabel)
 					buildArgs = append(buildArgs, fmt.Sprintf("VERSION=%s", versionLabel))
 
+					if err := GitMirror(ctx, r); err != nil {
+						return err
+					}
+
+					if err := GitCheckout(ctx, r, targetBranch); err != nil {
+						return err
+					}
+
 					nudges := b.Konflux.Nudges
 					if downstreamVersion != "release-next" {
 						_, ok := operatorVersions[downstreamVersion]
@@ -126,8 +106,8 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						Excludes:            b.Konflux.Excludes,
 						ExcludesImages:      b.Konflux.ExcludesImages,
 						FBCImages:           b.Konflux.FBCImages,
-						ResourcesOutputPath: resourcesOutputPath,
-						PipelinesOutputPath: pipelinesOutputPath,
+						ResourcesOutputPath: fmt.Sprintf("%s/.konflux", r.RepositoryDirectory()),
+						PipelinesOutputPath: fmt.Sprintf("%s/.tekton", r.RepositoryDirectory()),
 						Nudges:              nudges,
 						Tags:                []string{versionLabel},
 					}
@@ -142,7 +122,7 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 					}
 
 					pushBranch := fmt.Sprintf("%s%s", KonfluxBranchPrefix, branchName)
-					commitMsg := fmt.Sprintf("[%s] Sync Konflux configurations", branchName)
+					commitMsg := fmt.Sprintf("[%s] Sync Konflux configurations", targetBranch)
 
 					if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
 						return err


### PR DESCRIPTION
Reverts the logic to remove the Konflux and Tekton configs for release-next/main branches (from #255 and #258) and disables Konflux for the release-next branches.

Hint: this reverts #255 and #258, and does not only remove the "release-next logic", so we don't run into problems, when we enable Konflux on release-next again.

/hold until the following PRs merged (to remove the konflux & tekton configs):
* https://github.com/openshift-knative/eventing/pull/777
* https://github.com/openshift-knative/eventing-kafka-broker/pull/1163
* https://github.com/openshift-knative/eventing-istio/pull/287
* https://github.com/openshift-knative/serving/pull/824