### PR TITLE
Copy oc CLI in must-gather image from from cli-artifacts image

### DIFF
--- a/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
+++ b/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
@@ -1,11 +1,13 @@
 # DO NOT EDIT! Generated Dockerfile for {{.main}}.
-ARG MUSTGATHER={{.must_gather_base}}
+ARG CLI_ARTIFACTS={{ .oc_cli_artifacts }}
 ARG RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
-FROM $MUSTGATHER AS mustgather
+FROM $CLI_ARTIFACTS AS cli-artifacts
 
 FROM $RUNTIME
 
-COPY --from=mustgather /usr/bin/oc /usr/bin/oc
+ARG TARGETARCH
+
+COPY --from=cli-artifacts /usr/share/openshift/linux_$TARGETARCH/{{ .oc_binary_name }} /usr/bin/oc
 
 # Copy all collection scripts to /usr/bin
 COPY must-gather/bin/* /usr/bin/

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -255,7 +255,13 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 			return err
 		}
 		buildArgs := []string{fmt.Sprintf("VERSION=%s", soMetadata.Project.Version)}
-		buildArgs = append(buildArgs, fmt.Sprintf("MUSTGATHER=brew.registry.redhat.io/rh-osbs/openshift-ose-must-gather:v%s", soMetadata.Requirements.OcpVersion.Min))
+
+		cliImage, err := getCLIArtifactsImage(soMetadata.Requirements.OcpVersion.Min)
+		if err != nil {
+			return fmt.Errorf("failed to get cli artifacts image for OCP %s: %w", soMetadata.Requirements.OcpVersion.Min, err)
+		}
+
+		buildArgs = append(buildArgs, fmt.Sprintf("CLI_ARTIFACTS=%s", cliImage))
 
 		for _, img := range b.Konflux.ImageOverrides {
 			if img.Name == "" || img.PullSpec == "" {
@@ -346,6 +352,25 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 	}
 
 	return nil
+}
+
+func getCLIArtifactsImage(ocpVersion string) (string, error) {
+	parts := strings.SplitN(ocpVersion, ".", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid OCP version: %s", ocpVersion)
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("could not convert OCP minor to int (%q): %w", ocpVersion, err)
+	}
+
+	if minor <= 14 {
+		return fmt.Sprintf("registry.redhat.io/openshift4/ose-cli-artifacts:v4.%d", minor), nil
+	} else {
+		// use RHEL9 variant for OCP version >= 4.15
+		return fmt.Sprintf("registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.%d", minor), nil
+	}
 }
 
 func getPrefetchDeps(repo Repository, branch string) (*konfluxgen.PrefetchDeps, error) {


### PR DESCRIPTION
Copy oc cli in must-gather image from from cli-artifacts image.
This is because for Konflux we run into issues with the `brew.registry.redhat.io/rh-osbs/openshift-ose-must-gather` image, as this was from a not allowed registry. And for the must-gather we only need the oc CLI.

Gives us the following must-gather dockerfile:
```
# DO NOT EDIT! Generated Dockerfile for must-gather.
ARG CLI_ARTIFACTS=registry.ci.openshift.org/ocp/4.13:cli-artifacts
ARG RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
FROM $CLI_ARTIFACTS AS cli-artifacts

FROM $RUNTIME

ARG TARGETARCH

COPY --from=cli-artifacts /usr/share/openshift/linux_$TARGETARCH/oc /usr/bin/oc

# Copy all collection scripts to /usr/bin
COPY must-gather/bin/* /usr/bin/

RUN microdnf install -y rsync tar

LABEL \
      ...

ENTRYPOINT /usr/bin/gather
```

And adds the following as a build-arg in the pipelines for Konflux:
```
CLI_ARTIFACTS=registry.redhat.io/openshift4/ose-cli-artifacts:v4.13
```