### PR TITLE
Add required releaseNotes fields to RPA template

### DIFF
--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -16,6 +16,12 @@ spec:
       product_id: 579
       product_name: "OpenShift Serverless"
       product_version: "{{{ .SOVersion }}}"
+      references:
+        - https://docs.redhat.com/en/documentation/red_hat_openshift_serverless
+      solution: "The container images provided by this update can be downloaded from the Red Hat container registry at registry.redhat.io"
+      description: "Release {{{ .SOVersion }}} of OpenShift Serverless"
+      topic: "Release {{{ .SOVersion }}} of OpenShift Serverless"
+      synopsis: "OpenShift Serverless Release {{{ .SOVersion }}}"
     mapping:
       components:
       {{{- range $component := .Components }}}

--- a/pkg/konfluxgen/releaseplanadmission-fbc.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-fbc.template.yaml
@@ -19,6 +19,12 @@ spec:
       product_id: 579
       product_name: "OpenShift Serverless"
       product_version: "{{{ .SOVersion }}}"
+      references:
+        - https://docs.redhat.com/en/documentation/red_hat_openshift_serverless
+      solution: "The container images provided by this update can be downloaded from the Red Hat container registry at registry.redhat.io"
+      description: "Release {{{ .SOVersion }}} of OpenShift Serverless"
+      topic: "Release {{{ .SOVersion }}} of OpenShift Serverless"
+      synopsis: "OpenShift Serverless Release {{{ .SOVersion }}}"
     fbc:
       {{{- if .StagedIndex }}}
       stagedIndex: true


### PR DESCRIPTION
Got the following error in the `check-data-key` task of a release job:

```
+ for KEY in $(jq -r ".${SYSTEM}[]" <<< "$KEYS_JSON")
++ jq .releaseNotes.synopsis /workspace/data/b57c77b0-011c-402b-9764-348bd01ca7a6/data.json
+ [[ null == \n\u\l\l ]]
+ echo 'Missing required releaseNotes key: synopsis'
+ RC=1
Missing required releaseNotes key: synopsis
+ for KEY in $(jq -r ".${SYSTEM}[]" <<< "$KEYS_JSON")
++ jq .releaseNotes.topic /workspace/data/b57c77b0-011c-402b-9764-348bd01ca7a6/data.json
+ [[ null == \n\u\l\l ]]
+ echo 'Missing required releaseNotes key: topic'
+ RC=1
Missing required releaseNotes key: topic
+ for KEY in $(jq -r ".${SYSTEM}[]" <<< "$KEYS_JSON")
++ jq .releaseNotes.description /workspace/data/b57c77b0-011c-402b-9764-348bd01ca7a6/data.json
+ [[ null == \n\u\l\l ]]
+ echo 'Missing required releaseNotes key: description'
Missing required releaseNotes key: description
+ RC=1
+ for KEY in $(jq -r ".${SYSTEM}[]" <<< "$KEYS_JSON")
++ jq .releaseNotes.solution /workspace/data/b57c77b0-011c-402b-9764-348bd01ca7a6/data.json
+ [[ null == \n\u\l\l ]]
+ echo 'Missing required releaseNotes key: solution'
Missing required releaseNotes key: solution
+ RC=1
+ for KEY in $(jq -r ".${SYSTEM}[]" <<< "$KEYS_JSON")
++ jq .releaseNotes.references /workspace/data/b57c77b0-011c-402b-9764-348bd01ca7a6/data.json
+ [[ null == \n\u\l\l ]]
+ echo 'Missing required releaseNotes key: references'
Missing required releaseNotes key: references
+ RC=1
+ exit 1
```

Seems we need those labels (https://konflux.pages.redhat.com/docs/users/releasing/releasing-with-an-advisory.html)