### PR TITLE
Fix application name in ImageRepository

### DIFF
--- a/pkg/konfluxgen/imagerepository.template.yaml
+++ b/pkg/konfluxgen/imagerepository.template.yaml
@@ -4,10 +4,10 @@ metadata:
   annotations:
     image-controller.appstudio.redhat.com/update-component-image: "true"
   labels:
-    appstudio.redhat.com/application: {{ sanitize .ApplicationName }}
+    appstudio.redhat.com/application: {{ truncate ( sanitize .ApplicationName ) }}
     appstudio.redhat.com/component: {{ sanitize .ComponentName }}
   name: {{ sanitize .ComponentName }}
 spec:
   image:
-    name: {{ sanitize .ApplicationName }}/{{ .ProjectDirectoryImageBuildStepConfiguration.To }}
+    name: {{ truncate ( sanitize .ApplicationName ) }}/{{ .ProjectDirectoryImageBuildStepConfiguration.To }}
     visibility: public


### PR DESCRIPTION
Should help with current build issues: 

```
quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-bundle: authentication required
```

https://github.com/openshift-knative/hack/blob/f0ff98a4ec989f54a11b62d0edb17bd3e4bb1d55/.konflux/applications/serverless-operator-135/components/imagerepositories/serverless-bundle-135.yaml#L1-L13

https://github.com/openshift-knative/hack/blob/f0ff98a4ec989f54a11b62d0edb17bd3e4bb1d55/.konflux/applications/serverless-operator-135/components/serverless-bundle-135.yaml#L1-L21