### PR TITLE
konfluxgen: Create IntegrationTestScenarios for override snapshots

### DIFF
--- a/pkg/konfluxgen/integration-test-scenario.template.yaml
+++ b/pkg/konfluxgen/integration-test-scenario.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
 metadata:
-  name: {{{ truncate ( sanitize .ApplicationName ) }}}-enterprise-contract
+  name: {{{ truncate ( sanitize .Name ) }}}
 spec:
   params: 
     - name: POLICY_CONFIGURATION
@@ -10,8 +10,10 @@ spec:
       value: "120m"
   application: {{{ truncate ( sanitize .ApplicationName ) }}}
   contexts:
-    - description: Application testing
-      name: application
+    {{{- range .Contexts }}}
+    - description: {{{ .Description }}}
+      name: {{{ .Name }}}
+    {{{- end }}}
   resolverRef:
     params:
       - name: url

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -108,8 +108,6 @@ type Config struct {
 
 	ComponentReleasePlanConfig *ComponentReleasePlanConfig
 	AdditionalComponentConfigs []TemplateConfig
-
-	ECPolicyConfigName string
 }
 
 type PrefetchDeps struct {
@@ -326,12 +324,6 @@ func Generate(cfg Config) error {
 				r.Hermetic = "false"
 			}
 
-			if cfg.ECPolicyConfigName == "" {
-				r.ECPolicyConfiguration = "rhtap-releng-tenant/registry-standard-stage"
-			} else {
-				r.ECPolicyConfiguration = cfg.ECPolicyConfigName
-			}
-
 			applications[appKey][Truncate(Sanitize(cfg.ComponentNameFunc(c.ReleaseBuildConfiguration, ib)))] = r
 		}
 	}
@@ -410,20 +402,6 @@ func Generate(cfg Config) error {
 
 			buf.Reset()
 
-			ecTestPath := filepath.Join(cfg.ResourcesOutputPath, ApplicationsDirectoryName, appKey, "tests", "ec-test.yaml")
-			if err := os.MkdirAll(filepath.Dir(ecTestPath), 0777); err != nil {
-				return fmt.Errorf("failed to create directory for %q: %w", appPath, err)
-			}
-
-			if err := enterpriseContractTestScenarioTemplate.Execute(buf, config); err != nil {
-				return fmt.Errorf("failed to execute template for EC test: %w", err)
-			}
-			if err := WriteFileReplacingNewerTaskImages(ecTestPath, buf.Bytes(), 0777); err != nil {
-				return fmt.Errorf("failed to write application file %q: %w", ecTestPath, err)
-			}
-
-			buf.Reset()
-
 			if config.Pipeline == FBCBuild {
 
 				if err := pipelineFBCBuildTemplate.Execute(buf, nil); err != nil {
@@ -447,6 +425,65 @@ func Generate(cfg Config) error {
 				}
 
 			}
+		}
+
+		buf := &bytes.Buffer{}
+
+		// add default integration test scenario with the stage policies
+		config := IntegrationTestConfig{
+			Name:            appKey,
+			ApplicationName: cfg.ApplicationName,
+			Contexts: []IntegrationTestContext{{
+				Name:        "application",
+				Description: "Application testing",
+			}},
+		}
+
+		if len(cfg.FBCImages) > 0 {
+			config.ECPolicyConfiguration = "rhtap-releng-tenant/fbc-stage"
+		} else {
+			config.ECPolicyConfiguration = "rhtap-releng-tenant/registry-standard-stage"
+		}
+
+		ecTestDir := filepath.Join(cfg.ResourcesOutputPath, ApplicationsDirectoryName, appKey, "tests")
+		if err := os.MkdirAll(ecTestDir, 0777); err != nil {
+			return fmt.Errorf("failed to create directory for %q: %w", appKey, err)
+		}
+
+		if err := enterpriseContractTestScenarioTemplate.Execute(buf, config); err != nil {
+			return fmt.Errorf("failed to execute template for EC test: %w", err)
+		}
+		if err := WriteFileReplacingNewerTaskImages(filepath.Join(ecTestDir, "ec-test.yaml"), buf.Bytes(), 0777); err != nil {
+			return fmt.Errorf("failed to write application file: %w", err)
+		}
+
+		buf.Reset()
+
+		// add integration test scenario for override snapshots with prod policies
+		config = IntegrationTestConfig{
+			Name:            fmt.Sprintf("%s-override-snapshot", appKey),
+			ApplicationName: cfg.ApplicationName,
+			Contexts: []IntegrationTestContext{{
+				Name:        "override",
+				Description: "Override Snapshot testing",
+			}},
+		}
+
+		if len(cfg.FBCImages) > 0 {
+			config.ECPolicyConfiguration = "rhtap-releng-tenant/fbc-standard"
+		} else {
+			config.ECPolicyConfiguration = "rhtap-releng-tenant/registry-standard"
+		}
+
+		if err := os.MkdirAll(ecTestDir, 0777); err != nil {
+			return fmt.Errorf("failed to create directory for %q: %w", appKey, err)
+		}
+
+		if err := enterpriseContractTestScenarioTemplate.Execute(buf, config); err != nil {
+			return fmt.Errorf("failed to execute template for EC test: %w", err)
+		}
+		if err := WriteFileReplacingNewerTaskImages(filepath.Join(ecTestDir, "override-snapshot-ec-test.yaml"), buf.Bytes(), 0777); err != nil {
+			return fmt.Errorf("failed to write application file: %w", err)
 		}
 	}
 
@@ -566,8 +603,19 @@ type DockerfileApplicationConfig struct {
 
 	Hermetic string
 
-	DockerfilePath        string
+	DockerfilePath string
+}
+
+type IntegrationTestConfig struct {
+	Name                  string
+	ApplicationName       string
 	ECPolicyConfiguration string
+	Contexts              []IntegrationTestContext
+}
+
+type IntegrationTestContext struct {
+	Name        string
+	Description string
 }
 
 type PipelineEvent string

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -431,7 +431,7 @@ func Generate(cfg Config) error {
 
 		// add default integration test scenario with the stage policies
 		config := IntegrationTestConfig{
-			Name:            appKey,
+			Name:            fmt.Sprintf("%s-ec", appKey),
 			ApplicationName: cfg.ApplicationName,
 			Contexts: []IntegrationTestContext{{
 				Name:        "application",
@@ -461,7 +461,7 @@ func Generate(cfg Config) error {
 
 		// add integration test scenario for override snapshots with prod policies
 		config = IntegrationTestConfig{
-			Name:            fmt.Sprintf("%s-override-snapshot", appKey),
+			Name:            fmt.Sprintf("%s-ec-override-snapshot", appKey),
 			ApplicationName: cfg.ApplicationName,
 			Contexts: []IntegrationTestContext{{
 				Name:        "override",

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -474,9 +474,6 @@ func generateFBCApplications(soMetadata *project.Metadata, openshiftRelease Repo
 			// will change it before merging the PR.
 			// See `openshift-knative/serverless-operator/hack/generate/update-pipelines.sh` for more details.
 			Tags: []string{soMetadata.Project.Version},
-			// use fbc-stage enterprise contract policy for FBC applications
-			// we don't use fbc-standard, as fbc-stage excludes the fbc-related-image-check
-			ECPolicyConfigName: "rhtap-releng-tenant/fbc-stage",
 		}
 
 		if err := konfluxgen.Generate(c); err != nil {


### PR DESCRIPTION
Update konfluxgen to create IntegrationTestScenarios for the override snapshots with the prod policies, so we get early feedback on EC runs