### PR TITLE
Configure GOPATH for custom configs

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -65,7 +65,7 @@ repositories:
           cluster_profile: aws
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-e2e-with-kafka
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka
             from: serverless-source-image
             resources:
               limits:
@@ -74,7 +74,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -83,7 +83,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-kafka-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -106,7 +106,7 @@ repositories:
           cluster_profile: azure4
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-e2e-with-kafka
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka
             from: serverless-source-image
             resources:
               limits:
@@ -115,7 +115,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -124,7 +124,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-kafka-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -147,7 +147,7 @@ repositories:
           cluster_profile: gcp
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-e2e-with-kafka
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka
             from: serverless-source-image
             resources:
               limits:
@@ -156,7 +156,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -165,7 +165,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-kafka-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -207,7 +207,7 @@ repositories:
             HYPERSHIFT_NODE_COUNT: "6"
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true USER_MANAGEMENT_ALLOWED=false make
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin USER_MANAGEMENT_ALLOWED=false make
               test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -217,7 +217,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -226,7 +226,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-kafka-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -264,7 +264,7 @@ repositories:
           - ref: osd-create-create
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-e2e-with-kafka
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka
             from: serverless-source-image
             resources:
               limits:
@@ -273,7 +273,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true make test-upstream-e2e-no-upgrade
+            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
               limits:
@@ -295,7 +295,7 @@ repositories:
           cluster_profile: gcp
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true HA=false make test-e2e-with-kafka-no-tracing
+            commands: FORCE_KONFLUX_INDEX=true HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka-no-tracing
             from: serverless-source-image
             resources:
               limits:
@@ -323,7 +323,7 @@ repositories:
           cluster_profile: vsphere-elastic
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true HA=false make test-e2e-with-kafka
+            commands: FORCE_KONFLUX_INDEX=true HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka
             from: serverless-source-image
             resources:
               limits:


### PR DESCRIPTION
This is to prevent errors like this:
go: github.com/openshift-knative/hack/cmd/sobranch@latest: mkdir /go/pkg/mod/cache/download/github.com/openshift-knative: permission denied

Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-417-vsphere-e2e-vsphere-continuous/1860739093533560832