### PR TITLE
Generate config for INTEROP tests on 4.18

### DIFF
--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -21,6 +21,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - version: "4.17"
       - onDemand: true
         version: "4.13"

--- a/config/client.yaml
+++ b/config/client.yaml
@@ -11,6 +11,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - skipCron: true
         useClusterPool: true
         version: "4.17"

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -30,6 +30,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.16"
       - onDemand: true

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -44,6 +44,10 @@ config:
         - .*eventing-kafka-broker-receiver
         - .*eventing-kafka-broker-dispatcher
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.17"
       - onDemand: true

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -30,6 +30,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.17"
       - onDemand: true

--- a/config/kn-plugin-event.yaml
+++ b/config/kn-plugin-event.yaml
@@ -10,6 +10,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.17"
     release-next:

--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -16,6 +16,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - skipCron: true
         useClusterPool: true
         version: "4.17"

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -15,8 +15,19 @@ config:
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
       openShiftVersions:
+      - candidateRelease: true
+        cronForceKonfluxIndex: true
+        customConfigs:
+          enabled: true
+          includes:
+            - .*ocp4.18-lp-interop.*
+        onDemand: true
+        version: "4.18"
       - cronForceKonfluxIndex: true
-        generateCustomConfigs: true
+        customConfigs:
+          enabled: true
+          excludes:
+            - .*ocp4.18-lp-interop.*
         useClusterPool: true
         version: "4.17"
       - cronForceKonfluxIndex: true
@@ -403,6 +414,121 @@ repositories:
         branch: ""
         org: ""
         repo: ""
+  - name: ocp4.18-lp-interop
+    releaseBuildConfiguration:
+      tests:
+        - as: operator-e2e-interop-aws-ocp418
+          cron: 0 6 11 2 *
+          steps:
+            cluster_profile: aws-cspi-qe
+            env:
+              BASE_DOMAIN: cspilp.interop.ccitredhat.com
+              FIREWATCH_CONFIG: |
+                {
+                  "failure_rules":
+                    [
+                      {"step": "knative-eventing-kafka-broker-e2e", "failure_type": "test_failure", "classification": "knative-eventing-kafka-broker-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default","interop-tests"]},
+                      {"step": "knative-serving-eventing-e2e", "failure_type": "test_failure", "classification": "knative-serving-eventing-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default","interop-tests"]},
+                      {"step": "operator-e2e", "failure_type": "test_failure", "classification": "operator-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default","interop-tests"]},
+                      {"step": "knative-*", "failure_type": "pod_failure", "classification": "knative Test Execution", "jira_additional_labels": ["!default","interop-tests"]},
+                      {"step": "operator-e2e", "failure_type": "pod_failure", "classification": "operator-e2e Test Execution", "jira_additional_labels": ["!default","interop-tests"]}
+                    ]
+                }
+              FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/aws-ipi/lp-interop.json
+              FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.18-lp","self-managed-lp","serverless-lp"]'
+              FIREWATCH_DEFAULT_JIRA_ASSIGNEE: mgencur@redhat.com
+              FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
+              USER_TAGS: |
+                scenario serverless
+            test:
+              - as: operator-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make test-e2e-with-kafka
+                # Dependencies are injected automatically based on images.
+                from: serverless-source-image
+                resources:
+                  limits:
+                    memory: 8Gi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+              - as: knative-serving-eventing-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-no-upgrade
+                # Dependencies are injected automatically based on images.
+                from: serverless-source-image
+                resources:
+                  limits:
+                    memory: 8Gi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+              - as: knative-eventing-kafka-broker-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-kafka-no-upgrade
+                # Dependencies are injected automatically based on images.
+                from: serverless-source-image
+                resources:
+                  limits:
+                    memory: 10Gi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+            workflow: firewatch-ipi-aws
+          timeout: 8h0m0s
+        - as: operator-e2e-interop-aws-ocp418-fips
+          cron: 0 0 11 6 *
+          steps:
+            cluster_profile: aws-cspi-qe
+            env:
+              BASE_DOMAIN: cspilp.interop.ccitredhat.com
+              FIPS_ENABLED: "true"
+              FIREWATCH_CONFIG: |
+                {
+                  "failure_rules":
+                    [
+                      {"step": "knative-eventing-kafka-broker-e2e", "failure_type": "test_failure", "classification": "knative-eventing-kafka-broker-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default","interop-tests"]},
+                      {"step": "knative-serving-eventing-e2e", "failure_type": "test_failure", "classification": "knative-serving-eventing-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default","interop-tests"]},
+                      {"step": "operator-e2e", "failure_type": "test_failure", "classification": "operator-e2e Test Failure", "jira_project": "SRVCOM", "jira_additional_labels": ["!default","interop-tests"]},
+                      {"step": "knative-*", "failure_type": "pod_failure", "classification": "knative Test Execution", "jira_additional_labels": ["!default","interop-tests"]},
+                      {"step": "operator-e2e", "failure_type": "pod_failure", "classification": "operator-e2e Test Execution", "jira_additional_labels": ["!default","interop-tests"]}
+                    ]
+                }
+              FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/main/firewatch-base-configs/aws-ipi/lp-interop.json
+              FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.18-lp","self-managed-lp","serverless-lp","fips"]'
+              FIREWATCH_DEFAULT_JIRA_PROJECT: LPINTEROP
+              USER_TAGS: |
+                scenario serverless
+            test:
+              - as: operator-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make test-e2e-with-kafka
+                # Dependencies are injected automatically based on images.
+                from: serverless-source-image
+                resources:
+                  limits:
+                    memory: 8Gi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+              - as: knative-serving-eventing-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-no-upgrade
+                # Dependencies are injected automatically based on images.
+                from: serverless-source-image
+                resources:
+                  limits:
+                    memory: 8Gi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+              - as: knative-eventing-kafka-broker-e2e
+                commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-kafka-no-upgrade
+                # Dependencies are injected automatically based on images.
+                from: serverless-source-image
+                resources:
+                  limits:
+                    memory: 10Gi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+            workflow: firewatch-ipi-aws
+          timeout: 8h0m0s
   dockerfiles:
     matches:
     - knative-operator/.*
@@ -445,8 +571,6 @@ repositories:
   ignoreConfigs:
     matches:
     - .*main.yaml$
-    - .*lp-interop.*
-    - .*lp-interop.*
   imageNameOverrides:
     serverless-operator: bundle
     serverless-operator-index: index

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -24,6 +24,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.17"
       - onDemand: true

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -24,6 +24,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.17"
       - onDemand: true

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -37,6 +37,10 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.17"
       - onDemand: true

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -389,12 +389,7 @@ func AlwaysRunInjector() JobConfigInjector {
 					variant := jobConfig.PresubmitsStatic[k][i].Labels["ci-operator.openshift.io/variant"]
 					ocpVersion := strings.ReplaceAll(strings.SplitN(variant, "-", 2)[0], ".", "")
 
-					var err error
 					openshiftVersions := b.OpenShiftVersions
-					openshiftVersions, err = addCandidateRelease(b.OpenShiftVersions)
-					if err != nil {
-						return err
-					}
 					// Individual OpenShift versions can enforce all their jobs to be on demand.
 					var onDemandForOpenShift bool
 					for _, v := range openshiftVersions {


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCOM-3401

* Configuration for a candidate release of OpenShift now has to be specified explicitly. Previously, we generated them automatically by taking the highest version of OpenShift in config, bumping the minor version, and creating the config for the candidate release. Now, we need to be able to specify which custom configs will be run for each version of OpenShift - including this candidate version.
* Add tests for candidate OCP 4.18 explicitly for all repositories, but only for the latest version Serverless 1.36.
* Add INTEROP config for OpenShift 4.18. This is supposed to replace manual changes like in this PR: https://github.com/openshift/release/pull/57252 (it's error prone and requires multiple reviews from our team).
* Remove older interop tests for OCP <=4.17


When merging this PR, the following config will be generated: https://github.com/openshift/release/pull/58680