### PR TITLE
Add USER to must-gather Dockerfile

### DIFF
--- a/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
+++ b/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
@@ -14,6 +14,8 @@ COPY must-gather/bin/* /usr/bin/
 
 RUN microdnf install -y rsync tar
 
+USER 65532
+
 LABEL \
       com.redhat.component="openshift-serverless-1-{{.project_dashcase}}rhel8-container" \
       name="openshift-serverless-1/svls-{{.project_dashcase}}rhel8" \

--- a/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
+++ b/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
@@ -14,6 +14,10 @@ COPY must-gather/bin/* /usr/bin/
 
 RUN microdnf install -y rsync tar
 
+ENV LOGS_DIR="/must-gather"
+RUN mkdir -p $LOGS_DIR && \
+    chown -R 65532:65532 $LOGS_DIR
+
 USER 65532
 
 LABEL \


### PR DESCRIPTION
Seeing the following error in the EC ([ecosystem-cert-preflight-checks](https://console.redhat.com/application-pipeline/workspaces/ocp-serverless/applications/serverless-operator-135/taskruns/serverless-must-gather-135-on-pe4b3d53d0005598cad0e60359a3ac33e)):

```
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
```

Relates to https://github.com/openshift-knative/serverless-operator/pull/3018