### PR TITLE
Return max check-runs per page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -114,7 +114,7 @@
                                             "Authorization": `Bearer ${document.getElementById("pat").value}`
                                         }
                                     }
-                                    const res = await fetch(`https://api.github.com/repos/${r.org}/${r.repo}/commits/${b}/check-runs`, {
+                                    const res = await fetch(`https://api.github.com/repos/${r.org}/${r.repo}/commits/${b}/check-runs?per_page=100`, {
                                         headers: headers
                                     })
                                     const json = await res.json()


### PR DESCRIPTION
Currently we list only 30 checkruns per repo. This can lead to the issue, that some checkruns are not show on the dashboard, when the result is paginaged from GB. As a quick fix, this PR sets `per_page` to the max allowed 100.