### PR TITLE
Bump cluster pool for Serverless >=1.35 to OCP 4.17

### DIFF
--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -14,14 +14,14 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.17"
       - onDemand: true
         version: "4.13"
     release-v1.16:
       konflux:
         enabled: true
       openShiftVersions:
-      - version: "4.15"
+      - version: "4.17"
       - onDemand: true
         version: "4.13"
 repositories:

--- a/config/client.yaml
+++ b/config/client.yaml
@@ -6,14 +6,14 @@ config:
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.16"
+        version: "4.17"
     release-v1.16:
       konflux:
         enabled: true
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.16"
+        version: "4.17"
 repositories:
 - canonicalGoRepository: github.com/knative/client
   dockerfiles: {}

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -3,7 +3,7 @@ config:
     release-next:
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
     release-v1.12:
@@ -23,7 +23,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
     release-v1.16:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -7,7 +7,7 @@ config:
         - .*eventing-kafka-broker-dispatcher
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
       skipDockerFilesMatches:
@@ -32,7 +32,7 @@ config:
         - .*eventing-kafka-broker-dispatcher
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
       skipDockerFilesMatches:
@@ -45,7 +45,7 @@ config:
         - .*eventing-kafka-broker-dispatcher
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
       skipDockerFilesMatches:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -3,7 +3,7 @@ config:
     release-next:
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
     release-v1.12:
@@ -23,7 +23,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
     release-v1.16:
@@ -31,7 +31,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
 repositories:

--- a/config/kn-plugin-event.yaml
+++ b/config/kn-plugin-event.yaml
@@ -5,18 +5,18 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
     release-1.16:
       konflux:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
     release-next:
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.16"
+        version: "4.17"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -4,21 +4,21 @@ config:
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.16"
+        version: "4.17"
     release-v1.15:
       konflux:
         enabled: true
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.16"
+        version: "4.17"
     release-v1.16:
       konflux:
         enabled: true
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.16"
+        version: "4.17"
     serverless-1.34:
       openShiftVersions:
       - skipCron: true

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -18,7 +18,7 @@ config:
       - cronForceKonfluxIndex: true
         generateCustomConfigs: true
         useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - cronForceKonfluxIndex: true
         onDemand: true
         version: "4.13"
@@ -39,7 +39,7 @@ config:
       openShiftVersions:
       - generateCustomConfigs: true
         useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
       prowgen:
@@ -173,18 +173,18 @@ repositories:
     releaseBuildConfiguration:
       base_images:
         hypershift-operator:
-          name: "4.16"
+          name: "4.17"
           namespace: ocp
           tag: hypershift-operator
         upi-installer:
-          name: "4.16"
+          name: "4.17"
           namespace: ocp
           tag: upi-installer
       releases:
         latest:
           integration:
             include_built_images: true
-            name: "4.16"
+            name: "4.17"
             namespace: ocp
       tests:
       - as: e2e-hypershift-continuous
@@ -244,7 +244,7 @@ repositories:
           cluster_profile: osd-ephemeral
           env:
             CLUSTER_DURATION: "10800"
-            CLUSTER_VERSION: "4.16"
+            CLUSTER_VERSION: "4.17"
             COMPUTE_NODES: "4"
           post:
           - chain: gather
@@ -303,7 +303,7 @@ repositories:
     releaseBuildConfiguration:
       base_images:
         upi-installer:
-          name: "4.16"
+          name: "4.17"
           namespace: ocp
           tag: upi-installer
       tests:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -17,7 +17,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
     release-v1.16:
@@ -25,7 +25,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
 repositories:

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -17,7 +17,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
     release-v1.16:
@@ -25,7 +25,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
 repositories:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -3,7 +3,7 @@ config:
     release-next:
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
       skipDockerFilesMatches:
@@ -30,7 +30,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
     release-v1.16:
@@ -38,7 +38,7 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.16"
+        version: "4.17"
       - onDemand: true
         version: "4.13"
 repositories:


### PR DESCRIPTION
Not touching settings for branches 1.34 and older.

/hold
Depends on https://github.com/openshift/release/pull/58495