### PR TITLE
Add flag to extended builder env vars

### DIFF
--- a/cmd/generate/dockerfile-templates/DefaultDockerfile.template
+++ b/cmd/generate/dockerfile-templates/DefaultDockerfile.template
@@ -6,9 +6,9 @@ FROM $GO_BUILDER as builder
 
 WORKDIR /workspace
 COPY . .
-
-ENV CGO_ENABLED=1
-ENV GOEXPERIMENT=strictfipsruntime
+{{ range $c := .build_env_vars}}
+{{ $c }}
+{{- end }}
 
 RUN go build -tags strictfipsruntime -o /usr/bin/main ./{{.main}}
 


### PR DESCRIPTION
This should enable event sender or `kn` to be vendorless. 

There are a few other options, but the straight-forward env flag seemed the most practical to me. 

Other options:
- Inferring from existing or not-existing `./vendor` dir 
- Having `--vendorless` flag on the generator
- ... 

/cc @creydr @pierDipi @mgencur 