### PR TITLE
Specify 4.18 as on-demand for release-1.35 and release-1.36

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -48,6 +48,9 @@ config:
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
@@ -69,6 +72,9 @@ config:
         - name: JAVA_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        version: "4.18"
       - useClusterPool: true
         version: "4.17"
       - onDemand: true


### PR DESCRIPTION
This should be OK next time when "discover branches" runs. We have recently fixed the logic and the openshift versions are copied from the "latest" config in the file.