### PR TITLE
Remove workspace pvc for container builds except FBC builds

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -73,6 +73,7 @@ spec:
     name: {{{ .Pipeline }}}
   taskRunTemplate: {}
   workspaces:
+    {{{- if eq .Pipeline "fbc-builder" }}}
     - name: workspace
       volumeClaimTemplate:
         metadata:
@@ -84,6 +85,7 @@ spec:
             requests:
               storage: 1Gi
         status: {}
+    {{{- end }}}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
Resolves the PVC errors.

PVC is not needed for TA pipelines 