### PR TITLE
Use fbc-standard policy for FBC enterprise contract

### DIFF
--- a/pkg/konfluxgen/integration-test-scenario.template.yaml
+++ b/pkg/konfluxgen/integration-test-scenario.template.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   params: 
     - name: POLICY_CONFIGURATION
-      value: rhtap-releng-tenant/tmp-onboard-policy
+      value: {{{ .ECPolicyConfiguration }}}
     - name: TIMEOUT
       value: "45m0s"
   application: {{{ truncate ( sanitize .ApplicationName ) }}}

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -108,6 +108,8 @@ type Config struct {
 
 	ComponentReleasePlanConfig *ComponentReleasePlanConfig
 	AdditionalComponentConfigs []TemplateConfig
+
+	ECPolicyConfigName string
 }
 
 type PrefetchDeps struct {
@@ -322,6 +324,12 @@ func Generate(cfg Config) error {
 				r.Hermetic = "true"
 			} else {
 				r.Hermetic = "false"
+			}
+
+			if cfg.ECPolicyConfigName == "" {
+				r.ECPolicyConfiguration = "rhtap-releng-tenant/tmp-onboard-policy"
+			} else {
+				r.ECPolicyConfiguration = cfg.ECPolicyConfigName
 			}
 
 			applications[appKey][Truncate(Sanitize(cfg.ComponentNameFunc(c.ReleaseBuildConfiguration, ib)))] = r
@@ -558,7 +566,8 @@ type DockerfileApplicationConfig struct {
 
 	Hermetic string
 
-	DockerfilePath string
+	DockerfilePath        string
+	ECPolicyConfiguration string
 }
 
 type PipelineEvent string

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -413,6 +413,8 @@ func generateFBCApplications(soMetadata *project.Metadata, openshiftRelease Repo
 			// will change it before merging the PR.
 			// See `openshift-knative/serverless-operator/hack/generate/update-pipelines.sh` for more details.
 			Tags: []string{soMetadata.Project.Version},
+			// use fbc-standard enterprise contract policy for FBC applications
+			ECPolicyConfigName: "rhtap-releng-tenant/fbc-standard",
 		}
 
 		if err := konfluxgen.Generate(c); err != nil {


### PR DESCRIPTION
We should use the an EC Policy config for FBCs, when validating FBC apps:

![image](https://github.com/user-attachments/assets/8af35dff-2f8e-45e3-93b6-80302d0ade91)
