### PR TITLE
Increase IntegrationTestScenario timeout to 120m

### DIFF
--- a/pkg/konfluxgen/integration-test-scenario.template.yaml
+++ b/pkg/konfluxgen/integration-test-scenario.template.yaml
@@ -7,7 +7,7 @@ spec:
     - name: POLICY_CONFIGURATION
       value: {{{ .ECPolicyConfiguration }}}
     - name: TIMEOUT
-      value: "45m0s"
+      value: "120m"
   application: {{{ truncate ( sanitize .ApplicationName ) }}}
   contexts:
     - description: Application testing


### PR DESCRIPTION
The IntegrationTestScenarios on snapshots fail due to
```
Image URL is not accessible: Get \"https://quay.io/v2/\": exceeded allowed execution time of 45m0s, the timeout can be adjusted using the --timeout command line argument. Error: Get \"https://quay.io/v2/\": exceeded allowed execution time of 45m0s, the timeout can be adjusted using the --timeout command line argument
```
According to [this slack thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1732012495585929), we need to increase the timeout in the ITS

Slack: https://redhat-internal.slack.com/archives/CKR568L8G/p1732535816570409