### PR TITLE
Update signing keys for RPAs

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -809,7 +809,7 @@ func GenerateFBCReleasePlanAdmission(applications []string, resourceOutputPath s
 		PublishingCredentials: "staged-index-fbc-publishing-credentials",
 		PipelineSA:            "release-index-image-staging",
 		StagedIndex:           true,
-		SignCMName:            "hacbs-signing-pipeline-config-redhatbeta2",
+		SignCMName:            "hacbs-signing-pipeline-config-staging-redhatrelease2",
 	}
 	outputFilePath = filepath.Join(outputDir, fmt.Sprintf("%s.yaml", rpaName))
 	if err := executeFBCReleasePlanAdmissionTemplate(fbcData, outputFilePath); err != nil {
@@ -828,6 +828,7 @@ type rpaComponentData struct {
 	PyxisSecret string
 	PyxisServer string
 	PipelineSA  string
+	SignCMName  string
 }
 
 func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterServiceVersion, bundleName string, bundleRepoName string, resourceOutputPath string, appName string) error {
@@ -858,6 +859,7 @@ func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterService
 		PyxisSecret:     "pyxis-prod-secret",
 		PyxisServer:     "production",
 		PipelineSA:      "release-registry-prod",
+		SignCMName:      "hacbs-signing-pipeline-config-redhatrelease2",
 	}
 	outputFilePath := filepath.Join(outputDir, fmt.Sprintf("%s.yaml", rpaName))
 	if err := executeComponentReleasePlanAdmissionTemplate(rpaData, outputFilePath); err != nil {
@@ -882,6 +884,7 @@ func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterService
 		PyxisSecret:     "pyxis-staging-secret",
 		PyxisServer:     "stage",
 		PipelineSA:      "release-registry-staging",
+		SignCMName:      "hacbs-signing-pipeline-config-staging-redhatrelease2",
 	}
 	outputFilePath = filepath.Join(outputDir, fmt.Sprintf("%s.yaml", rpaName))
 	if err := executeComponentReleasePlanAdmissionTemplate(rpaData, outputFilePath); err != nil {

--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -38,7 +38,7 @@ spec:
       secret: {{{ .PyxisSecret }}}
       server: {{{ .PyxisServer }}}
     sign:
-      configMapName: "hacbs-signing-pipeline-config-redhatrelease2"
+      configMapName: {{{ .SignCMName }}}
   pipeline:
     pipelineRef:
       resolver: git


### PR DESCRIPTION
The signing keys for staging were renamed, so we need to include this into the RPA generator:

* https://gitlab.cee.redhat.com/releng/konflux-release-data/-/commit/c0a4e281909ca54f58645229368735f9a5ebba41
* https://gitlab.cee.redhat.com/releng/konflux-release-data/-/commit/b38596145c0c0843f7f8d1e097873e53c02db904
* https://gitlab.cee.redhat.com/releng/konflux-release-data/-/commit/a9540cc8062c0a5aa62f32e1a59dd3e523a9b0d5