### PR TITLE
:lady_beetle: [kn-event] Proper unit tests target

### DIFF
--- a/config/kn-plugin-event.yaml
+++ b/config/kn-plugin-event.yaml
@@ -43,6 +43,6 @@ repositories:
   slackChannel: '#knative-client'
   tests:
   - as: unit
-    commands: make test
+    commands: make unit
     container:
       from: src


### PR DESCRIPTION
## Changes

- :lady_beetle: Proper Makefile target for unit tests for kn-event

See the target: 

https://github.com/openshift-knative/kn-plugin-event/blob/41fbdb9642d1ee516af1043a8efa4ee523656904/Makefile#L14-L16