### PR TITLE
Run konflux-apply only on main branch

### DIFF
--- a/.github/workflows/apply-konflux-manifests.yaml
+++ b/.github/workflows/apply-konflux-manifests.yaml
@@ -6,6 +6,8 @@ on:
   push:
     paths:
       - ".konflux/**"
+    branches:
+      - main
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
konflux-apply is currently not only limited to main branch: 
![image](https://github.com/user-attachments/assets/e856e77f-a8cf-4261-a578-49912baa99a2)

Addressing it in this PR so it runs only on main!