### PR TITLE
Update Serving CI config for 1.16

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -382,6 +382,30 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
+        name: '[net-istio - release-v1.16] Create Konflux PR'
+        run: |
+          set -x
+          repo="net-istio"
+          branch="sync-konflux-release-v1.16"
+          target_branch="release-v1.16"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
+      - env:
+          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[net-kourier - release-v1.15] Create Konflux PR'
         run: |
           set -x
@@ -406,12 +430,60 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
+        name: '[net-kourier - release-v1.16] Create Konflux PR'
+        run: |
+          set -x
+          repo="net-kourier"
+          branch="sync-konflux-release-v1.16"
+          target_branch="release-v1.16"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
+      - env:
+          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[serving - release-v1.15] Create Konflux PR'
         run: |
           set -x
           repo="serving"
           branch="sync-konflux-release-v1.15"
           target_branch="release-v1.15"
+          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
+          remote_exists=$(git ls-remote --heads fork "$branch")
+          if [ -z "$remote_exists" ]; then
+            # remote doesn't exist.
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
+          fi
+          git fetch fork "$branch"
+          if git diff --quiet "fork/$branch" "$branch"; then
+            echo "Branches are identical. No need to force push."
+          else
+            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
+          fi
+          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Add Konflux configurations" --body "Add Konflux components and pipelines" || true
+        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving
+      - env:
+          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
+        name: '[serving - release-v1.16] Create Konflux PR'
+        run: |
+          set -x
+          repo="serving"
+          branch="sync-konflux-release-v1.16"
+          target_branch="release-v1.16"
           git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
           remote_exists=$(git ls-remote --heads fork "$branch")
           if [ -z "$remote_exists" ]; then

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -20,6 +20,14 @@ config:
         version: "4.16"
       - onDemand: true
         version: "4.13"
+    release-v1.16:
+      konflux:
+        enabled: true
+      openShiftVersions:
+      - useClusterPool: true
+        version: "4.16"
+      - onDemand: true
+        version: "4.13"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -20,6 +20,14 @@ config:
         version: "4.16"
       - onDemand: true
         version: "4.13"
+    release-v1.16:
+      konflux:
+        enabled: true
+      openShiftVersions:
+      - useClusterPool: true
+        version: "4.16"
+      - onDemand: true
+        version: "4.13"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -33,6 +33,14 @@ config:
         version: "4.16"
       - onDemand: true
         version: "4.13"
+    release-v1.16:
+      konflux:
+        enabled: true
+      openShiftVersions:
+      - useClusterPool: true
+        version: "4.16"
+      - onDemand: true
+        version: "4.13"
 repositories:
 - dockerfiles:
     matches:


### PR DESCRIPTION
- Similar to https://github.com/openshift-knative/hack/pull/192
- 4.12 is EOL Jan/17/2025 so keeping it for now with 1.12.
- We don't have a 4.17 cluster-pool, probably we should?