### PR TITLE
Inject standardized writable GOPATH for e2e tests

### DIFF
--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -115,7 +115,7 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 							LiteralTestStep: &cioperatorapi.LiteralTestStep{
 								As:       "test",
 								From:     sourceImageName,
-								Commands: fmt.Sprintf("SKIP_MESH_AUTH_POLICY_GENERATION=true make %s", test.Command),
+								Commands: fmt.Sprintf("GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make %s", test.Command),
 								Resources: cioperatorapi.ResourceRequirements{
 									Requests: cioperatorapi.ResourceList{
 										"cpu": "100m",

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -728,5 +728,5 @@ func mustGatherSteps(sourceImage string, optionalOnSuccess bool) []cioperatorapi
 }
 
 func formatCommand(cmd string) string {
-	return fmt.Sprintf("SKIP_MESH_AUTH_POLICY_GENERATION=true %s", cmd)
+	return fmt.Sprintf("GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true %s", cmd)
 }


### PR DESCRIPTION
Tested with:

`Makefile`

```
print:
	$(info PATH: $(PATH))
	$(info GOPATH: $(GOPATH))
.PHONY: print
```

Execution:
```
pierdipi@pierdipi eventing (release-v1.14) $ GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make print
PATH: /usr/lib/jvm/java/bin/:/home/pierdipi/.nvm/versions/node/v20.16.0/bin:/usr/lib/jvm/java/bin/:/home/pierdipi/.local/bin:/home/pierdipi/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/var/lib/snapd/snap/bin:/home/pierdipi/.composer/vendor/bin:/home/pierdipi/.dotnet/tools:/usr/local/go/bin:/home/pierdipi/go/bin:/home/pierdipi/.npm-packages/bin:/home/pierdipi/.local/share/JetBrains/Toolbox/scripts:/home/pierdipi/go/bin:/home/pierdipi/.npm-packages/bin:/tmp/go/bin
GOPATH: /tmp/go
make: Nothing to be done for 'print'.
```

In the test scripts we can now just run:

```shell
$ go install xyz
$ xyz --a "a" ...
```