### PR TITLE
Further reduce the possibility of truncating

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -415,6 +415,8 @@ func Truncate(input interface{}) string {
 	in := fmt.Sprintf("%s", input)
 	in = strings.ReplaceAll(in, "release-v", "")
 	in = strings.ReplaceAll(in, "release-", "")
+	in = strings.ReplaceAll(in, "knative-", "kn-")
+	in = strings.ReplaceAll(in, "eventing-kafka-broker-", "ekb-")
 	return Name(in, "")
 }
 


### PR DESCRIPTION
So that we get `kn-ekb-test-consumer-group-lag-provider-test` (44 chars) for https://github.com/openshift-knative/eventing-kafka-broker/blob/release-v1.15/.konflux/applications/serverless-operator-135/components/knative-eventing-kafka-broker-t02ed9730c0badcab07cecd8cbaeb0430.yaml