### PR TITLE
set soak test timeout

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -566,6 +566,7 @@ repositories:
     match: ^test-soak$
     onDemand: true
     runIfChanged: test/soak
+    timeout: 4h0m0s
   - ignoreError: true
     match: ^kitchensink-e2e$
     onDemand: true


### PR DESCRIPTION
Current run time-outs while the must-gather runs

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-417-test-soak-aws-417-c/1860922812198293504

Setting a `timeout: 4h0m0s` just like the mesh tests  do, will set the overall timeout to test+1h=5h, which should be enough, hopefully.