### PR TITLE
Discover: Fix empty branch name

### DIFF
--- a/pkg/prowgen/prowgen_git.go
+++ b/pkg/prowgen/prowgen_git.go
@@ -39,10 +39,12 @@ func Branches(ctx context.Context, r Repository) ([]string, error) {
 
 	branchesList := string(branchesBytes)
 
-	sortedBranches := strings.Split(branchesList, "\n")
-	for i, b := range sortedBranches {
-		b = strings.TrimSpace(b)
-		sortedBranches[i] = b
+	var sortedBranches []string
+	for _, branch := range strings.Split(branchesList, "\n") {
+		branch = strings.TrimSpace(branch)
+		if branch != "" {
+			sortedBranches = append(sortedBranches, branch)
+		}
 	}
 	slices.SortFunc(sortedBranches, CmpBranches)
 


### PR DESCRIPTION
Prevent empty branch names like [here](https://github.com/openshift-knative/hack/pull/288/files#r1764849510)