### PR TITLE
Remove FORCE_KONFLUX_INDEX flag

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -16,22 +16,19 @@ config:
           pullSpec: registry.access.redhat.com/ubi8/openjdk-21-runtime
       openShiftVersions:
       - candidateRelease: true
-        cronForceKonfluxIndex: true
         customConfigs:
           enabled: true
           includes:
           - .*ocp4.18-lp-interop.*
         onDemand: true
         version: "4.18"
-      - cronForceKonfluxIndex: true
-        customConfigs:
+      - customConfigs:
           enabled: true
           excludes:
           - .*ocp4.18-lp-interop.*
         useClusterPool: true
         version: "4.17"
-      - cronForceKonfluxIndex: true
-        onDemand: true
+      - onDemand: true
         version: "4.13"
     release-1.35:
       konflux:
@@ -92,7 +89,7 @@ repositories:
           cluster_profile: aws
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -102,7 +99,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
@@ -112,7 +109,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
@@ -136,7 +133,7 @@ repositories:
           cluster_profile: azure4
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -146,7 +143,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
@@ -156,7 +153,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
@@ -180,7 +177,7 @@ repositories:
           cluster_profile: gcp
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -190,7 +187,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
@@ -200,7 +197,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
@@ -243,7 +240,7 @@ repositories:
             HYPERSHIFT_NODE_COUNT: "6"
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               USER_MANAGEMENT_ALLOWED=false make test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -253,7 +250,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
@@ -263,7 +260,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
@@ -302,7 +299,7 @@ repositories:
           - ref: osd-create-create
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -312,7 +309,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
@@ -335,7 +332,7 @@ repositories:
           cluster_profile: gcp
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-e2e-with-kafka-no-tracing
             from: serverless-source-image
             resources:
@@ -364,7 +361,7 @@ repositories:
           cluster_profile: vsphere-elastic
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               make test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -426,7 +423,7 @@ repositories:
           test:
           - ref: cucushift-installer-check-cluster-health
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
@@ -434,7 +431,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true DELETE_CRD_ON_TEARDOWN=false make
               teardown test-e2e-with-kafka
             from: serverless-source-image
@@ -443,7 +440,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
@@ -484,7 +481,7 @@ repositories:
               scenario serverless
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true make test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -494,7 +491,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
@@ -504,7 +501,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:
@@ -540,7 +537,7 @@ repositories:
               scenario serverless
           test:
           - as: operator-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true make test-e2e-with-kafka
             from: serverless-source-image
             resources:
@@ -550,7 +547,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-serving-eventing-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-no-upgrade
             from: serverless-source-image
             resources:
@@ -560,7 +557,7 @@ repositories:
                 cpu: 100m
                 memory: 200Mi
           - as: knative-eventing-kafka-broker-e2e
-            commands: FORCE_KONFLUX_INDEX=true GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
+            commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin
               SKIP_MESH_AUTH_POLICY_GENERATION=true make test-upstream-e2e-kafka-no-upgrade
             from: serverless-source-image
             resources:

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -103,11 +103,10 @@ type OpenShift struct {
 	UseClusterPool bool   `json:"useClusterPool,omitempty" yaml:"useClusterPool,omitempty"`
 	Cron           string `json:"cron,omitempty" yaml:"cron,omitempty"`
 	// SkipCron ensures that no periodic jobs are generated for tests running on the given OpenShift version.
-	SkipCron              bool                     `json:"skipCron,omitempty" yaml:"skipCron,omitempty"`
-	CronForceKonfluxIndex bool                     `json:"cronForceKonfluxIndex,omitempty" yaml:"cronForceKonfluxIndex,omitempty"`
-	OnDemand              bool                     `json:"onDemand,omitempty" yaml:"onDemand,omitempty"`
-	CustomConfigs         *CustomConfigsEnablement `json:"customConfigs,omitempty" yaml:"customConfigs,omitempty"`
-	CandidateRelease      bool                     `json:"candidateRelease,omitempty" yaml:"candidateRelease,omitempty"`
+	SkipCron         bool                     `json:"skipCron,omitempty" yaml:"skipCron,omitempty"`
+	OnDemand         bool                     `json:"onDemand,omitempty" yaml:"onDemand,omitempty"`
+	CustomConfigs    *CustomConfigsEnablement `json:"customConfigs,omitempty" yaml:"customConfigs,omitempty"`
+	CandidateRelease bool                     `json:"candidateRelease,omitempty" yaml:"candidateRelease,omitempty"`
 }
 
 type CustomConfigsEnablement struct {

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -202,10 +202,6 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 			if !test.SkipCron && !openShift.SkipCron && !openShift.CandidateRelease {
 				cronTestConfiguration := testConfiguration.DeepCopy()
 				cronTestConfiguration.As += "-c"
-				// Override test command for periodic jobs if desired.
-				if openShift.CronForceKonfluxIndex {
-					cronTestConfiguration.MultiStageTestConfiguration.Test[0].Commands = fmt.Sprintf("FORCE_KONFLUX_INDEX=true %s", testCommand)
-				}
 				if openShift.Cron == "" {
 					cronTemplate := midstreamCronTemplate
 					// Run s-o tests on other days to prevent hitting limits in AWS.


### PR DESCRIPTION
The flag doesn't work in all cases. For example, there can be changes in serverless-operator images (like knative-openshift) and matching changes in tests. However,  after merging that pull request, only the specific operator image will be built but the Konflux index will still point to old operator images. In this case, running with an out-of-date Konflux index makes the tests fail and people have to investigate these false alarms which might be tricky. The Konflux index will be ready only after a few "make generated-files" runs against s-o.
It is generally safer to always build the Bundle AND Index image within the CI run and have everything up to date. Forcing the Konflux index image makes sense only for specific builds when we're sure all changes propagated to the Index image properly.