### PR TITLE
Update FBC target image accordingly

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -787,7 +787,7 @@ func GenerateFBCReleasePlanAdmission(applications []string, resourceOutputPath s
 		SOVersion:             *semv,
 		Policy:                "fbc-standard",
 		FromIndex:             "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:{{ OCP_VERSION }}",
-		TargetIndex:           "quay.io/redhat/redhat----redhat-operator-index:{{ OCP_VERSION }}",
+		TargetIndex:           "quay.io/redhat-prod/redhat----redhat-operator-index:{{ OCP_VERSION }}",
 		PublishingCredentials: "fbc-production-publishing-credentials",
 		PipelineSA:            "release-index-image-prod",
 		SignCMName:            "hacbs-signing-pipeline-config-redhatrelease2",


### PR DESCRIPTION
According to https://groups.google.com/a/redhat.com/g/konflux-announce/c/nuKyLiwb0WQ:

> Hi Konflux users,
> In order to complete the migration of operator index images, FBC production releases will be disabled during 2024-12-06 10:00-12:00 UTC.
> During the outage, images in [quay.io/redhat/redhat----redhat-operator-index](http://quay.io/redhat/redhat----redhat-operator-index) will be fully migrated to [quay.io/redhat-prod/redhat----redhat-operator-index](http://quay.io/redhat-prod/redhat----redhat-operator-index). Pulling images from [registry.redhat.io/redhat/redhat-operator-index](http://registry.redhat.io/redhat/redhat-operator-index) won't be impacted during or after the outage.

As we generate the RPAs on our own, and can't make use of the [migration](https://redhat-internal.slack.com/archives/C074JM28DTP/p1732545631284419?thread_ts=1732540764.505019&cid=C074JM28DTP), we need to update our generator

/hold DNM before migration is done (24-12-06 12:00 UTC)