### PR TITLE
Remove version skip for kn-plugin-func as versions are aligned now

### DIFF
--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -53,14 +53,7 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						targetBranch = "main"
 					} else {
 						soVersion = soversion.FromUpstreamVersion(branchName)
-
-						if r.Org == "openshift-knative" && r.Repo == "kn-plugin-func" {
-							// functions is one minor ahead the others (with client 1.15 comes func 1.16)
-							soVersion.Minor--
-							soBranchName = soversion.BranchName(soVersion)
-						} else {
-							soBranchName = soversion.BranchName(soVersion)
-						}
+						soBranchName = soversion.BranchName(soVersion)
 					}
 
 					// Checkout s-o to get the right release version from project.yaml (e.g. 1.34.1)


### PR DESCRIPTION
As func versions are now aligned with the other components, we can remove the version skip for func

Discussion: https://redhat-internal.slack.com/archives/CLMP7R2G2/p1727789129599039?thread_ts=1727771460.710709&cid=CLMP7R2G2