### PR TITLE
Add pipeline, pyxis and sign config to component RPA

### DIFF
--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -15,8 +15,26 @@ spec:
           repository: {{{ $component.ImageRepository }}}
           pushSourceContainer: true
       {{{- end }}}
+    pyxis:
+      secret: {{{ .PyxisSecret }}}
+      server: {{{ .PyxisServer }}}
+    sign:
+      configMapName: "hacbs-signing-pipeline-config-redhatrelease2"
     defaults:
       tags:
         - "{{ git_sha }}"
         - "{{ git_short_sha }}"
-        - "{{{ .Version }}}"
+        - "{{{ .SOVersion }}}"
+  pipeline:
+    pipelineRef:
+      resolver: git
+      params:
+        - name: url
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: revision
+          value: production
+        - name: pathInRepo
+          value: "pipelines/rh-advisories/rh-advisories.yaml"
+    serviceAccountName: {{{ .PipelineSA }}}
+    timeouts:
+      pipeline: "4h0m0s"


### PR DESCRIPTION
Adding the pyxis, sign and pipeline options to the component RPA:

Output for example:
```
apiVersion: appstudio.redhat.com/v1alpha1
kind: ReleasePlanAdmission
metadata:
  name: serverless-operator-135-1350-prod
  namespace: rhtap-releng-tenant
spec:
  applications: [serverless-operator-135]
  origin: ocp-serverless-tenant
  policy: registry-standard
  data:
    mapping:
      components:
        - name: serverless-openshift-kn-operator-135
          repository: registry.redhat.io/openshift-serverless-1/serverless-openshift-kn-operator
          pushSourceContainer: true
        ...
    pyxis:
      secret: pyxis-prod-secret
      server: production
    sign:
      configMapName: "hacbs-signing-pipeline-config-redhatrelease2"
   ...
  pipeline:
    pipelineRef:
      resolver: git
      params:
        - name: url
          value: "https://github.com/konflux-ci/release-service-catalog.git"
        - name: revision
          value: production
        - name: pathInRepo
          value: "pipelines/rh-advisories/rh-advisories.yaml"
    serviceAccountName: release-registry-prod
    timeouts:
      pipeline: "4h0m0s"
```