### PR TITLE
Revert "change stage rpas to still use prod singing configmaps"

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -934,7 +934,7 @@ func GenerateComponentReleasePlanAdmission(csv *operatorsv1alpha1.ClusterService
 		PyxisSecret:     "pyxis-staging-secret",
 		PyxisServer:     "stage",
 		PipelineSA:      "release-registry-staging",
-		SignCMName:      "hacbs-signing-pipeline-config-redhatrelease2",
+		SignCMName:      "hacbs-signing-pipeline-config-staging-redhatrelease2",
 		Policy:          "registry-standard-stage",
 	}
 	outputFilePath = filepath.Join(outputDir, fmt.Sprintf("%s.yaml", rpaName))


### PR DESCRIPTION
This reverts commit 5cefd34d5ede20cfade3f6393f129eaa818cca91, as this I didn't put this on hold and https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/2995 didn't merge :(