### PR TITLE
Automatically create ReleasePlans

### DIFF
--- a/pkg/konfluxgen/releaseplan.template.yaml
+++ b/pkg/konfluxgen/releaseplan.template.yaml
@@ -1,0 +1,26 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: '{{{ .AutoRelease }}}'
+    release.appstudio.openshift.io/releasePlanAdmission: '{{{ truncate ( sanitize .ReleasePlanAdmissionName ) }}}'
+  name: {{{ truncate ( sanitize .Name ) }}}
+spec:
+  releaseNotes:
+    type: "Product Enhancement Advisory"
+    synopsis: "Red Hat OpenShift Serverless Release"
+    topic: |
+      The {{{ .SOVersion }}} GA release of Red Hat OpenShift Serverless Operator.
+      For more details see [product documentation](https://docs.redhat.com/documentation/red_hat_openshift_serverless).
+    description: "The {{{ .SOVersion }}} release of Red Hat OpenShift Serverless Operator."
+    solution: |
+      The Red Hat OpenShift Serverless Operator provides a collection of APIs that
+      enables containers, microservices and functions to run "serverless".
+      Serverless applications can scale up and down (to zero) on demand and be triggered by a
+      number of event sources. OpenShift Serverless integrates with a number of
+      platform services, such as Monitoring and it is based on the open
+      source project Knative.
+    references:
+      - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
+  application: {{{ truncate ( sanitize .ApplicationName ) }}}
+  target: rhtap-releng-tenant

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -412,8 +412,12 @@ func generateFBCApplications(soMetadata *project.Metadata, openshiftRelease Repo
 		fbcApps = append(fbcApps, fbcAppName)
 	}
 
-	if err := konfluxgen.GenerateFBCReleasePlanAdmission(fbcApps, resourceOutputPath, fmt.Sprintf("serverless-operator %s", release), soMetadata.Project.Version); err != nil {
+	appName := fmt.Sprintf("serverless-operator %s", release)
+	if err := konfluxgen.GenerateFBCReleasePlanAdmission(fbcApps, resourceOutputPath, appName, soMetadata.Project.Version); err != nil {
 		return fmt.Errorf("failed to generate ReleasePlanAdmissions for FBC of %s (%s): %w", r.RepositoryDirectory(), branch, err)
+	}
+	if err := konfluxgen.GenerateReleasePlans(fbcApps, resourceOutputPath, appName, soMetadata.Project.Version); err != nil {
+		return fmt.Errorf("failed to generate ReleasePlan for FBC of %s (%s): %w", r.RepositoryDirectory(), branch, err)
 	}
 
 	return nil


### PR DESCRIPTION
- Use `auto-release` only for stage environments

Example prod RP for components app:
```yaml
apiVersion: appstudio.redhat.com/v1alpha1
kind: ReleasePlan
metadata:
  labels:
    release.appstudio.openshift.io/auto-release: 'false'
    release.appstudio.openshift.io/releasePlanAdmission: 'serverless-operator-135-1350-prod'
  name: serverless-operator-135-1350-prod
spec:
  releaseNotes:
    type: "Product Enhancement Advisory"
    synopsis: "Red Hat OpenShift Serverless Release"
    topic: |
      The 1.35.0 GA release of Red Hat OpenShift Serverless Operator.
      For more details see [product documentation](https://docs.redhat.com/documentation/red_hat_openshift_serverless).
    description: "The 1.35.0 release of Red Hat OpenShift Serverless Operator."
    solution: |
      The Red Hat OpenShift Serverless Operator provides a collection of APIs that
      enables containers, microservices and functions to run "serverless".
      Serverless applications can scale up and down (to zero) on demand and be triggered by a
      number of event sources. OpenShift Serverless integrates with a number of
      platform services, such as Monitoring and it is based on the open
      source project Knative.
    references:
      - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
  application: serverless-operator-135
  target: rhtap-releng-tenant
```

Example stage RP for components:

```yaml
apiVersion: appstudio.redhat.com/v1alpha1
kind: ReleasePlan
metadata:
  labels:
    release.appstudio.openshift.io/auto-release: 'true'
    release.appstudio.openshift.io/releasePlanAdmission: 'serverless-operator-135-1350-stage'
  name: serverless-operator-135-1350-stage
spec:
  releaseNotes:
    type: "Product Enhancement Advisory"
    synopsis: "Red Hat OpenShift Serverless Release"
    topic: |
      The 1.35.0 GA release of Red Hat OpenShift Serverless Operator.
      For more details see [product documentation](https://docs.redhat.com/documentation/red_hat_openshift_serverless).
    description: "The 1.35.0 release of Red Hat OpenShift Serverless Operator."
    solution: |
      The Red Hat OpenShift Serverless Operator provides a collection of APIs that
      enables containers, microservices and functions to run "serverless".
      Serverless applications can scale up and down (to zero) on demand and be triggered by a
      number of event sources. OpenShift Serverless integrates with a number of
      platform services, such as Monitoring and it is based on the open
      source project Knative.
    references:
      - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
  application: serverless-operator-135
  target: rhtap-releng-tenant
```

---

Example prod RP for FBC app:
```yaml
apiVersion: appstudio.redhat.com/v1alpha1
kind: ReleasePlan
metadata:
  labels:
    release.appstudio.openshift.io/auto-release: 'false'
    release.appstudio.openshift.io/releasePlanAdmission: 'serverless-operator-135-1350-fbc-prod'
  name: serverless-operator-135-fbc-417-1350-prod
spec:
  releaseNotes:
    type: "Product Enhancement Advisory"
    synopsis: "Red Hat OpenShift Serverless Release"
    topic: |
      The 1.35.0 GA release of Red Hat OpenShift Serverless Operator.
      For more details see [product documentation](https://docs.redhat.com/documentation/red_hat_openshift_serverless).
    description: "The 1.35.0 release of Red Hat OpenShift Serverless Operator."
    solution: |
      The Red Hat OpenShift Serverless Operator provides a collection of APIs that
      enables containers, microservices and functions to run "serverless".
      Serverless applications can scale up and down (to zero) on demand and be triggered by a
      number of event sources. OpenShift Serverless integrates with a number of
      platform services, such as Monitoring and it is based on the open
      source project Knative.
    references:
      - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
  application: serverless-operator-135-fbc-417
  target: rhtap-releng-tenant
```

Example stage RP for FBC app:
```yaml
apiVersion: appstudio.redhat.com/v1alpha1
kind: ReleasePlan
metadata:
  labels:
    release.appstudio.openshift.io/auto-release: 'true'
    release.appstudio.openshift.io/releasePlanAdmission: 'serverless-operator-135-1350-fbc-stage'
  name: serverless-operator-135-fbc-417-1350-stage
spec:
  releaseNotes:
    type: "Product Enhancement Advisory"
    synopsis: "Red Hat OpenShift Serverless Release"
    topic: |
      The 1.35.0 GA release of Red Hat OpenShift Serverless Operator.
      For more details see [product documentation](https://docs.redhat.com/documentation/red_hat_openshift_serverless).
    description: "The 1.35.0 release of Red Hat OpenShift Serverless Operator."
    solution: |
      The Red Hat OpenShift Serverless Operator provides a collection of APIs that
      enables containers, microservices and functions to run "serverless".
      Serverless applications can scale up and down (to zero) on demand and be triggered by a
      number of event sources. OpenShift Serverless integrates with a number of
      platform services, such as Monitoring and it is based on the open
      source project Knative.
    references:
      - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
  application: serverless-operator-135-fbc-417
  target: rhtap-releng-tenant
```