### PR TITLE
Generate config for ROSA classic

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -326,6 +326,75 @@ repositories:
         branch: ""
         org: ""
         repo: ""
+  - name: lp-rosa-classic
+    releaseBuildConfiguration:
+      base_images:
+        rosa-aws-cli:
+          name: rosa-aws-cli
+          namespace: ci
+          tag: latest
+      releases:
+        latest:
+          integration:
+            include_built_images: true
+            name: "4.17"
+            namespace: ocp
+      tests:
+        - as: operator-e2e-rosa-aws
+          cron: 0 6 25 10 *
+          steps:
+            cluster_profile: aws-cspi-qe
+            env:
+              CHANNEL_GROUP: candidate
+              FIREWATCH_CONFIG: |
+                {
+                  "failure_rules":
+                    [
+                      {"step": "knative-eventing-kafka-broker-e2e", "failure_type": "test_failure", "classification": "knative-eventing-kafka-broker-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default"]},
+                      {"step": "knative-serving-eventing-e2e", "failure_type": "test_failure", "classification": "knative-serving-eventing-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default"]},
+                      {"step": "operator-e2e", "failure_type": "test_failure", "classification": "operator-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default"]},
+                      {"step": "knative-*", "failure_type": "pod_failure", "classification": "knative Test Execution", "jira_additional_labels": ["!default"]},
+                      {"step": "operator-e2e", "failure_type": "pod_failure", "classification": "operator-e2e Test Execution", "jira_additional_labels": ["!default"]},
+                    ]
+                }
+              FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/rosa/lp-interop.json
+              FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.17-lp","rosa-classic-lp","serverless-lp"]'
+              FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
+              FIREWATCH_FAIL_WITH_TEST_FAILURES: "true"
+              OCM_LOGIN_ENV: staging
+              OPENSHIFT_VERSION: "4.17"
+            test:
+              - ref: cucushift-installer-check-cluster-health
+              - as: knative-eventing-kafka-broker-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-kafka-no-upgrade
+                from: serverless-source-image
+                # Dependencies are injected automatically based on images.
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+              - as: operator-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true DELETE_CRD_ON_TEARDOWN=false make teardown test-e2e-with-kafka
+                from: serverless-source-image
+                # Dependencies are injected automatically based on images.
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+              - as: knative-serving-eventing-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-no-upgrade
+                from: serverless-source-image
+                # Dependencies are injected automatically based on images.
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+            workflow: firewatch-rosa-aws-sts
+          timeout: 8h0m0s
+      zz_generated_metadata:
+        branch: ""
+        org: ""
+        repo: ""
   dockerfiles:
     matches:
     - knative-operator/.*
@@ -370,7 +439,6 @@ repositories:
     - .*main.yaml$
     - .*lp-interop.*
     - .*lp-interop.*
-    - .*rosa-classic.*
   imageNameOverrides:
     serverless-operator: bundle
     serverless-operator-index: index

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -362,7 +362,7 @@ repositories:
                       {"step": "knative-serving-eventing-e2e", "failure_type": "test_failure", "classification": "knative-serving-eventing-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default"]},
                       {"step": "operator-e2e", "failure_type": "test_failure", "classification": "operator-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default"]},
                       {"step": "knative-*", "failure_type": "pod_failure", "classification": "knative Test Execution", "jira_additional_labels": ["!default"]},
-                      {"step": "operator-e2e", "failure_type": "pod_failure", "classification": "operator-e2e Test Execution", "jira_additional_labels": ["!default"]},
+                      {"step": "operator-e2e", "failure_type": "pod_failure", "classification": "operator-e2e Test Execution", "jira_additional_labels": ["!default"]}
                     ]
                 }
               FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/rosa/lp-interop.json

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -329,6 +329,14 @@ repositories:
   - name: lp-rosa-classic
     releaseBuildConfiguration:
       base_images:
+        cli:
+          name: "4.17"
+          namespace: ocp
+          tag: cli
+        cli-ocm:
+          name: cli-ocm
+          namespace: ci
+          tag: latest
         rosa-aws-cli:
           name: rosa-aws-cli
           namespace: ci

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -239,7 +239,10 @@ func DependenciesForTestSteps() ReleaseBuildConfigurationOption {
 		for _, testConfig := range cfg.Tests {
 			if testConfig.MultiStageTestConfiguration != nil {
 				for _, testStep := range testConfig.MultiStageTestConfiguration.Test {
-					testStep.Dependencies = dependenciesFromImages(cfg.Images, nil)
+					// Add dependencies only if it's LiteralTestStep.
+					if testStep.Reference == nil {
+						testStep.Dependencies = dependenciesFromImages(cfg.Images, nil)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCOM-3400

* Generates ROSA classic config for OCP 4.17. Indicated by [this config element](https://github.com/openshift-knative/hack/blob/main/config/serverless-operator.yaml#L19) 
* Removes old configs (4.14 and 4.15) as we generate these custom configs only for one OCP version.
* Removes also serverless-p2p-rosa-classic config. I have no idea if this is still required. I can put it back if necessary.

This is the config that will be generated after merging this PR: https://github.com/openshift/release/pull/58599