### PR TITLE
Add serverless-index to default excludeImages of SO

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -5,8 +5,6 @@ config:
         enabled: true
         excludes:
         - .*rosa.*
-        excludesImages:
-        - .*serverless-index.*
         imageOverrides:
         - name: GO_BUILDER
           pullSpec: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.22
@@ -23,8 +21,6 @@ config:
         enabled: true
         excludes:
         - .*rosa.*
-        excludesImages:
-        - .*serverless-index.*
         imageOverrides:
         - name: GO_BUILDER
           pullSpec: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.22

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -315,6 +315,7 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 			cfg.ExcludesImages = []string{
 				".*operator-src.*",
 				".*source.*",
+				".*serverless-index.*",
 			}
 		}
 


### PR DESCRIPTION
Add serverless-index to default excludes, to not override default list (which includes for example the `source` images)