### PR TITLE
Only build images for x86 on PRs

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -46,6 +46,10 @@ spec:
       value: 5d
     - name: output-image
       value: quay.io/redhat-user-workloads/ocp-serverless-tenant/{{{ truncate ( sanitize .ApplicationName ) }}}/{{{ truncate ( sanitize .ProjectDirectoryImageBuildStepConfiguration.To ) }}}:on-pr-{{revision}}
+    {{{- if ne .Pipeline "fbc-builder" }}}
+    - name: build-platforms
+      value: linux/x86_64
+    {{{- end }}}
     {{{- else }}}
     - name: output-image
       value: quay.io/redhat-user-workloads/ocp-serverless-tenant/{{{ truncate ( sanitize .ApplicationName ) }}}/{{{ truncate ( sanitize .ProjectDirectoryImageBuildStepConfiguration.To ) }}}:{{revision}}


### PR DESCRIPTION
Multi-platform builds are slow and on PRs don't make a lot of sense.