### PR TITLE
Add IntegrationTestScenarios for EC only in hack repo

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -110,6 +110,8 @@ type Config struct {
 	AdditionalComponentConfigs []TemplateConfig
 
 	ECPolicyConfigName string
+
+	CreateEnterpriseContractIntegrationTestSecenario bool
 }
 
 type PrefetchDeps struct {
@@ -410,16 +412,18 @@ func Generate(cfg Config) error {
 
 			buf.Reset()
 
-			ecTestPath := filepath.Join(cfg.ResourcesOutputPath, ApplicationsDirectoryName, appKey, "tests", "ec-test.yaml")
-			if err := os.MkdirAll(filepath.Dir(ecTestPath), 0777); err != nil {
-				return fmt.Errorf("failed to create directory for %q: %w", appPath, err)
-			}
+			if cfg.CreateEnterpriseContractIntegrationTestSecenario {
+				ecTestPath := filepath.Join(cfg.ResourcesOutputPath, ApplicationsDirectoryName, appKey, "tests", "ec-test.yaml")
+				if err := os.MkdirAll(filepath.Dir(ecTestPath), 0777); err != nil {
+					return fmt.Errorf("failed to create directory for %q: %w", appPath, err)
+				}
 
-			if err := enterpriseContractTestScenarioTemplate.Execute(buf, config); err != nil {
-				return fmt.Errorf("failed to execute template for EC test: %w", err)
-			}
-			if err := WriteFileReplacingNewerTaskImages(ecTestPath, buf.Bytes(), 0777); err != nil {
-				return fmt.Errorf("failed to write application file %q: %w", ecTestPath, err)
+				if err := enterpriseContractTestScenarioTemplate.Execute(buf, config); err != nil {
+					return fmt.Errorf("failed to execute template for EC test: %w", err)
+				}
+				if err := WriteFileReplacingNewerTaskImages(ecTestPath, buf.Bytes(), 0777); err != nil {
+					return fmt.Errorf("failed to write application file %q: %w", ecTestPath, err)
+				}
 			}
 
 			buf.Reset()

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -322,6 +322,7 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 			// See `openshift-knative/serverless-operator/hack/generate/update-pipelines.sh` for more details.
 			Tags:         []string{soMetadata.Project.Version},
 			PrefetchDeps: *prefetchDeps,
+			CreateEnterpriseContractIntegrationTestSecenario: true,
 		}
 		if len(cfg.ExcludesImages) == 0 {
 			cfg.ExcludesImages = []string{
@@ -456,6 +457,7 @@ func generateFBCApplications(soMetadata *project.Metadata, openshiftRelease Repo
 			// will change it before merging the PR.
 			// See `openshift-knative/serverless-operator/hack/generate/update-pipelines.sh` for more details.
 			Tags: []string{soMetadata.Project.Version},
+			CreateEnterpriseContractIntegrationTestSecenario: true,
 			// use fbc-stage enterprise contract policy for FBC applications
 			// we don't use fbc-standard, as fbc-stage excludes the fbc-related-image-check
 			ECPolicyConfigName: "rhtap-releng-tenant/fbc-stage",


### PR DESCRIPTION
As discussed we want to keep the EC tests only in hack repo