### PR TITLE
Do NOT add OCP variant to custom config names

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -46,7 +46,7 @@ config:
         disabled: true
 repositories:
 - customConfigs:
-  - name: aws-ovn
+  - name: 417-aws-ovn
     releaseBuildConfiguration:
       tests:
       - as: e2e-aws-ovn-continuous
@@ -87,7 +87,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: azure
+  - name: 417-azure
     releaseBuildConfiguration:
       tests:
       - as: e2e-azure-continuous
@@ -128,7 +128,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: gcp
+  - name: 417-gcp
     releaseBuildConfiguration:
       tests:
       - as: e2e-gcp-continuous
@@ -169,7 +169,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: hypershift
+  - name: 417-hypershift
     releaseBuildConfiguration:
       base_images:
         hypershift-operator:
@@ -230,7 +230,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: osd
+  - name: 417-osd
     releaseBuildConfiguration:
       base_images:
         cli-ocm:
@@ -276,7 +276,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: single-node
+  - name: 417-single-node
     releaseBuildConfiguration:
       tests:
       - as: e2e-sno-continuous
@@ -299,7 +299,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: vsphere
+  - name: 417-vsphere
     releaseBuildConfiguration:
       base_images:
         upi-installer:
@@ -326,7 +326,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: lp-rosa-classic
+  - name: ocp4.17-lp-rosa-classic
     releaseBuildConfiguration:
       base_images:
         cli:

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -58,7 +58,7 @@ type Promotion struct {
 }
 
 type CustomConfigs struct {
-	// Name will be used together with OpenShift version to generate a specific variant.
+	// Name will be used to generate a specific variant.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// ReleaseBuildConfiguration allows defining configuration manually. The final configuration
 	// is extended with images and test steps with dependencies.
@@ -319,7 +319,7 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 
 				buildConfigPath = filepath.Join(
 					r.RepositoryDirectory(),
-					r.Org+"-"+r.Repo+"-"+branchName+"__"+variant+"-"+customCfg.Name+".yaml",
+					r.Org+"-"+r.Repo+"-"+branchName+"__"+customCfg.Name+".yaml",
 				)
 
 				cfgs = append(cfgs, ReleaseBuildConfiguration{


### PR DESCRIPTION
I have spoken with INTEROP team and they rely on some automation and processes that need certain naming conventions. 
* Change `lp-rosa-classic` to `ocp4.17-lp-rosa-classic`
* As part of this change - prevent adding the OpenShift variant to the custom config name. It makes sense to hard code the name of the file/variant, i.e. take it directly from the config name. The custom configs often include OCP-specific configuration elements so they're bound to certain OCP version anyway.