### PR TITLE
Remove .additional_packages var from func-util Dockerfile generator

### DIFF
--- a/cmd/generate/dockerfile-templates/FuncUtilDockerfile.template
+++ b/cmd/generate/dockerfile-templates/FuncUtilDockerfile.template
@@ -16,7 +16,10 @@ FROM $GO_RUNTIME
 
 ARG VERSION={{.version}}
 
-RUN microdnf install socat tar {{.additional_packages}}
+RUN microdnf install socat tar
+{{- range $c := .additional_instructions }}
+{{ $c }}
+{{- end }}
 
 COPY --from=builder /usr/bin/main {{.app_file}}
 


### PR DESCRIPTION
Fix Dockerfile generator for func-util, after `additional_packages` var has been removed in #387