### PR TITLE
Use build args in FBC pipeline too

### DIFF
--- a/pkg/konfluxgen/fbc-builder.yaml
+++ b/pkg/konfluxgen/fbc-builder.yaml
@@ -50,6 +50,10 @@ spec:
     - name: workspace
       workspace: workspace
   params:
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
   - default: "true"
     description: Build a source image.
     name: build-source-image
@@ -116,6 +120,42 @@ spec:
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
   tasks:
+  - name: build-container
+    params:
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: buildah
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:312d8292fd972fc8e8a7ba254b54c31dabf85df731ca33af6823c3f62505ce00
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
   - name: apply-tags
     params:
     - name: ADDITIONAL_TAGS
@@ -177,39 +217,6 @@ spec:
       workspace: workspace
     - name: basic-auth
       workspace: git-auth
-  - name: build-container
-    params:
-    - name: IMAGE
-      value: $(params.output-image)
-    - name: DOCKERFILE
-      value: $(params.dockerfile)
-    - name: CONTEXT
-      value: $(params.path-context)
-    - name: HERMETIC
-      value: $(params.hermetic)
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(params.image-expires-after)
-    - name: COMMIT_SHA
-      value: $(tasks.clone-repository.results.commit)
-    runAfter:
-    - clone-repository
-    taskRef:
-      params:
-      - name: name
-        value: buildah
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:b105a3bcc57274c6cb0884d915bc71935c9334d1a3571d83e1df8641f0268f8b
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(tasks.init.results.build)
-      operator: in
-      values:
-      - "true"
-    workspaces:
-    - name: source
-      workspace: workspace
   - name: build-image-index
     params:
     - name: IMAGE

--- a/pkg/konfluxgen/kustomize/kustomize-fbc-builder/kustomization.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-fbc-builder/kustomization.yaml
@@ -10,5 +10,8 @@ patches:
   - path: ../patch_source_image.patch.yaml
     target:
       kind: Pipeline
+  - path: ./patch_build_args.patch.yaml
+    target:
+      kind: Pipeline
 openapi:
   path: ../pipeline_schema.json

--- a/pkg/konfluxgen/kustomize/kustomize-fbc-builder/patch_build_args.patch.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-fbc-builder/patch_build_args.patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: docker-build
+spec:
+  params:
+    - name: build-args
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      type: array
+      default: []
+  tasks:
+    - name: build-container
+      params:
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])


### PR DESCRIPTION
We are getting a `Base image "registry.ci.openshift.org/origin/4.17" is from a disallowed registry` on the FBC applications:
![image](https://github.com/user-attachments/assets/b52005aa-74fb-4eb7-8889-7e8adbc79d1d)

This is, because we don't owerride the `ARG OPM_IMAGE=registry.ci.openshift.org/origin/4.17:operator-registry` arg in the index builds
