### PR TITLE
Fix: Use `registry.redhat.io/openshift4/ose-cli-artifacts` image for OCP up to 4.15

### DIFF
--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -366,10 +366,10 @@ func getCLIArtifactsImage(ocpVersion string) (string, error) {
 		return "", fmt.Errorf("could not convert OCP minor to int (%q): %w", ocpVersion, err)
 	}
 
-	if minor <= 14 {
+	if minor <= 15 {
 		return fmt.Sprintf("registry.redhat.io/openshift4/ose-cli-artifacts:v4.%d", minor), nil
 	} else {
-		// use RHEL9 variant for OCP version >= 4.15
+		// use RHEL9 variant for OCP version > 4.15
 		return fmt.Sprintf("registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.%d", minor), nil
 	}
 }


### PR DESCRIPTION
registry.redhat.io/openshift4/ose-cli-artifacts-**rhel9** have only tags for >= 4.16: https://catalog.redhat.com/software/containers/openshift4/ose-cli-artifacts-rhel9/652809671ab6f3a50efd1fd8

registry.redhat.io/openshift4/ose-cli-artifacts have tags for <= 4.15: https://catalog.redhat.com/software/containers/openshift4/ose-cli-artifacts/5cdda1cad70cc57c44b2d7a5