### PR TITLE
Add PipelineRun specific tag

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -56,13 +56,12 @@ spec:
     - name: revision
       value: '{{revision}}'
     {{{- if eq .Event "push" }}}
-    {{{- if gt (len .Tags) 0 }}}
     - name: additional-tags
       value:
+        - $(context.pipelineRun.uid)-{{revision}}
       {{{- range $tag := .Tags }}}
         - {{{ $tag }}}
       {{{- end }}}
-    {{{- end }}}
     {{{- end }}}
     {{{- if .PrefetchDeps.PrefetchInput }}}
     - name: prefetch-input


### PR DESCRIPTION
We have an operator repository that is aggregating other components images using the custom `latest` tag which eventually turns into a resolved SHA.

When a pipeline runs on push for any "other components", a task after pushing or apply-tags could fail (for whatever reason), in that case, if we re-run the pipeline, the image revision (and therefore tag) is the same, but the SHA is different which ends up invalidating the "previous SHAs" in the operator repository.

Tested in https://github.com/openshift-knative/serverless-operator/pull/3141