### PR TITLE
Place ReleasePlanAdmissions on same level as applications

### DIFF
--- a/cmd/konflux-apply/main.go
+++ b/cmd/konflux-apply/main.go
@@ -8,6 +8,8 @@ import (
 	"os/signal"
 	"path/filepath"
 
+	"github.com/openshift-knative/hack/pkg/konfluxgen"
+
 	"github.com/openshift-knative/hack/pkg/konfluxapply"
 )
 
@@ -17,7 +19,7 @@ func main() {
 	defer cancel()
 
 	inputConfig := flag.String("config", filepath.Join("config"), "Specify repositories config")
-	konfluxDir := flag.String("konflux-dir", ".konflux", "Konflux directory containing applications, components, etc")
+	konfluxDir := flag.String("konflux-dir", filepath.Join(".konflux", konfluxgen.ApplicationsDirectoryName), "Konflux directory containing applications, components, etc")
 	flag.Parse()
 
 	err := konfluxapply.Apply(ctx, konfluxapply.ApplyConfig{

--- a/cmd/konflux-apply/main.go
+++ b/cmd/konflux-apply/main.go
@@ -2,16 +2,11 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"flag"
 	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
-
-	"github.com/openshift-knative/hack/pkg/konfluxgen"
-
-	"github.com/openshift-knative/hack/pkg/util"
-	"github.com/spf13/pflag"
 
 	"github.com/openshift-knative/hack/pkg/konfluxapply"
 )
@@ -21,31 +16,13 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer cancel()
 
-	var (
-		inputConfig string
-		konfluxDir  string
-		excludes    []string
-	)
+	inputConfig := flag.String("config", filepath.Join("config"), "Specify repositories config")
+	konfluxDir := flag.String("konflux-dir", ".konflux", "Konflux directory containing applications, components, etc")
+	flag.Parse()
 
-	defaultExcludes := []string{
-		fmt.Sprintf(".*%s.*", konfluxgen.ReleasePlanAdmissionsDirectoryName),
-	}
-
-	pflag.StringVar(&inputConfig, "config", filepath.Join("config"), "Specify repositories config")
-	pflag.StringVar(&konfluxDir, "konflux-dir", ".konflux", "Konflux directory containing applications, components, etc")
-	pflag.StringArrayVar(&excludes, "exclude", defaultExcludes, "Regex patterns of files or directories to exclude from apply")
-
-	pflag.Parse()
-
-	excludeRegex, err := util.ToRegexp(excludes)
-	if err != nil {
-		log.Fatal("failed to parse excludes regex: ", err)
-	}
-
-	err = konfluxapply.Apply(ctx, konfluxapply.ApplyConfig{
-		InputConfigPath: inputConfig,
-		KonfluxDir:      konfluxDir,
-		ExcludePatterns: excludeRegex,
+	err := konfluxapply.Apply(ctx, konfluxapply.ApplyConfig{
+		InputConfigPath: *inputConfig,
+		KonfluxDir:      *konfluxDir,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/konfluxapply/konflux_apply.go
+++ b/pkg/konfluxapply/konflux_apply.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openshift-knative/hack/pkg/konfluxgen"
+
 	"github.com/openshift-knative/hack/pkg/prowgen"
 )
 
@@ -90,7 +92,7 @@ func apply(ctx context.Context, cfg ApplyConfig, config *prowgen.Config) error {
 				return fmt.Errorf("[%s] failed to stat Konflux directory %q for branch %q: %w", r.RepositoryDirectory(), cfg.KonfluxDir, bn, err)
 			}
 
-			if _, err := prowgen.Run(ctx, r, "oc", "apply", "-Rf", cfg.KonfluxDir); err != nil {
+			if _, err := prowgen.Run(ctx, r, "oc", "apply", "-Rf", filepath.Join(cfg.KonfluxDir, konfluxgen.ApplicationsDirectoryName)); err != nil {
 				return fmt.Errorf("[%s] failed to apply branch %q: %w", r.RepositoryDirectory(), bn, err)
 			}
 		}

--- a/pkg/konfluxapply/konflux_apply.go
+++ b/pkg/konfluxapply/konflux_apply.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/openshift-knative/hack/pkg/prowgen"
@@ -16,8 +15,8 @@ import (
 
 type ApplyConfig struct {
 	InputConfigPath string
-	ExcludePatterns []*regexp.Regexp
-	KonfluxDir      string // default: `.konflux`
+
+	KonfluxDir string // default: `.konflux`
 }
 
 func Apply(ctx context.Context, cfg ApplyConfig) error {
@@ -84,39 +83,14 @@ func apply(ctx context.Context, cfg ApplyConfig, config *prowgen.Config) error {
 				continue
 			}
 
-			repoKonfluxDir := filepath.Join(r.RepositoryDirectory(), cfg.KonfluxDir)
-			if _, err := os.Stat(repoKonfluxDir); err != nil {
+			if _, err := os.Stat(filepath.Join(r.RepositoryDirectory(), cfg.KonfluxDir)); err != nil {
 				if errors.Is(err, os.ErrNotExist) {
 					continue // Skip repositories without Konflux components directory
 				}
 				return fmt.Errorf("[%s] failed to stat Konflux directory %q for branch %q: %w", r.RepositoryDirectory(), cfg.KonfluxDir, bn, err)
 			}
 
-			err := filepath.WalkDir(repoKonfluxDir, func(path string, d fs.DirEntry, err error) error {
-				if err != nil {
-					return fmt.Errorf("failed to walk directory %q: %w", path, err)
-				}
-
-				if d.IsDir() {
-					return nil
-				}
-
-				for _, exclude := range cfg.ExcludePatterns {
-					if exclude.MatchString(path) {
-						log.Printf("skipping excluded file %q\n", path)
-						return nil
-					}
-				}
-
-				inRepoPath := strings.TrimPrefix(path, r.RepositoryDirectory()+"/")
-				if _, err := prowgen.Run(ctx, r, "oc", "apply", "-f", inRepoPath); err != nil {
-					return fmt.Errorf("failed to apply konflux manifest %q: %w", path, err)
-				}
-
-				return nil
-			})
-
-			if err != nil {
+			if _, err := prowgen.Run(ctx, r, "oc", "apply", "-Rf", cfg.KonfluxDir); err != nil {
 				return fmt.Errorf("[%s] failed to apply branch %q: %w", r.RepositoryDirectory(), bn, err)
 			}
 		}

--- a/pkg/konfluxapply/konflux_apply.go
+++ b/pkg/konfluxapply/konflux_apply.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openshift-knative/hack/pkg/konfluxgen"
-
 	"github.com/openshift-knative/hack/pkg/prowgen"
 )
 
@@ -92,7 +90,7 @@ func apply(ctx context.Context, cfg ApplyConfig, config *prowgen.Config) error {
 				return fmt.Errorf("[%s] failed to stat Konflux directory %q for branch %q: %w", r.RepositoryDirectory(), cfg.KonfluxDir, bn, err)
 			}
 
-			if _, err := prowgen.Run(ctx, r, "oc", "apply", "-Rf", filepath.Join(cfg.KonfluxDir, konfluxgen.ApplicationsDirectoryName)); err != nil {
+			if _, err := prowgen.Run(ctx, r, "oc", "apply", "-Rf", cfg.KonfluxDir); err != nil {
 				return fmt.Errorf("[%s] failed to apply branch %q: %w", r.RepositoryDirectory(), bn, err)
 			}
 		}

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -693,7 +693,7 @@ func GenerateReleasePlanAdmission(csvPath string, resourceOutputPath string, app
 		return fmt.Errorf("failed to load ClusterServiceVersion: %w", err)
 	}
 
-	outputDir := filepath.Join(resourceOutputPath, "applications", Truncate(Sanitize(appName)), "releaseplanadmission")
+	outputDir := filepath.Join(resourceOutputPath, "releaseplanadmissions")
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
 		return fmt.Errorf("failed to create release plan admissions directory: %w", err)
 	}

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -24,6 +24,10 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
+const (
+	ApplicationsDirectoryName = "applications"
+)
+
 //go:embed application.template.yaml
 var ApplicationTemplate embed.FS
 
@@ -300,7 +304,7 @@ func Generate(cfg Config) error {
 		for componentKey, config := range components {
 			buf := &bytes.Buffer{}
 
-			appPath := filepath.Join(cfg.ResourcesOutputPath, "applications", appKey, fmt.Sprintf("%s.yaml", appKey))
+			appPath := filepath.Join(cfg.ResourcesOutputPath, ApplicationsDirectoryName, appKey, fmt.Sprintf("%s.yaml", appKey))
 			if err := os.MkdirAll(filepath.Dir(appPath), 0777); err != nil {
 				return fmt.Errorf("failed to create directory for %q: %w", appPath, err)
 			}
@@ -314,7 +318,7 @@ func Generate(cfg Config) error {
 
 			buf.Reset()
 
-			componentPath := filepath.Join(cfg.ResourcesOutputPath, "applications", appKey, "components", fmt.Sprintf("%s.yaml", componentKey))
+			componentPath := filepath.Join(cfg.ResourcesOutputPath, ApplicationsDirectoryName, appKey, "components", fmt.Sprintf("%s.yaml", componentKey))
 			if err := os.MkdirAll(filepath.Dir(componentPath), 0777); err != nil {
 				return fmt.Errorf("failed to create directory for %q: %w", componentPath, err)
 			}
@@ -328,7 +332,7 @@ func Generate(cfg Config) error {
 
 			buf.Reset()
 
-			imageRepositoryPath := filepath.Join(cfg.ResourcesOutputPath, "applications", appKey, "components", "imagerepositories", fmt.Sprintf("%s.yaml", componentKey))
+			imageRepositoryPath := filepath.Join(cfg.ResourcesOutputPath, ApplicationsDirectoryName, appKey, "components", "imagerepositories", fmt.Sprintf("%s.yaml", componentKey))
 			if err := os.MkdirAll(filepath.Dir(imageRepositoryPath), 0777); err != nil {
 				return fmt.Errorf("failed to create directory for %q: %w", imageRepositoryPath, err)
 			}
@@ -365,7 +369,7 @@ func Generate(cfg Config) error {
 
 			buf.Reset()
 
-			ecTestPath := filepath.Join(cfg.ResourcesOutputPath, "applications", appKey, "tests", "ec-test.yaml")
+			ecTestPath := filepath.Join(cfg.ResourcesOutputPath, ApplicationsDirectoryName, appKey, "tests", "ec-test.yaml")
 			if err := os.MkdirAll(filepath.Dir(ecTestPath), 0777); err != nil {
 				return fmt.Errorf("failed to create directory for %q: %w", appPath, err)
 			}

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -24,10 +24,6 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
-const (
-	ReleasePlanAdmissionsDirectoryName = "releaseplanadmissions"
-)
-
 //go:embed application.template.yaml
 var ApplicationTemplate embed.FS
 
@@ -697,7 +693,7 @@ func GenerateReleasePlanAdmission(csvPath string, resourceOutputPath string, app
 		return fmt.Errorf("failed to load ClusterServiceVersion: %w", err)
 	}
 
-	outputDir := filepath.Join(resourceOutputPath, "applications", Truncate(Sanitize(appName)), ReleasePlanAdmissionsDirectoryName)
+	outputDir := filepath.Join(resourceOutputPath, "applications", Truncate(Sanitize(appName)), "releaseplanadmission")
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
 		return fmt.Errorf("failed to create release plan admissions directory: %w", err)
 	}


### PR DESCRIPTION
Placing the RPAs under `.konflux/releaseplanadmissions` and auto-apply only manifests under `.konflux/applications` to simplify auto-apply logic again.