### PR TITLE
Add `standing-attribution` label in RP to inherit author to the release.

### DIFF
--- a/pkg/konfluxgen/releaseplan.template.yaml
+++ b/pkg/konfluxgen/releaseplan.template.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     release.appstudio.openshift.io/auto-release: '{{{ .AutoRelease }}}'
     release.appstudio.openshift.io/releasePlanAdmission: '{{{ truncate ( sanitize .ReleasePlanAdmissionName ) }}}'
+    release.appstudio.openshift.io/standing-attribution: 'true'
   name: {{{ truncate ( sanitize .Name ) }}}
 spec:
   releaseNotes:


### PR DESCRIPTION
Current releases fail with 
```
status:
  automated: true
  completionTime: "2024-10-25T06:51:01Z"
  conditions:
  - lastTransitionTime: "2024-10-25T06:51:01Z"
    message: Release validation failed
    reason: Failed
    status: "False"
    type: Released
  - lastTransitionTime: "2024-10-25T06:51:01Z"
    message: no author in the ReleasePlan found for automated release
    reason: Failed
    status: "False"
    type: Validated
```

Adding the `release.appstudio.openshift.io/standing-attribution` label to use the user creating the RP as the author of the release. See https://konflux.pages.redhat.com/docs/users/releasing/releasing-products.html#authoring-releases