### PR TITLE
Add ReleasePlanAdmission for FBC apps

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -801,7 +801,7 @@ func GenerateComponentReleasePlanAdmission(csvPath string, resourceOutputPath st
 	return nil
 }
 
-func executeFBCReleasePlanAdmissionTemplate(data rpaFBCData, outputFilePath string) interface{} {
+func executeFBCReleasePlanAdmissionTemplate(data rpaFBCData, outputFilePath string) error {
 	funcs := template.FuncMap{
 		"sanitize": Sanitize,
 		"truncate": Truncate,

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	ApplicationsDirectoryName = "applications"
+	ApplicationsDirectoryName          = "applications"
+	ReleasePlanAdmissionsDirectoryName = "releaseplanadmissions"
 )
 
 //go:embed application.template.yaml
@@ -722,7 +723,7 @@ type rpaFBCData struct {
 }
 
 func GenerateFBCReleasePlanAdmission(applications []string, resourceOutputPath string, appName string, soVersion string) error {
-	outputDir := filepath.Join(resourceOutputPath, "releaseplanadmissions")
+	outputDir := filepath.Join(resourceOutputPath, ReleasePlanAdmissionsDirectoryName)
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
 		return fmt.Errorf("failed to create release plan admissions directory: %w", err)
 	}
@@ -766,7 +767,7 @@ func GenerateComponentReleasePlanAdmission(csvPath string, resourceOutputPath st
 	}
 	soVersion := csv.Spec.Version
 
-	outputDir := filepath.Join(resourceOutputPath, "releaseplanadmissions")
+	outputDir := filepath.Join(resourceOutputPath, ReleasePlanAdmissionsDirectoryName)
 	if err := os.MkdirAll(outputDir, 0777); err != nil {
 		return fmt.Errorf("failed to create release plan admissions directory: %w", err)
 	}

--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlanAdmission
 metadata:
-  name: {{{ truncate ( sanitize .ApplicationName ) }}}-{{{ truncate ( sanitize .Version ) }}}
+  name: {{{ truncate ( sanitize .Name ) }}}
   namespace: rhtap-releng-tenant
 spec:
   applications: [{{{ truncate ( sanitize .ApplicationName ) }}}]

--- a/pkg/konfluxgen/releaseplanadmission-fbc.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-fbc.template.yaml
@@ -1,0 +1,36 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: {{{ truncate ( sanitize .Name ) }}}
+  namespace: rhtap-releng-tenant
+spec:
+  applications:
+  {{{- range .Applications }}}
+    - {{{ truncate ( sanitize . ) }}}
+  {{{- end}}}
+  origin: ocp-serverless-tenant
+  policy: fbc-standard
+  data:
+    fbc:
+      fromIndex: "{{{ .FromIndex }}}"
+      targetIndex: "{{{ .TargetIndex }}}"
+      publishingCredentials: "{{{ .PublishingCredentials }}}"
+      requestTimeoutSeconds: 1500
+      buildTimeoutSeconds: 1500
+      allowedPackages: [serverless-operator]
+    sign:
+      configMapName: hacbs-signing-pipeline-config-redhatrelease2
+  pipeline:
+    pipelineRef:
+      resolver: git
+      params:
+        - name: url
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: revision
+          value: production
+        - name: pathInRepo
+          value: "pipelines/fbc-release/fbc-release.yaml"
+    serviceAccountName: {{{ .PipelineSA }}}
+    timeouts:
+      pipeline: "4h0m0s"
+


### PR DESCRIPTION
Adds the RPAs for the FBC apps.
Look for example like 
```
apiVersion: appstudio.redhat.com/v1alpha1
kind: ReleasePlanAdmission
metadata:
  name: serverless-operator-135-1350-fbc-prod
  namespace: rhtap-releng-tenant
spec:
  applications:
    - serverless-operator-135-fbc-413
    - serverless-operator-135-fbc-414
    - serverless-operator-135-fbc-415
    - serverless-operator-135-fbc-416
    - serverless-operator-135-fbc-417
  origin: ocp-serverless-tenant
  policy: fbc-standard
  data:
    fbc:
      fromIndex: "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:{{ OCP_VERSION }}"
      targetIndex: "quay.io/redhat/redhat----redhat-operator-index:{{ OCP_VERSION }}"
      publishingCredentials: "fbc-production-publishing-credentials"
      requestTimeoutSeconds: 1500
      buildTimeoutSeconds: 1500
      allowedPackages: [serverless-operator]
    sign:
      configMapName: hacbs-signing-pipeline-config-redhatrelease2
  pipeline:
    pipelineRef:
      resolver: git
      params:
        - name: url
          value: "https://github.com/konflux-ci/release-service-catalog.git"
        - name: revision
          value: production
        - name: pathInRepo
          value: "pipelines/fbc-release/fbc-release.yaml"
    serviceAccountName: release-index-image-prod
    timeouts:
      pipeline: "4h0m0s"
```