### PR TITLE
Don't force push when there are no changes

### DIFF
--- a/.github/workflows/release-generate-ci-template.yaml
+++ b/.github/workflows/release-generate-ci-template.yaml
@@ -85,8 +85,20 @@ jobs:
         run: |
           set -x
           git remote add fork "https://github.com/serverless-qe/release.git"
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/release.git" sync-serverless-ci:sync-serverless-ci -f
-          gh pr create --base master --head serverless-qe:sync-serverless-ci --fill-verbose || true
+          branch="sync-serverless-ci"
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/release.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/release.git" "$branch:$branch" -f
+          fi
+          gh pr create --base master --head "serverless-qe:$branch" --fill-verbose || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift/release
 
       - name: Create Pull Request - openshift-knative/hack
@@ -97,7 +109,19 @@ jobs:
         run: |
           set -x
           git remote add fork "https://github.com/serverless-qe/hack.git"
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" sync-konflux/main:sync-konflux/main -f
-          gh pr create --base main --head serverless-qe:sync-konflux/main --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          branch="sync-konflux-main"
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" "$branch:$branch" -f
+          fi
+          gh pr create --base main --head "serverless-qe:$branch" --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         # Use the repository cloned by the prowgen tool
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/hack

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -211,7 +211,6 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
       - env:
@@ -237,7 +236,6 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
       - env:
@@ -263,7 +261,6 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
       - env:
@@ -289,7 +286,6 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serverless-operator
       - env:
@@ -315,7 +311,6 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
       - env:
@@ -341,7 +336,6 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
       - env:
@@ -367,6 +361,5 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -149,8 +149,20 @@ jobs:
         run: |
           set -x
           git remote add fork "https://github.com/serverless-qe/release.git"
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/release.git" sync-serverless-ci:sync-serverless-ci -f
-          gh pr create --base master --head serverless-qe:sync-serverless-ci --fill-verbose || true
+          branch="sync-serverless-ci"
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/release.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/release.git" "$branch:$branch" -f
+          fi
+          gh pr create --base master --head "serverless-qe:$branch" --fill-verbose || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift/release
       - name: Create Pull Request - openshift-knative/hack
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -160,8 +172,20 @@ jobs:
         run: |
           set -x
           git remote add fork "https://github.com/serverless-qe/hack.git"
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" sync-konflux/main:sync-konflux/main -f
-          gh pr create --base main --head serverless-qe:sync-konflux/main --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          branch="sync-konflux-main"
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" "$branch:$branch" -f
+          fi
+          gh pr create --base main --head "serverless-qe:$branch" --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         # Use the repository cloned by the prowgen tool
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/hack
       - env:
@@ -171,9 +195,24 @@ jobs:
         name: '[eventing-istio - release-v1.15] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/eventing-istio.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing-istio.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
-          gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          repo="eventing-istio"
+          branch="sync-konflux-release-v1.15"
+          target_branch="release-v1.15"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -182,9 +221,24 @@ jobs:
         name: '[eventing-kafka-broker - release-v1.15] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/eventing-kafka-broker.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing-kafka-broker.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
-          gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          repo="eventing-kafka-broker"
+          branch="sync-konflux-release-v1.15"
+          target_branch="release-v1.15"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -193,9 +247,24 @@ jobs:
         name: '[eventing - release-v1.15] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/eventing.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/eventing.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
-          gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          repo="eventing"
+          branch="sync-konflux-release-v1.15"
+          target_branch="release-v1.15"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -204,9 +273,24 @@ jobs:
         name: '[serverless-operator - main] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/serverless-operator.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/serverless-operator.git" sync-konflux/main:sync-konflux/main -f
-          gh pr create --base main --head serverless-qe:sync-konflux/main --title "[main] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          repo="serverless-operator"
+          branch="sync-konflux-main"
+          target_branch="main"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serverless-operator
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -215,9 +299,24 @@ jobs:
         name: '[net-istio - release-v1.15] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/net-istio.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/net-istio.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
-          gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          repo="net-istio"
+          branch="sync-konflux-release-v1.15"
+          target_branch="release-v1.15"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -226,9 +325,24 @@ jobs:
         name: '[net-kourier - release-v1.15] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/net-kourier.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/net-kourier.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
-          gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          repo="net-kourier"
+          branch="sync-konflux-release-v1.15"
+          target_branch="release-v1.15"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -237,7 +351,22 @@ jobs:
         name: '[serving - release-v1.15] Create Konflux PR'
         run: |
           set -x
-          git remote add fork "https://github.com/serverless-qe/serving.git" || true # ignore: already exists errors
-          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/serving.git" sync-konflux/release-v1.15:sync-konflux/release-v1.15 -f
-          gh pr create --base release-v1.15 --head serverless-qe:sync-konflux/release-v1.15 --title "[release-v1.15] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+          repo="serving"
+          branch="sync-konflux-release-v1.15"
+          target_branch="release-v1.15"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+            exit $?
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving

--- a/pkg/action/update_action.go
+++ b/pkg/action/update_action.go
@@ -150,7 +150,6 @@ if git diff --quiet "fork/$branch" "$branch"; then
 else
   git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
 fi
-git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
 gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
 `,
 						r.Repo,

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	KonfluxBranchPrefix = "sync-konflux/"
+	KonfluxBranchPrefix = "sync-konflux-"
 )
 
 func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs []*Config) error {


### PR DESCRIPTION
Prevent force pushing when there are no changes to avoid
unnecessary CI runs.

First commit is the logic change, second generates the action