### PR TITLE
Use path-context param in pipeline when specified

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -26,6 +26,10 @@ spec:
     - name: dockerfile
       value: {{{ .ProjectDirectoryImageBuildStepConfiguration.ProjectDirectoryImageBuildInputs.DockerfilePath }}}
     {{{- end }}}
+    {{{- if .ProjectDirectoryImageBuildStepConfiguration.ProjectDirectoryImageBuildInputs.ContextDir }}}
+    - name: path-context
+      value: {{{ .ProjectDirectoryImageBuildStepConfiguration.ProjectDirectoryImageBuildInputs.ContextDir }}}
+    {{{- end }}}
     {{{- if gt (len .BuildArgs) 0 }}}
     - name: build-args
       value:


### PR DESCRIPTION
In case the build context is not the repo root, we need to set it in the pipeline via the `patch-context` (e.g. for the FBC components).

Addresses https://github.com/openshift-knative/serverless-operator/pull/2937#pullrequestreview-2369523887