### PR TITLE
Switch to registry-standard-stage policy for EC tests

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -824,6 +824,7 @@ type rpaComponentData struct {
 	ApplicationName string
 	Components      []ComponentImageRepoRef
 
+	Policy      string
 	SOVersion   semver.Version
 	PyxisSecret string
 	PyxisServer string
@@ -860,6 +861,7 @@ func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterService
 		PyxisServer:     "production",
 		PipelineSA:      "release-registry-prod",
 		SignCMName:      "hacbs-signing-pipeline-config-redhatrelease2",
+		Policy:          "registry-standard",
 	}
 	outputFilePath := filepath.Join(outputDir, fmt.Sprintf("%s.yaml", rpaName))
 	if err := executeComponentReleasePlanAdmissionTemplate(rpaData, outputFilePath); err != nil {
@@ -885,6 +887,7 @@ func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterService
 		PyxisServer:     "stage",
 		PipelineSA:      "release-registry-staging",
 		SignCMName:      "hacbs-signing-pipeline-config-redhatrelease2",
+		Policy:          "registry-standard-stage",
 	}
 	outputFilePath = filepath.Join(outputDir, fmt.Sprintf("%s.yaml", rpaName))
 	if err := executeComponentReleasePlanAdmissionTemplate(rpaData, outputFilePath); err != nil {

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -327,7 +327,7 @@ func Generate(cfg Config) error {
 			}
 
 			if cfg.ECPolicyConfigName == "" {
-				r.ECPolicyConfiguration = "rhtap-releng-tenant/registry-standard"
+				r.ECPolicyConfiguration = "rhtap-releng-tenant/registry-standard-stage"
 			} else {
 				r.ECPolicyConfiguration = cfg.ECPolicyConfigName
 			}

--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   applications: [{{{ truncate ( sanitize .ApplicationName ) }}}]
   origin: ocp-serverless-tenant
-  policy: registry-standard
+  policy: {{{ .Policy }}}
   data:
     releaseNotes:
       product_id: 579


### PR DESCRIPTION
Switching to `registry-standard-stage` policy for ECs as discussed in [Slack](https://redhat-internal.slack.com/archives/CD87JDUB0/p1732200833731069?thread_ts=1732024980.981129&cid=CD87JDUB0)