### PR TITLE
Switch to registry-standard policy for EC tests

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -327,7 +327,7 @@ func Generate(cfg Config) error {
 			}
 
 			if cfg.ECPolicyConfigName == "" {
-				r.ECPolicyConfiguration = "rhtap-releng-tenant/tmp-onboard-policy"
+				r.ECPolicyConfiguration = "rhtap-releng-tenant/registry-standard"
 			} else {
 				r.ECPolicyConfiguration = cfg.ECPolicyConfigName
 			}


### PR DESCRIPTION
Switching to [`registry-standard`](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/1cc32f0e30e7727c68034d57c4ff14cf69fb197b/config/common/product/EnterpriseContractPolicy/registry-standard.yaml) policy for EC tests