### PR TITLE
Remove unsupported releases

### DIFF
--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -6,19 +6,6 @@ config:
         version: "4.16"
       - onDemand: true
         version: "4.13"
-    release-v1.10:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-    release-v1.11:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-      - onDemand: true
-        skipCron: true
-        version: "4.12"
     release-v1.12:
       openShiftVersions:
       - useClusterPool: true

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -12,18 +12,6 @@ config:
         version: "4.13"
       skipDockerFilesMatches:
       - .*hermetic.*
-    release-v1.10:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-    release-v1.11:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-      - onDemand: true
-        version: "4.12"
     release-v1.12:
       openShiftVersions:
       - useClusterPool: true

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -5,19 +5,6 @@ config:
       - useClusterPool: true
         version: "4.16"
       - version: "4.13"
-    release-v1.10:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-    release-v1.11:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-      - onDemand: true
-        skipCron: true
-        version: "4.12"
     release-v1.12:
       openShiftVersions:
       - useClusterPool: true

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -1,13 +1,5 @@
 config:
   branches:
-    release-v1.11:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-      - onDemand: true
-        skipCron: true
-        version: "4.12"
     release-v1.12:
       openShiftVersions:
       - useClusterPool: true

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -1,13 +1,5 @@
 config:
   branches:
-    release-v1.11:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-      - onDemand: true
-        skipCron: true
-        version: "4.12"
     release-v1.12:
       openShiftVersions:
       - useClusterPool: true

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -11,14 +11,6 @@ config:
       skipE2EMatches:
       - perf-tests$
       - .*e2e-tls$
-    release-v1.11:
-      openShiftVersions:
-      - skipCron: true
-        useClusterPool: true
-        version: "4.16"
-      - onDemand: true
-        skipCron: true
-        version: "4.12"
     release-v1.12:
       openShiftVersions:
       - useClusterPool: true


### PR DESCRIPTION
1.32 ends support Oct 20 https://access.redhat.com/product-life-cycles?product=Red%20Hat%20OpenShift%20Serverless