### PR TITLE
Use `registry.redhat.io/openshift4/ose-cli-artifacts:v4.15` for CLI image

### DIFF
--- a/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
+++ b/cmd/generate/dockerfile-templates/MustGatherDockerfile.template
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for {{.main}}.
-ARG CLI_ARTIFACTS={{ .oc_cli_artifacts }}
+ARG CLI_ARTIFACTS=registry.ci.openshift.org/ocp/4.15:cli-artifacts
 ARG RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 FROM $CLI_ARTIFACTS AS cli-artifacts
 

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -14,6 +14,8 @@ config:
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
+        - name: CLI_ARTIFACTS
+          pullSpec: registry.redhat.io/openshift4/ose-cli-artifacts:v4.15
       openShiftVersions:
       - candidateRelease: true
         cronForceKonfluxIndex: true
@@ -47,6 +49,8 @@ config:
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
+        - name: CLI_ARTIFACTS
+          pullSpec: registry.redhat.io/openshift4/ose-cli-artifacts:v4.15
       openShiftVersions:
       - useClusterPool: true
         version: "4.17"

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -257,13 +257,6 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 		}
 		buildArgs := []string{fmt.Sprintf("VERSION=%s", soMetadata.Project.Version)}
 
-		cliImage, err := getCLIArtifactsImage(soMetadata.Requirements.OcpVersion.Min)
-		if err != nil {
-			return fmt.Errorf("failed to get cli artifacts image for OCP %s: %w", soMetadata.Requirements.OcpVersion.Min, err)
-		}
-
-		buildArgs = append(buildArgs, fmt.Sprintf("CLI_ARTIFACTS=%s", cliImage))
-
 		for _, img := range b.Konflux.ImageOverrides {
 			if img.Name == "" || img.PullSpec == "" {
 				return fmt.Errorf("image override missing name or pull spec: %#v", img)
@@ -353,25 +346,6 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 	}
 
 	return nil
-}
-
-func getCLIArtifactsImage(ocpVersion string) (string, error) {
-	parts := strings.SplitN(ocpVersion, ".", 2)
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid OCP version: %s", ocpVersion)
-	}
-
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return "", fmt.Errorf("could not convert OCP minor to int (%q): %w", ocpVersion, err)
-	}
-
-	if minor <= 14 {
-		return fmt.Sprintf("registry.redhat.io/openshift4/ose-cli-artifacts:v4.%d", minor), nil
-	} else {
-		// use RHEL9 variant for OCP version >= 4.15
-		return fmt.Sprintf("registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.%d", minor), nil
-	}
 }
 
 func getPrefetchDeps(repo Repository, branch string) (*konfluxgen.PrefetchDeps, error) {


### PR DESCRIPTION
As discussed in https://redhat-internal.slack.com/archives/CKR568L8G/p1732026872336829?thread_ts=1732003309.673969&cid=CKR568L8G


/hold
to see if 4.14 issues will be fixed with the new release