### PR TITLE
Add workflow in each repo to apply Konflux manifests on changes

### DIFF
--- a/.github/workflows/apply-konflux-manifests.yaml
+++ b/.github/workflows/apply-konflux-manifests.yaml
@@ -1,6 +1,13 @@
-name: Reusable Apply Konflux Manifests
+name: Apply Konflux Manifests
 on:
-  workflow_call:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 06:00.
+  workflow_dispatch: # Manual workflow trigger
+  push:
+    paths:
+      - ".konflux/**"
+    branches:
+      - 'main'
 defaults:
   run:
     shell: bash
@@ -27,4 +34,4 @@ jobs:
           kubectl config use-context konflux-sa@konflux
 
       - name: Apply Manifests
-        run: kubectl apply -Rf .konflux/
+        run: make konflux-apply

--- a/.github/workflows/reusable-apply-konflux-manifests.yaml
+++ b/.github/workflows/reusable-apply-konflux-manifests.yaml
@@ -1,4 +1,4 @@
-name: Apply Konflux Manifests
+name: Reusable Apply Konflux Manifests
 on:
   schedule:
     - cron: "0 6 * * *" # Daily at 06:00.
@@ -6,6 +6,9 @@ on:
   push:
     paths:
       - ".konflux/**"
+    branches:
+      - 'main',
+      - 'release-v*'
 defaults:
   run:
     shell: bash
@@ -32,4 +35,4 @@ jobs:
           kubectl config use-context konflux-sa@konflux
 
       - name: Apply Manifests
-        run: make konflux-apply
+        run: kubectl apply -Rf .konflux/

--- a/.github/workflows/reusable-apply-konflux-manifests.yaml
+++ b/.github/workflows/reusable-apply-konflux-manifests.yaml
@@ -1,14 +1,6 @@
 name: Reusable Apply Konflux Manifests
 on:
-  schedule:
-    - cron: "0 6 * * *" # Daily at 06:00.
-  workflow_dispatch: # Manual workflow trigger
-  push:
-    paths:
-      - ".konflux/**"
-    branches:
-      - 'main',
-      - 'release-v*'
+  workflow_call:
 defaults:
   run:
     shell: bash

--- a/cmd/konflux-apply/README.md
+++ b/cmd/konflux-apply/README.md
@@ -35,3 +35,10 @@ As we use by default Tokens with a validity of 6 months, we need to recreate the
    ```shell
    kubectl create token gh-action --duration $((6*30*24))h
    ```
+   
+## Manually apply all Konflux Manifests
+
+In case you want to manually apply all Konflux manifests across all repos, do the following:
+
+0. Make sure, you're logged in to Konflux via the CLI and have access to the `ocp-serverless` workspace. Check for example the [Konflux kickstart recording](https://drive.google.com/drive/u/0/folders/0AB3Zk0vHI6ulUk9PVA) or the [Konflux docs](https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/getting-access.md#accessing-konflux-via-cli)
+1. Run `make konflux-apply`. This will clone all repos and checkout the branches which have Konflux enabled and apply their Konflux manifests.

--- a/cmd/konflux-apply/README.md
+++ b/cmd/konflux-apply/README.md
@@ -40,5 +40,5 @@ As we use by default Tokens with a validity of 6 months, we need to recreate the
 
 In case you want to manually apply all Konflux manifests across all repos, do the following:
 
-0. Make sure, you're logged in to Konflux via the CLI and have access to the `ocp-serverless` workspace. Check for example the [Konflux kickstart recording](https://drive.google.com/drive/u/0/folders/0AB3Zk0vHI6ulUk9PVA) or the [Konflux docs](https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/getting-access.md#accessing-konflux-via-cli)
-1. Run `make konflux-apply`. This will clone all repos and checkout the branches which have Konflux enabled and apply their Konflux manifests.
+1. Make sure, you're logged in to Konflux via the CLI and have access to the `ocp-serverless` workspace. Check for example the [Konflux kickstart recording](https://drive.google.com/drive/u/0/folders/0AB3Zk0vHI6ulUk9PVA) or the [Konflux docs](https://gitlab.cee.redhat.com/konflux/docs/users/-/blob/main/topics/getting-started/getting-access.md#accessing-konflux-via-cli)
+2. Run `make konflux-apply`. This will clone all repos and checkout the branches which have Konflux enabled and apply their Konflux manifests.

--- a/cmd/konflux-gen/main.go
+++ b/cmd/konflux-gen/main.go
@@ -18,6 +18,7 @@ const (
 	fbcBuilderImagesFlag     = "fbc-images"
 	outputFlag               = "output"
 	pipelineOutputFlag       = "pipeline-output"
+	workflowsPathFlag        = "workflows-path"
 )
 
 func main() {
@@ -34,6 +35,7 @@ func run() error {
 	pflag.StringVar(&cfg.ApplicationName, applicationNameFlag, "", "Konflux application name")
 	pflag.StringVar(&cfg.ResourcesOutputPath, outputFlag, "", "output path")
 	pflag.StringVar(&cfg.PipelinesOutputPath, pipelineOutputFlag, ".tekton", "output path for pipelines")
+	pflag.StringVar(&cfg.WorkflowsPath, workflowsPathFlag, ".github/workflows", "output path for Github workflows")
 	pflag.StringArrayVar(&cfg.Includes, includesFlag, nil, "Regex to select CI config files to include")
 	pflag.StringArrayVar(&cfg.Excludes, excludesFlag, nil, "Regex to select CI config files to exclude")
 	pflag.StringArrayVar(&cfg.ExcludesImages, excludeImagesFlag, nil, "Regex to select CI config images to exclude")

--- a/pkg/konfluxgen/apply-konflux-manifests-workflow.yaml
+++ b/pkg/konfluxgen/apply-konflux-manifests-workflow.yaml
@@ -1,0 +1,12 @@
+name: Apply Konflux Manifests
+on:
+  workflow_dispatch: # Manual workflow trigger
+  push:
+    paths:
+      - ".konflux/**"
+    branches:
+    - 'main',
+    - 'release-v*'
+jobs:
+  konflux-apply:
+    uses: openshift-knative/hack/.github/workflows/reusable-apply-konflux-manifests.yaml@main

--- a/pkg/konfluxgen/apply-konflux-manifests-workflow.yaml
+++ b/pkg/konfluxgen/apply-konflux-manifests-workflow.yaml
@@ -10,3 +10,4 @@ on:
 jobs:
   konflux-apply:
     uses: openshift-knative/hack/.github/workflows/reusable-apply-konflux-manifests.yaml@main
+    secrets: inherit

--- a/pkg/konfluxgen/apply-konflux-manifests-workflow.yaml
+++ b/pkg/konfluxgen/apply-konflux-manifests-workflow.yaml
@@ -5,9 +5,21 @@ on:
     paths:
       - ".konflux/**"
     branches:
-    - 'main',
+    - 'main'
     - 'release-v*'
 jobs:
-  konflux-apply:
-    uses: openshift-knative/hack/.github/workflows/reusable-apply-konflux-manifests.yaml@main
-    secrets: inherit
+  trigger-konflux-apply:
+    name: Trigger Konflux Apply
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Konflux Apply
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SERVERLESS_QE_ROBOT }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'hack',
+              workflow_id: 'apply-konflux-manifests.yaml',
+              ref: 'main',
+            })

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -322,6 +322,9 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 			// will change it before merging the PR.
 			// See `openshift-knative/serverless-operator/hack/generate/update-pipelines.sh` for more details.
 			Tags: []string{soMetadata.Project.Version},
+			// We can skip the GH workflow creation to apply the Konflux manifests, as the SO
+			// manifests are stored in the hack repo and the workflow is anyhow present in there
+			SkipApplyKonfluxWorkflowCreation: true,
 		}
 		if len(cfg.ExcludesImages) == 0 {
 			cfg.ExcludesImages = []string{
@@ -415,6 +418,9 @@ func generateFBCApplications(soMetadata *project.Metadata, openshiftRelease Repo
 			// will change it before merging the PR.
 			// See `openshift-knative/serverless-operator/hack/generate/update-pipelines.sh` for more details.
 			Tags: []string{soMetadata.Project.Version},
+			// We can skip the GH workflow creation to apply the Konflux manifests, as the SO
+			// manifests are stored in the hack repo and the workflow is anyhow present in there
+			SkipApplyKonfluxWorkflowCreation: true,
 		}
 
 		if err := konfluxgen.Generate(c); err != nil {

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -150,6 +150,7 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						JavaImages:          b.Konflux.JavaImages,
 						ResourcesOutputPath: fmt.Sprintf("%s/.konflux", r.RepositoryDirectory()),
 						PipelinesOutputPath: fmt.Sprintf("%s/.tekton", r.RepositoryDirectory()),
+						WorkflowsPath:       fmt.Sprintf("%s/.github/workflows", r.RepositoryDirectory()),
 						Nudges:              nudges,
 						// Preserve the version tag as first tag in any instance since SO, when bumping the patch version
 						// will change it before merging the PR.
@@ -304,6 +305,7 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 			ResourcesOutputPathSkipRemove: true,
 			ResourcesOutputPath:           resourceOutputPath,
 			PipelinesOutputPath:           fmt.Sprintf("%s/.tekton", r.RepositoryDirectory()),
+			WorkflowsPath:                 fmt.Sprintf("%s/.github/workflows", r.RepositoryDirectory()),
 			Nudges:                        b.Konflux.Nudges,
 			NudgesFunc: func(cfg cioperatorapi.ReleaseBuildConfiguration, ib cioperatorapi.ProjectDirectoryImageBuildStepConfiguration) []string {
 				if strings.Contains(string(ib.To), "serverless-bundle") {


### PR DESCRIPTION
* add a reusable action to apply the Konflux manifests
* Adds a workflow to each repo & branch which have Konflux enabled calling the above reusable action. This allows to apply the manifests directly after changes in the `.konflux/` directory in the repositories and does not need the periodic runs from hack repo anymore

/hold
as we need to move the `KONFLUX_SA_TOKEN` secret from the hack repo to the org (when we agreed on this PR)