### PR TITLE
Fix pipelinetemplate with correct repo name to align with imagerepository

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -30,10 +30,10 @@ spec:
     - name: image-expires-after
       value: 5d
     - name: output-image
-      value: quay.io/redhat-user-workloads/ocp-serverless-tenant/{{{ truncate ( sanitize .ApplicationName ) }}}/{{{ truncate ( sanitize .ProjectDirectoryImageBuildStepConfiguration.To ) }}}:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/ocp-serverless-tenant/{{{ truncate ( sanitize .ApplicationName ) }}}/{{{ .ProjectDirectoryImageBuildStepConfiguration.To }}}:on-pr-{{revision}}
     {{{- else }}}
     - name: output-image
-      value: quay.io/redhat-user-workloads/ocp-serverless-tenant/{{{ truncate ( sanitize .ApplicationName ) }}}/{{{ truncate ( sanitize .ProjectDirectoryImageBuildStepConfiguration.To ) }}}:{{revision}}
+      value: quay.io/redhat-user-workloads/ocp-serverless-tenant/{{{ truncate ( sanitize .ApplicationName ) }}}/{{{ .ProjectDirectoryImageBuildStepConfiguration.To }}}:{{revision}}
     {{{- end }}}
     - name: revision
       value: '{{revision}}'


### PR DESCRIPTION
After #268 we're still getting `quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/kn-eventing-istio-controller: authentication required` build failures.
This is because I missed to update the pipeline template with the correct output-image. This PR addresses it.

So 
https://github.com/openshift-knative/hack/blob/f774ac2c3557ddf3cc5ae970f7cd915330bd25fa/pkg/konfluxgen/pipeline-run.template.yaml#L33

and 
https://github.com/openshift-knative/hack/blob/f774ac2c3557ddf3cc5ae970f7cd915330bd25fa/pkg/konfluxgen/pipeline-run.template.yaml#L36

need to match

https://github.com/openshift-knative/hack/blob/f774ac2c3557ddf3cc5ae970f7cd915330bd25fa/pkg/konfluxgen/imagerepository.template.yaml#L12