### PR TITLE
Use correct repo for bundle in RPA

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -120,7 +120,8 @@ type PrefetchDeps struct {
 
 type ComponentReleasePlanConfig struct {
 	ClusterServiceVersionPath string
-	BundleName                string
+	BundleComponentName       string
+	BundleImageRepoName       string
 }
 
 func (pd *PrefetchDeps) WithRPMs() {
@@ -457,7 +458,7 @@ func Generate(cfg Config) error {
 			return fmt.Errorf("failed to load ClusterServiceVersion: %w", err)
 		}
 
-		if err := GenerateComponentReleasePlanAdmission(csv, cfg.ComponentReleasePlanConfig.BundleName, cfg.ResourcesOutputPath, cfg.ApplicationName); err != nil {
+		if err := GenerateComponentReleasePlanAdmission(csv, cfg.ComponentReleasePlanConfig.BundleComponentName, cfg.ComponentReleasePlanConfig.BundleImageRepoName, cfg.ResourcesOutputPath, cfg.ApplicationName); err != nil {
 			return fmt.Errorf("failed to generate ReleasePlanAdmission: %w", err)
 		}
 
@@ -820,7 +821,7 @@ type rpaComponentData struct {
 	PipelineSA  string
 }
 
-func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterServiceVersion, bundleName string, resourceOutputPath string, appName string) error {
+func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterServiceVersion, bundleName string, bundleRepoName string, resourceOutputPath string, appName string) error {
 	soVersion := csv.Spec.Version
 
 	outputDir := filepath.Join(resourceOutputPath, ReleasePlanAdmissionsDirectoryName)
@@ -836,7 +837,7 @@ func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterService
 	// append bundle component, as this is not part of the CSV
 	components = append(components, ComponentImageRepoRef{
 		ComponentName:   fmt.Sprintf("%s-%d%d", bundleName, soVersion.Major, soVersion.Minor),
-		ImageRepository: fmt.Sprintf("%s/%s", prodRegistry, bundleName),
+		ImageRepository: fmt.Sprintf("%s/%s", prodRegistry, bundleRepoName),
 	})
 
 	rpaName := releasePlanAdmissionName(appName, soVersion.String(), ProdEnv)

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -313,7 +313,8 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 			},
 			ComponentReleasePlanConfig: &konfluxgen.ComponentReleasePlanConfig{
 				ClusterServiceVersionPath: filepath.Join(r.RepositoryDirectory(), "olm-catalog", "serverless-operator", "manifests", "serverless-operator.clusterserviceversion.yaml"),
-				BundleName:                "serverless-bundle",
+				BundleComponentName:       "serverless-bundle",
+				BundleImageRepoName:       "serverless-operator-bundle",
 			},
 			// Preserve the version tag as first tag in any instance since SO, when bumping the patch version
 			// will change it before merging the PR.


### PR DESCRIPTION
Follow up on https://redhat-internal.slack.com/archives/CKR568L8G/p1729684088850349 and use image repo `serverless-operator-bundle` for `serverless-bundle` component.