### PR TITLE
update must gather default base image

### DIFF
--- a/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
+++ b/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
@@ -6,7 +6,6 @@ FROM $MUSTGATHER AS mustgather
 FROM $RUNTIME
 
 COPY --from=mustgather /usr/bin/oc /usr/bin/oc
-COPY --from=mustgather /usr/bin/gather /usr/bin/gather_original
 
 # Copy all collection scripts to /usr/bin
 COPY must-gather/bin/* /usr/bin/

--- a/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
+++ b/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
@@ -1,12 +1,12 @@
 # DO NOT EDIT! Generated Dockerfile for {{.main}}.
 ARG MUSTGATHER={{.must_gather_base}}
 ARG RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
-FROM $MUSTGATHER AS builder
+FROM $MUSTGATHER AS mustgather
 
 FROM $RUNTIME
 
-COPY --from=builder /usr/bin/oc /usr/bin/oc
-COPY --from=builder /usr/bin/gather /usr/bin/gather_original
+COPY --from=mustgather /usr/bin/oc /usr/bin/oc
+COPY --from=mustgather /usr/bin/gather /usr/bin/gather_original
 
 # Copy all collection scripts to /usr/bin
 COPY must-gather/bin/* /usr/bin/

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -83,7 +83,6 @@ func main() {
 		dockerfilesSourceDir         string
 		projectFilePath              string
 		dockerfileImageBuilderFmt    string
-		mustGatherBuilderImageFmt    string
 		appFileFmt                   string
 		registryImageFmt             string
 		imagesFromRepositories       []string
@@ -113,7 +112,6 @@ func main() {
 	pflag.StringVar(&output, "output", filepath.Join(wd, "openshift"), "Output directory")
 	pflag.StringVar(&projectFilePath, "project-file", filepath.Join(wd, "openshift", "project.yaml"), "Project metadata file path")
 	pflag.StringVar(&dockerfileImageBuilderFmt, "dockerfile-image-builder-fmt", builderImageFmt, "Dockerfile image builder format")
-	pflag.StringVar(&mustGatherBuilderImageFmt, "must-gather-builder-image-fmt", mustGatherBaseImageFmt, "Must gather Dockerfile image builder format")
 	pflag.StringVar(&appFileFmt, "app-file-fmt", "/usr/bin/%s", "Target application binary path format")
 	pflag.StringVar(&registryImageFmt, "registry-image-fmt", "registry.ci.openshift.org/openshift/%s:%s", "Container registry image format")
 	pflag.StringArrayVar(&imagesFromRepositories, "images-from", nil, "Additional image references to be pulled from other midstream repositories matching the tag in project.yaml")
@@ -354,12 +352,7 @@ func main() {
 			log.Println("File ", projectFilePath, " not found")
 			metadata = nil
 		}
-		// Builder image might be provided without formatting '%s' string as plain value
-		builderImage := mustGatherBuilderImageFmt
-		if strings.Count(mustGatherBuilderImageFmt, "%s") == 1 {
-			builderImage = fmt.Sprintf(mustGatherBaseImageFmt, metadata.Requirements.OcpVersion.Max)
-		}
-
+		builderImage := fmt.Sprintf(mustGatherBaseImageFmt, metadata.Requirements.OcpVersion.Max)
 		projectName := mustGatherDockerfileTemplateName
 		projectDashCaseWithSep := projectName + "-"
 

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -352,7 +352,7 @@ func main() {
 			log.Println("File ", projectFilePath, " not found")
 			metadata = nil
 		}
-		builderImage := fmt.Sprintf(mustGatherBaseImageFmt, metadata.Requirements.OcpVersion.Max)
+		builderImage := fmt.Sprintf(mustGatherBaseImageFmt, metadata.Requirements.OcpVersion.Min)
 		projectName := mustGatherDockerfileTemplateName
 		projectDashCaseWithSep := projectName + "-"
 

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -14,8 +14,6 @@ config:
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
-        - name: MUSTGATHER
-          pullSpec: brew.registry.redhat.io/rh-osbs/openshift-ose-must-gather:latest
       openShiftVersions:
       - cronForceKonfluxIndex: true
         generateCustomConfigs: true
@@ -38,8 +36,6 @@ config:
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
-        - name: MUSTGATHER
-          pullSpec: brew.registry.redhat.io/rh-osbs/openshift-ose-must-gather:latest
       openShiftVersions:
       - generateCustomConfigs: true
         useClusterPool: true

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -14,6 +14,8 @@ config:
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
+        - name: MUSTGATHER
+          pullSpec: brew.registry.redhat.io/rh-osbs/openshift-ose-must-gather:latest
       openShiftVersions:
       - cronForceKonfluxIndex: true
         generateCustomConfigs: true
@@ -36,6 +38,8 @@ config:
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
+        - name: MUSTGATHER
+          pullSpec: brew.registry.redhat.io/rh-osbs/openshift-ose-must-gather:latest
       openShiftVersions:
       - generateCustomConfigs: true
         useClusterPool: true


### PR DESCRIPTION
As build is [failing](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_serverless-operator/2990/pull-ci-openshift-knative-serverless-operator-main-416-images/1853857018083807232) due to base image, 

- update the base image
- override default value of must gather base image and as per https://redhat-internal.slack.com/archives/CKR568L8G/p1730883580226309 we are going to use Min OCP version Tag.
- Nit: add writeRPMLockFile function

cc @creydr 
