### PR TITLE
Discover: Respect serverless-x.y.z branch names in sorting too

### DIFF
--- a/pkg/prowgen/prowgen_git.go
+++ b/pkg/prowgen/prowgen_git.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift-knative/hack/pkg/soversion"
 	"log"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/openshift-knative/hack/pkg/soversion"
 
 	"github.com/coreos/go-semver/semver"
 )

--- a/pkg/prowgen/prowgen_git_test.go
+++ b/pkg/prowgen/prowgen_git_test.go
@@ -1,9 +1,10 @@
 package prowgen
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"slices"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCmpBranches(t *testing.T) {

--- a/pkg/prowgen/prowgen_git_test.go
+++ b/pkg/prowgen/prowgen_git_test.go
@@ -1,0 +1,37 @@
+package prowgen
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"slices"
+	"testing"
+)
+
+func TestCmpBranches(t *testing.T) {
+	tests := []struct {
+		versions       []string
+		expectedSorted []string
+	}{
+		{
+			versions:       []string{"release-v1.15", "release-v1.14", "release-v1.16"},
+			expectedSorted: []string{"release-v1.14", "release-v1.15", "release-v1.16"},
+		},
+		{
+			versions:       []string{"release-v1.15", "release-v1.16", "serverless-1.35"},
+			expectedSorted: []string{"release-v1.15", "serverless-1.35", "release-v1.16"},
+		},
+		{
+			versions:       []string{"release-v1.15", "release-v1.16", "serverless-1.34"},
+			expectedSorted: []string{"serverless-1.34", "release-v1.15", "release-v1.16"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			sorted := tt.versions
+			//testing indirect via stort func, as this is easier to read
+			slices.SortFunc(sorted, CmpBranches)
+			if diff := cmp.Diff(tt.expectedSorted, sorted); diff != "" {
+				t.Error("CmpBranches() (-want, +got):", diff)
+			}
+		})
+	}
+}

--- a/pkg/soversion/version.go
+++ b/pkg/soversion/version.go
@@ -32,6 +32,32 @@ func FromUpstreamVersion(upstream string) *semver.Version {
 	return soVersion
 }
 
+func ToUpstreamVersion(soversion string) *semver.Version {
+	soversion = strings.Replace(soversion, "serverless-v", "", 1)
+	soversion = strings.Replace(soversion, "serverless-", "", 1)
+	soversion = strings.Replace(soversion, "v", "", 1)
+
+	dotParts := strings.SplitN(soversion, ".", 3)
+	if len(dotParts) == 2 {
+		soversion = soversion + ".0"
+	}
+	upstreamVersion := semver.New(soversion)
+	upstreamVersion.Patch = 0
+	for i := 0; i < 21; i++ { // Example 1.32 -> 1.11
+		upstreamVersion.Minor--
+	}
+
+	soVersion := semver.New(soversion)
+	if soVersion.Compare(*semver.New("1.34.0")) >= 0 { //so >= xy
+		// As 1.12 was actually 1.13
+		// 1.33 -> 1.12
+		// 1.34 -> 1.14
+		upstreamVersion.Minor++
+	}
+
+	return upstreamVersion
+}
+
 func BranchName(soVersion *semver.Version) string {
 	return fmt.Sprintf("release-%d.%d", soVersion.Major, soVersion.Minor)
 }

--- a/pkg/soversion/version_test.go
+++ b/pkg/soversion/version_test.go
@@ -41,3 +41,32 @@ func TestFromUpstreamVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestToUpstreamVersion(t *testing.T) {
+	tests := []struct {
+		soVersion string
+		want      string
+	}{
+		{
+			soVersion: "1.32.0",
+			want:      "1.11.0",
+		}, {
+			soVersion: "1.33.0",
+			want:      "1.12.0",
+		}, {
+			soVersion: "1.33.1",
+			want:      "1.12.0",
+		}, {
+			soVersion: "1.34.0",
+			want:      "1.14.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q -> %q", tt.soVersion, tt.want), func(t *testing.T) {
+			if got := ToUpstreamVersion(tt.soVersion); got.String() != semver.New(tt.want).String() {
+				t.Errorf("ToUpstreamVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow up on https://github.com/openshift-knative/hack/pull/288#discussion_r1764905222 to take funcs current branch naming scheme into account too to discover branches