### PR TITLE
Add support for WORKDIR in general dockerfile template

### DIFF
--- a/cmd/generate/dockerfile-templates/DefaultDockerfile.template
+++ b/cmd/generate/dockerfile-templates/DefaultDockerfile.template
@@ -3,12 +3,10 @@ ARG GO_BUILDER={{.builder}}
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
-{{if .workdir}}
+
 WORKDIR /go/src/{{.main}}
 COPY . .
-{{else}}
-COPY . .
-{{end}}
+
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/cmd/generate/dockerfile-templates/DefaultDockerfile.template
+++ b/cmd/generate/dockerfile-templates/DefaultDockerfile.template
@@ -3,9 +3,12 @@ ARG GO_BUILDER={{.builder}}
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
-
+{{if .workdir}}
+WORKDIR /go/src/{{.main}}
 COPY . .
-
+{{else}}
+COPY . .
+{{end}}
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
 

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -90,7 +90,6 @@ func main() {
 		additionalPackages           []string
 		templateName                 string
 		rpmsLockFileEnabled          bool
-		workdir                      bool
 	)
 
 	defaultIncludes := []string{
@@ -120,7 +119,6 @@ func main() {
 	pflag.StringArrayVar(&additionalPackages, "additional-packages", nil, "Additional packages to be installed in the image")
 	pflag.StringVar(&templateName, "template-name", defaultDockerfileTemplateName, fmt.Sprintf("Dockerfile template name to use. Supported values are [%s, %s]", defaultDockerfileTemplateName, funcUtilDockerfileTemplateName))
 	pflag.BoolVar(&rpmsLockFileEnabled, "generate-rpms-lock-file", false, "Enable the creation of the rpms.lock.yaml file")
-	pflag.BoolVar(&workdir, "dockerfile-workdir", false, "Enable default WORKDIR in builder images")
 	pflag.Parse()
 
 	if rootDir == "" {
@@ -264,7 +262,6 @@ func main() {
 				"component":               capitalize(p),
 				"component_dashcase":      dashcase(p),
 				"additional_instructions": additionalInstructions,
-				"workdir":                 workdir,
 			}
 
 			var DockerfileTemplate embed.FS

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -90,6 +90,7 @@ func main() {
 		additionalPackages           []string
 		templateName                 string
 		rpmsLockFileEnabled          bool
+		workdir                      bool
 	)
 
 	defaultIncludes := []string{
@@ -119,6 +120,7 @@ func main() {
 	pflag.StringArrayVar(&additionalPackages, "additional-packages", nil, "Additional packages to be installed in the image")
 	pflag.StringVar(&templateName, "template-name", defaultDockerfileTemplateName, fmt.Sprintf("Dockerfile template name to use. Supported values are [%s, %s]", defaultDockerfileTemplateName, funcUtilDockerfileTemplateName))
 	pflag.BoolVar(&rpmsLockFileEnabled, "generate-rpms-lock-file", false, "Enable the creation of the rpms.lock.yaml file")
+	pflag.BoolVar(&workdir, "dockerfile-workdir", false, "Enable default WORKDIR in builder images")
 	pflag.Parse()
 
 	if rootDir == "" {
@@ -262,6 +264,7 @@ func main() {
 				"component":               capitalize(p),
 				"component_dashcase":      dashcase(p),
 				"additional_instructions": additionalInstructions,
+				"workdir":                 workdir,
 			}
 
 			var DockerfileTemplate embed.FS

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -4,6 +4,7 @@ ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder
 
+WORKDIR /go/src/cmd/discover
 COPY . .
 
 ENV CGO_ENABLED=1


### PR DESCRIPTION
Adds support to define `WORKDIR` as an optional stanza. 

I've formatted the template to prevent updates with newline in the existing Dockerfiles. Pls let me know if that's ok or can be any prettier wrt/ `text/template` placeholders. Otherwise it's working as expected not adding newline and changes if flag is not set. 

 


/cc @pierDipi @creydr 