### PR TITLE
[discover] Fix SO branch discovery and remove update action SO special casing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ generate-functions-ci:
 	go run github.com/openshift-knative/hack/cmd/prowgen --config config/kn-plugin-func.yaml $(ARGS)
 .PHONY: generate-functions-ci
 
-discover-branches:
+discover-branches: clean
 	go run github.com/openshift-knative/hack/cmd/discover $(ARGS)
 .PHONY: discover-branches
 

--- a/cmd/generate-ci-action/main.go
+++ b/cmd/generate-ci-action/main.go
@@ -1,21 +1,26 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
+	"os"
+	"os/signal"
 	"path/filepath"
 
 	"github.com/openshift-knative/hack/pkg/action"
 )
 
 func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
 
 	inputConfig := flag.String("config", filepath.Join("config"), "Specify repositories config")
 	inputAction := flag.String("input", filepath.Join(".github", "workflows", "release-generate-ci-template.yaml"), "Input action (template)")
 	outputAction := flag.String("output", filepath.Join(".github", "workflows", "release-generate-ci.yaml"), "Output action")
 	flag.Parse()
 
-	err := action.UpdateAction(action.Config{
+	err := action.UpdateAction(ctx, action.Config{
 		InputAction:     *inputAction,
 		InputConfigPath: *inputConfig,
 		OutputAction:    *outputAction,

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -1,8 +1,6 @@
 config:
   branches:
     release-next:
-      skipDockerFilesMatches:
-      - .*hermetic.*
       konflux:
         javaImages:
         - .*eventing-kafka-broker-receiver
@@ -12,6 +10,8 @@ config:
         version: "4.16"
       - onDemand: true
         version: "4.13"
+      skipDockerFilesMatches:
+      - .*hermetic.*
     release-v1.10:
       openShiftVersions:
       - skipCron: true
@@ -37,8 +37,6 @@ config:
       - onDemand: true
         version: "4.13"
     release-v1.15:
-      skipDockerFilesMatches:
-      - .*hermetic.*
       konflux:
         enabled: true
       openShiftVersions:
@@ -46,6 +44,8 @@ config:
         version: "4.16"
       - onDemand: true
         version: "4.13"
+      skipDockerFilesMatches:
+      - .*hermetic.*
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -7,6 +7,11 @@ config:
         - .*rosa.*
         fbcImages:
         - .*serverless-index.*
+        imageOverrides:
+        - name: GO_BUILDER
+          pullSpec: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.22
+        - name: GO_RUNTIME
+          pullSpec: registry.access.redhat.com/ubi8/ubi-minimal
       openShiftVersions:
       - generateCustomConfigs: true
         useClusterPool: true
@@ -15,11 +20,22 @@ config:
         version: "4.13"
     release-1.35:
       konflux:
+        enabled: true
+        excludes:
+        - .*rosa.*
+        fbcImages:
+        - .*serverless-index.*
         imageOverrides:
         - name: GO_BUILDER
           pullSpec: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.22
         - name: GO_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/ubi-minimal
+      openShiftVersions:
+      - generateCustomConfigs: true
+        useClusterPool: true
+        version: "4.16"
+      - onDemand: true
+        version: "4.13"
       prowgen:
         disabled: true
 repositories:

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -428,3 +428,7 @@ func applyOptions(cfg *cioperatorapi.ReleaseBuildConfiguration, opts ...ReleaseB
 	}
 	return nil
 }
+
+func (r Repository) IsServerlessOperator() bool {
+	return r.Org == "openshift-knative" && r.Repo == "serverless-operator"
+}

--- a/pkg/soversion/version.go
+++ b/pkg/soversion/version.go
@@ -61,3 +61,12 @@ func ToUpstreamVersion(soversion string) *semver.Version {
 func BranchName(soVersion *semver.Version) string {
 	return fmt.Sprintf("release-%d.%d", soVersion.Major, soVersion.Minor)
 }
+
+func IncrementBranchName(branch string) string {
+	var major, minor int
+	n, err := fmt.Sscanf(branch, "release-%d.%d", &major, &minor)
+	if err != nil && n != 2 {
+		panic(fmt.Errorf("failed to parse branch name %q: err %v or unexpected format", branch, err))
+	}
+	return fmt.Sprintf("release-%d.%d", major, minor+1)
+}

--- a/pkg/soversion/version_test.go
+++ b/pkg/soversion/version_test.go
@@ -70,3 +70,23 @@ func TestToUpstreamVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestIncrementBranchName(t *testing.T) {
+	tests := []struct {
+		soVersion string
+		want      string
+	}{
+		{
+			soVersion: "release-1.34",
+			want:      "release-1.35",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q -> %q", tt.soVersion, tt.want), func(t *testing.T) {
+			if got := IncrementBranchName(tt.soVersion); got != tt.want {
+				t.Errorf("ToUpstreamVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Fix SO branch discovery by adding "future branches" when the non-existing configured one is created/available
- Remove Update action specifial casing for SO and skip non existing branches
- Run `make discover-branches`
- Add image overrides for SO main

This will also enable more special casing removal in the future.