### PR TITLE
Bump OCP 4.15 to 4.16 in configs

### DIFF
--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -2,35 +2,41 @@ config:
   branches:
     release-next:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
 repositories:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -2,34 +2,40 @@ config:
   branches:
     release-next:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
 repositories:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -2,33 +2,39 @@ config:
   branches:
     release-next:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - version: "4.13"
     release-v1.10:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - version: "4.13"
 repositories:
 - dockerfiles: {}

--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -3,11 +3,13 @@ config:
     release-next:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
     serverless-1.34:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}
@@ -36,7 +38,7 @@ repositories:
       owner: serverless-ci
       product: ocp
       timeout: 1h0m0s
-      version: "4.15"
+      version: "4.16"
     steps:
       test:
       - as: test

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -9,7 +9,8 @@ config:
         - .*serverless-index.*
       openShiftVersions:
       - generateCustomConfigs: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
     release-1.35:
@@ -150,18 +151,18 @@ repositories:
     releaseBuildConfiguration:
       base_images:
         hypershift-operator:
-          name: "4.15"
+          name: "4.16"
           namespace: ocp
           tag: hypershift-operator
         upi-installer:
-          name: "4.15"
+          name: "4.16"
           namespace: ocp
           tag: upi-installer
       releases:
         latest:
           integration:
             include_built_images: true
-            name: "4.15"
+            name: "4.16"
             namespace: ocp
       tests:
       - as: e2e-hypershift-continuous
@@ -220,7 +221,7 @@ repositories:
           cluster_profile: osd-ephemeral
           env:
             CLUSTER_DURATION: "10800"
-            CLUSTER_VERSION: "4.15"
+            CLUSTER_VERSION: "4.16"
             COMPUTE_NODES: "4"
           post:
           - chain: gather
@@ -279,7 +280,7 @@ repositories:
     releaseBuildConfiguration:
       base_images:
         upi-installer:
-          name: "4.15"
+          name: "4.16"
           namespace: ocp
           tag: upi-installer
       tests:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -3,25 +3,29 @@ config:
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
 repositories:

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -3,25 +3,29 @@ config:
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.12"
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
 repositories:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -2,7 +2,8 @@ config:
   branches:
     release-next:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
       skipDockerFilesMatches:
@@ -13,27 +14,31 @@ config:
     release-v1.11:
       openShiftVersions:
       - skipCron: true
-        version: "4.15"
+        version: "4.16"
+        useClusterPool: true
       - onDemand: true
         skipCron: true
         version: "4.12"
     release-v1.12:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.12"
       skipE2EMatches:
       - .*e2e-tls$
     release-v1.14:
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.16"
+        useClusterPool: true
       - onDemand: true
         version: "4.13"
 repositories:

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -96,8 +96,9 @@ type Prowgen struct {
 }
 
 type OpenShift struct {
-	Version string `json:"version,omitempty" yaml:"version,omitempty"`
-	Cron    string `json:"cron,omitempty" yaml:"cron,omitempty"`
+	Version        string `json:"version,omitempty" yaml:"version,omitempty"`
+	UseClusterPool bool   `json:"useClusterPool,omitempty" yaml:"useClusterPool,omitempty"`
+	Cron           string `json:"cron,omitempty" yaml:"cron,omitempty"`
 	// SkipCron ensures that no periodic jobs are generated for tests running on the given OpenShift version.
 	SkipCron              bool `json:"skipCron,omitempty" yaml:"skipCron,omitempty"`
 	OnDemand              bool `json:"onDemand,omitempty" yaml:"onDemand,omitempty"`

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -31,9 +31,6 @@ const (
 	// in AWS under rh-serverless account. The cluster profile defined earlier has permissions
 	// to create subdomains for new clusters.
 	devclusterBaseDomain = "serverless.devcluster.openshift.com"
-	// Holds version of the existing cluster pool dedicated to OpenShift Serverless in CI.
-	// See https://docs.ci.openshift.org/docs/how-tos/cluster-claim/#existing-cluster-pools
-	clusterPoolVersion = "4.15"
 	// Name of the owner for the existing cluster pool.
 	// Introduced in https://github.com/openshift/release/pull/49904
 	clusterPoolOwner = "serverless-ci"
@@ -76,9 +73,8 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 				env            cioperatorapi.TestEnvironment
 			)
 
-			useClusterPool := openShift.Version == clusterPoolVersion
 			// Make sure to use the existing cluster pool if available for the given OpenShift version.
-			if useClusterPool {
+			if openShift.UseClusterPool {
 				// ClusterClaim references the existing cluster pool.
 				// Mutually exclusive with ClusterProfile.
 				clusterClaim = &cioperatorapi.ClusterClaim{
@@ -183,7 +179,7 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 				},
 			}
 
-			if !useClusterPool {
+			if !openShift.UseClusterPool {
 				testConfiguration.MultiStageTestConfiguration.Post =
 					append(testConfiguration.MultiStageTestConfiguration.Post,
 						cioperatorapi.TestStep{

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -315,7 +315,7 @@ func TestDiscoverTestsServingClusterClaim(t *testing.T) {
 	servingSourceImage := "knative-serving-source-image"
 	options := []ReleaseBuildConfigurationOption{
 		DiscoverImages(r, []string{"skip-images/.*"}),
-		DiscoverTests(r, OpenShift{Version: clusterPoolVersion, Cron: *cron}, servingSourceImage, []string{"skip-e2e$"}, random),
+		DiscoverTests(r, OpenShift{Version: "4.16", UseClusterPool: true, Cron: *cron}, servingSourceImage, []string{"skip-e2e$"}, random),
 	}
 
 	perfDependencies := []cioperatorapi.StepDependency{
@@ -331,10 +331,10 @@ func TestDiscoverTestsServingClusterClaim(t *testing.T) {
 
 	expectedTests := []cioperatorapi.TestStepConfiguration{
 		{
-			As: fmt.Sprintf("perf-tests-aws-%s", strings.ReplaceAll(clusterPoolVersion, ".", "")),
+			As: fmt.Sprintf("perf-tests-aws-%s", strings.ReplaceAll("4.16", ".", "")),
 			ClusterClaim: &cioperatorapi.ClusterClaim{
 				Product:      cioperatorapi.ReleaseProductOCP,
-				Version:      clusterPoolVersion,
+				Version:      "4.16",
 				Architecture: cioperatorapi.ReleaseArchitectureAMD64,
 				Cloud:        cioperatorapi.CloudAWS,
 				Owner:        "serverless-ci",


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCOM-3351

Also, make it explicit in the config which version uses cluster pool. Having to update the constant in prowgen_tests.go every time would be annoying, and error prone (we could forget about it).

/hold

Depends on https://github.com/openshift/release/pull/56966