### PR TITLE
Switch to fbc-stage policy for EC of FBC applications

### DIFF
--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -413,8 +413,9 @@ func generateFBCApplications(soMetadata *project.Metadata, openshiftRelease Repo
 			// will change it before merging the PR.
 			// See `openshift-knative/serverless-operator/hack/generate/update-pipelines.sh` for more details.
 			Tags: []string{soMetadata.Project.Version},
-			// use fbc-standard enterprise contract policy for FBC applications
-			ECPolicyConfigName: "rhtap-releng-tenant/fbc-standard",
+			// use fbc-stage enterprise contract policy for FBC applications
+			// we don't use fbc-standard, as fbc-stage excludes the fbc-related-image-check
+			ECPolicyConfigName: "rhtap-releng-tenant/fbc-stage",
 		}
 
 		if err := konfluxgen.Generate(c); err != nil {


### PR DESCRIPTION
Switch to [fbc-stage policy](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/common/product/EnterpriseContractPolicy/fbc-stage.yaml) as discussed, as this excludes the `fbc-related-image-check`, which fails as the image references in the bundle point to registry.redhat.io and don't exist at that point yet.