### PR TITLE
Fix base images for FBC catalog

### DIFF
--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -491,10 +491,10 @@ func getOPMImage(v string) (string, error) {
 	}
 
 	if minor <= 14 {
-		return fmt.Sprintf("brew.registry.redhat.io/rh-osbs/ose-operator-registry:v4.%d", minor), nil
+		return fmt.Sprintf("registry.redhat.io/openshift4/ose-operator-registry:v4.%d", minor), nil
 	} else {
 		// use RHEL9 variant for OCP version >= 4.15
-		return fmt.Sprintf("brew.registry.redhat.io/rh-osbs/ose-operator-registry-rhel9:v4.%d", minor), nil
+		return fmt.Sprintf("brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.%d", minor), nil
 	}
 }
 


### PR DESCRIPTION
* Use registry.redhat.io for 4.14 and older (registry.redhat.io is allowd by Konflux by default)
* Use Brew variant for 4.15+:
- The brew registry brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9 is explicitly allowed in Konflux:
https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/common/product/EnterpriseContractPolicy/fbc-standard.yaml#L16
- Brew variants are for versions that are not public yet (e.g. 4.18 at the moment)