### PR TITLE
Use OPM image from Brew

### DIFF
--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -491,10 +491,10 @@ func getOPMImage(v string) (string, error) {
 	}
 
 	if minor <= 14 {
-		return fmt.Sprintf("registry.redhat.io/openshift4/ose-operator-registry:v4.%d", minor), nil
+		return fmt.Sprintf("brew.registry.redhat.io/rh-osbs/ose-operator-registry:v4.%d", minor), nil
 	} else {
 		// use RHEL9 variant for OCP version >= 4.15
-		return fmt.Sprintf("registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.%d", minor), nil
+		return fmt.Sprintf("brew.registry.redhat.io/rh-osbs/ose-operator-registry-rhel9:v4.%d", minor), nil
 	}
 }
 


### PR DESCRIPTION
This ensure the image exist even for a pre-release version of OCP (such as 4.18 at the moment). The respective EnterpriseContractPolicy allows it: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/common/product/EnterpriseContractPolicy/fbc-standard.yaml

Related Slack threads:
[serverless-productizes](https://redhat-internal.slack.com/archives/CKR568L8G/p1731682221189979)
[forum-fbc-support](https://redhat-internal.slack.com/archives/C074JM28DTP/p1731924910708669)