### PR TITLE
Enable hermetic builds for Go components

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -26,6 +26,8 @@ spec:
       value: [{{{ range $arg := .BuildArgs }}} {{{ $arg }}}, {{{ end }}}]
     - name: git-url
       value: '{{source_url}}'
+    - name: hermetic
+      value: "{{{ .Hermetic }}}"
     {{{- if eq .Event "pull_request" }}}
     - name: image-expires-after
       value: 5d


### PR DESCRIPTION
This enables hermetic builds for components that are not java-based or the index image (since index is using the registry.ci images to create the index) 

Tested here https://github.com/openshift-knative/eventing/pull/793