### PR TITLE
Use correct Dockerfile path in component config

### DIFF
--- a/pkg/konfluxgen/dockerfile-component.template.yaml
+++ b/pkg/konfluxgen/dockerfile-component.template.yaml
@@ -17,5 +17,5 @@ spec:
     git:
       url: https://github.com/{{ .ReleaseBuildConfiguration.Metadata.Org }}/{{ .ReleaseBuildConfiguration.Metadata.Repo }}.git
       context: {{ .ProjectDirectoryImageBuildStepConfiguration.ProjectDirectoryImageBuildInputs.ContextDir }}
-      dockerfileUrl: {{ .ProjectDirectoryImageBuildStepConfiguration.ProjectDirectoryImageBuildInputs.DockerfilePath }}
+      dockerfileUrl: {{ .DockerfilePath }}
       revision: {{ .ReleaseBuildConfiguration.Metadata.Branch }}


### PR DESCRIPTION
For hermetic java builds, we use the wrong Dockerfile path in the component config:

https://github.com/openshift-knative/eventing-kafka-broker/blob/ee2a4c2017f48c9d29579eae7f612cc65c3e443a/.konflux/applications/serverless-operator-135/components/kn-ekb-dispatcher-115.yaml#L20

should actutually be `openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile` as defined in the [pipeline](https://github.com/openshift-knative/eventing-kafka-broker/blob/ee2a4c2017f48c9d29579eae7f612cc65c3e443a/.tekton/kn-ekb-dispatcher-115-pull-request.yaml#L21C14-L21C80).

`dockerfilePath` is defined here:
https://github.com/openshift-knative/hack/blob/5cefd34d5ede20cfade3f6393f129eaa818cca91/pkg/konfluxgen/konfluxgen.go#L296-L305

And set for the template use here:
https://github.com/openshift-knative/hack/blob/5cefd34d5ede20cfade3f6393f129eaa818cca91/pkg/konfluxgen/konfluxgen.go#L320