### PR TITLE
[konfluxgen] Enable RPMs and Go pre-fetching for hermetic builds

### DIFF
--- a/pkg/konfluxgen/docker-build.yaml
+++ b/pkg/konfluxgen/docker-build.yaml
@@ -50,6 +50,10 @@ spec:
     - name: workspace
       workspace: workspace
   params:
+  - default: "false"
+    description: 'Enable in-development package managers. WARNING: the behavior may
+      change at any time without notice. Use at your own risk.'
+    name: prefetch-input-dev-package-managers
   - default: []
     description: Additional image tags
     name: additional-tags
@@ -124,6 +128,35 @@ spec:
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
   tasks:
+  - name: prefetch-dependencies
+    params:
+    - name: dev-package-managers
+      value: $(params.prefetch-input-dev-package-managers)
+    - name: input
+      value: $(params.prefetch-input)
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: prefetch-dependencies
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:fd1fda0dcf53938860ae6fcba37f5572ae25ae02dba44c15754fb7ba7549fb5c
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.prefetch-input)
+      operator: notin
+      values:
+      - ""
+    workspaces:
+    - name: source
+      workspace: workspace
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
   - name: apply-tags
     params:
     - name: ADDITIONAL_TAGS
@@ -185,33 +218,6 @@ spec:
       workspace: workspace
     - name: basic-auth
       workspace: git-auth
-  - name: prefetch-dependencies
-    params:
-    - name: input
-      value: $(params.prefetch-input)
-    runAfter:
-    - clone-repository
-    taskRef:
-      params:
-      - name: name
-        value: prefetch-dependencies
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:fd1fda0dcf53938860ae6fcba37f5572ae25ae02dba44c15754fb7ba7549fb5c
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.prefetch-input)
-      operator: notin
-      values:
-      - ""
-    workspaces:
-    - name: source
-      workspace: workspace
-    - name: git-basic-auth
-      workspace: git-auth
-    - name: netrc
-      workspace: netrc
   - name: build-container
     params:
     - name: IMAGE

--- a/pkg/konfluxgen/kustomize/kustomize-docker-build/kustomization.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-docker-build/kustomization.yaml
@@ -7,5 +7,8 @@ patches:
   - path: ../additional_tags.patch.yaml
     target:
       name: docker-build
+  - path: ../prefetch-input_dev-package-managers.yaml
+    target:
+      name: docker-build
 openapi:
   path: ../pipeline_schema.json

--- a/pkg/konfluxgen/kustomize/prefetch-input_dev-package-managers.yaml
+++ b/pkg/konfluxgen/kustomize/prefetch-input_dev-package-managers.yaml
@@ -1,0 +1,14 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: docker-build
+spec:
+  params:
+    - name: prefetch-input-dev-package-managers
+      description: "Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk."
+      default: "false"
+  tasks:
+    - name: prefetch-dependencies
+      params:
+        - name: dev-package-managers
+          value: $(params.prefetch-input-dev-package-managers)

--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -41,6 +41,14 @@ spec:
     - name: additional-tags
       value: [{{{ range $tag := .Tags }}} {{{ $tag }}}, {{{ end }}}]
     {{{- end }}}
+    {{{- if .PrefetchDeps.PrefetchInput }}}
+    - name: prefetch-input
+      value: "{{{ .PrefetchDeps.PrefetchInput }}}"
+    {{{- end }}}
+    {{{- if .PrefetchDeps.DevPackageManagers }}}
+    - name: prefetch-input-dev-package-managers
+      value: "{{{ .PrefetchInput.DevPackageManagers }}}"
+    {{{- end }}}
   pipelineRef:
     name: {{{ .Pipeline }}}
   taskRunTemplate: {}

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -96,6 +96,19 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						log.Printf("[%s] created nudges (%v) - operatorVersions: %#v - downstreamVersion: %v): %#v", r.RepositoryDirectory(), ok, operatorVersions, downstreamVersion, nudges)
 					}
 
+					prefetchDeps := konfluxgen.PrefetchDeps{}
+					if _, err := os.Stat(filepath.Join(r.RepositoryDirectory(), "rpms.lock.yaml")); err == nil {
+						// If rpms.lock.yaml is present enable dev-package-managers and RPM caching
+						prefetchDeps.DevPackageManagers = "true"
+						prefetchDeps.WithRPMs()
+					}
+					if _, err := os.Stat(filepath.Join(r.RepositoryDirectory(), "vendor")); err != nil {
+						if _, err := os.Stat(filepath.Join(r.RepositoryDirectory(), "go.mod")); err == nil {
+							// If it's a Go project and no vendor dir is present enable Go caching
+							prefetchDeps.WithUnvendoredGo("." /* root of the repository */)
+						}
+					}
+
 					cfg := konfluxgen.Config{
 						OpenShiftReleasePath: openshiftRelease.RepositoryDirectory(),
 						ApplicationName:      fmt.Sprintf("serverless-operator %s", downstreamVersion),
@@ -110,6 +123,7 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						PipelinesOutputPath: fmt.Sprintf("%s/.tekton", r.RepositoryDirectory()),
 						Nudges:              nudges,
 						Tags:                []string{versionLabel},
+						PrefetchDeps:        prefetchDeps,
 					}
 					if len(cfg.ExcludesImages) == 0 {
 						cfg.ExcludesImages = []string{


### PR DESCRIPTION
This in combination with https://github.com/openshift-knative/hack/pull/278, will enable func-utils and must-gather hermetic builds