### PR TITLE
Allow setting jobTimeout explicitly

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -568,6 +568,7 @@ repositories:
   e2e:
   - match: ^operator-e2e$
   - match: ^test-upgrade$
+    timeout: 1h30m0s
   - ignoreError: true
     match: ^upstream-e2e$
     skipCron: true

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -569,6 +569,7 @@ repositories:
   - match: ^operator-e2e$
   - match: ^test-upgrade$
     timeout: 1h30m0s
+    jobTimeout: 5h0m0s
   - ignoreError: true
     match: ^upstream-e2e$
     skipCron: true

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -42,6 +42,7 @@ type E2ETest struct {
 	SkipCron   bool              `json:"skipCron,omitempty" yaml:"skipCron,omitempty"`
 	SkipImages []string          `json:"skipImages,omitempty" yaml:"skipImages,omitempty"`
 	Timeout    *prowapi.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	JobTimeout *prowapi.Duration `json:"jobTimeout,omitempty" yaml:"jobTimeout,omitempty"`
 }
 
 type Dockerfiles struct {

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -58,13 +58,12 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 			var testTimeout *prowapi.Duration
 			var jobTimeout *prowapi.Duration
 
+			// Use 4h test timeout by default
+			testTimeout = &prowapi.Duration{Duration: 4 * time.Hour}
 			if test.Timeout != nil {
 				testTimeout = test.Timeout
-				jobTimeout = &prowapi.Duration{Duration: test.Timeout.Duration + time.Hour} // test time + 3 * 20m must-gathers
-			} else {
-				// Use 4h test timeout by default
-				testTimeout = &prowapi.Duration{Duration: 4 * time.Hour}
 			}
+			jobTimeout = &prowapi.Duration{Duration: testTimeout.Duration + time.Hour} // test time + 3 * 20m must-gathers
 
 			var (
 				clusterClaim   *cioperatorapi.ClusterClaim

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -64,6 +64,9 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 				testTimeout = test.Timeout
 			}
 			jobTimeout = &prowapi.Duration{Duration: testTimeout.Duration + time.Hour} // test time + 3 * 20m must-gathers
+			if test.JobTimeout != nil {
+				jobTimeout = test.JobTimeout
+			}
 
 			var (
 				clusterClaim   *cioperatorapi.ClusterClaim
@@ -257,6 +260,7 @@ type Test struct {
 	SkipCron     bool
 	SkipImages   []string
 	Timeout      *prowapi.Duration
+	JobTimeout   *prowapi.Duration
 }
 
 func (t *Test) HexSha() string {
@@ -314,7 +318,7 @@ func createTest(r Repository, target string, e2e E2ETest, tests *[]Test, command
 		return fmt.Errorf("[%s] failed to match test %s: %w", r.RepositoryDirectory(), e2e.Match, err)
 	}
 	if matches && !commands.Has(target) {
-		*tests = append(*tests, Test{Command: target, OnDemand: e2e.OnDemand, IgnoreError: e2e.IgnoreError, RunIfChanged: e2e.RunIfChanged, SkipCron: e2e.SkipCron, SkipImages: e2e.SkipImages, Timeout: e2e.Timeout})
+		*tests = append(*tests, Test{Command: target, OnDemand: e2e.OnDemand, IgnoreError: e2e.IgnoreError, RunIfChanged: e2e.RunIfChanged, SkipCron: e2e.SkipCron, SkipImages: e2e.SkipImages, Timeout: e2e.Timeout, JobTimeout: e2e.JobTimeout})
 		commands.Insert(target)
 	}
 	return nil

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -410,7 +410,9 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				Match: "test-e2e$",
 			},
 			{
-				Match: "test-reconcile.*",
+				Match:      "test-reconcile.*",
+				Timeout:    &prowapi.Duration{Duration: 2 * time.Hour},
+				JobTimeout: &prowapi.Duration{Duration: 4 * time.Hour},
 			},
 			{
 				Match: "test-conformance.*",
@@ -611,7 +613,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 									"cpu": "100m",
 								},
 							},
-							Timeout:      &prowapi.Duration{Duration: 4 * time.Hour},
+							Timeout:      &prowapi.Duration{Duration: 2 * time.Hour},
 							Dependencies: dependencies,
 							Cli:          "latest",
 						},
@@ -619,7 +621,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
-			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
+			Timeout: &prowapi.Duration{Duration: 4 * time.Hour},
 		},
 		{
 			As:   "test-reconciler-c",
@@ -637,7 +639,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 									"cpu": "100m",
 								},
 							},
-							Timeout:      &prowapi.Duration{Duration: 4 * time.Hour},
+							Timeout:      &prowapi.Duration{Duration: 2 * time.Hour},
 							Dependencies: dependencies,
 							Cli:          "latest",
 						},
@@ -645,7 +647,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
-			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
+			Timeout: &prowapi.Duration{Duration: 4 * time.Hour},
 		},
 	}
 

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -120,6 +120,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As:       "test-e2e",
@@ -145,6 +146,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As:   "test-e2e-c",
@@ -170,6 +172,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As: "test-e2e-tls",
@@ -194,6 +197,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As:   "test-e2e-tls-c",
@@ -219,6 +223,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As:           "ui-e2e",
@@ -244,6 +249,7 @@ func TestDiscoverTestsServing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 	}
 
@@ -359,6 +365,7 @@ func TestDiscoverTestsServingClusterClaim(t *testing.T) {
 				},
 				Workflow: pointer.String("generic-claim"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 	}
 
@@ -459,6 +466,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As:   "test-conformance-c",
@@ -484,6 +492,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As: "test-conformance-long-long-long-80ea36d",
@@ -508,6 +517,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As:   "test-conformance-long-long-long-80ea36d-c",
@@ -533,6 +543,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As: "test-e2e",
@@ -557,6 +568,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As:   "test-e2e-c",
@@ -582,6 +594,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As: "test-reconciler",
@@ -606,6 +619,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 		{
 			As:   "test-reconciler-c",
@@ -631,6 +645,7 @@ func TestDiscoverTestsEventing(t *testing.T) {
 				},
 				Workflow: pointer.String("ipi-aws"),
 			},
+			Timeout: &prowapi.Duration{Duration: 5 * time.Hour},
 		},
 	}
 


### PR DESCRIPTION
* If not specified, it is testTimeout + 1 hour. Even if the default 4h timeout is used for "test" step, there needs to be some buffer for running must-gather.
* Reduce test timeout for upgrade tests - successful runs take 50-60 minutes so limiting to 1h30m should be enough. 
* Set jobTimeout for upgrade tests explicitly.
