### PR TITLE
Fix SO release 1.35 cleanup

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -193,7 +193,7 @@ func Generate(cfg Config) error {
 	}
 
 	if !cfg.PipelinesOutputPathSkipRemove {
-		if err := removeAllExcept(cfg.PipelinesOutputPath, fbcBuildPipelinePath, containerBuildPipelinePath); err != nil {
+		if err := removeAllExcept(cfg.PipelinesOutputPath, fbcBuildPipelinePath, containerBuildPipelinePath, containerJavaBuildPipelinePath); err != nil {
 			return fmt.Errorf("failed to clean %q directory: %w", cfg.PipelinesOutputPath, err)
 		}
 	}

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -521,7 +521,12 @@ func InitializeOpenShiftReleaseRepository(ctx context.Context, openShiftRelease 
 		for _, r := range inConfig.Repositories {
 			// TODO: skip automatic deletion for S-O for now
 			if strings.Contains(r.RepositoryDirectory(), "serverless-operator") {
-				for branch := range inConfig.Config.Branches {
+				for branch, branchConfig := range inConfig.Config.Branches {
+					if branchConfig.Prowgen != nil && branchConfig.Prowgen.Disabled {
+						// only cleanup, when we have also to create the prowconfig
+						continue
+					}
+
 					matches, err := filepath.Glob(filepath.Join(*outputConfig, r.RepositoryDirectory(), "*"+branch+"*"))
 					if err != nil {
 						return err

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -523,7 +523,6 @@ func InitializeOpenShiftReleaseRepository(ctx context.Context, openShiftRelease 
 			if strings.Contains(r.RepositoryDirectory(), "serverless-operator") {
 				for branch, branchConfig := range inConfig.Config.Branches {
 					if branchConfig.Prowgen != nil && branchConfig.Prowgen.Disabled {
-						// only cleanup, when we have also to create the prowconfig
 						continue
 					}
 

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -232,9 +232,6 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 	log.Println("Recreating konflux configurations for serverless operator")
 
 	resourceOutputPath := fmt.Sprintf("%s/.konflux", hackRepo.RepositoryDirectory())
-	if err := os.RemoveAll(resourceOutputPath); err != nil {
-		return fmt.Errorf("failed to remove %q directory: %w", resourceOutputPath, err)
-	}
 
 	for release, branch := range konfluxVersions {
 


### PR DESCRIPTION
Fixing a couple of issues:
* Fix: don't remove docker-java-build.yaml pipeline (af87770eed543961b917d1dda0b1a44bb76c4752)
* Fix: Don't delete .konflux dir always (39f286d9ef7a47664f4e141994971694863f02ce)
* Fix: Prowgen only cleanup dir, when prowgen is enabled (57a1a26b45d7572b7b7d01b782c01187d159131b)

Should help on https://github.com/openshift-knative/hack/pull/455#issuecomment-2503728956