### PR TITLE
Gather test logs on failure

### DIFF
--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -130,6 +130,22 @@ func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, sk
 					Post: []cioperatorapi.TestStep{
 						{
 							LiteralTestStep: &cioperatorapi.LiteralTestStep{
+								As:       "testlog-gather",
+								From:     sourceImageName,
+								Commands: `cp -v ${SHARED_DIR}/debuglog-*.log ${SHARED_DIR}/stdout-*.log ${SHARED_DIR}/stderr-*.log "${ARTIFACT_DIR}/" || true`,
+								Resources: cioperatorapi.ResourceRequirements{
+									Requests: cioperatorapi.ResourceList{
+										"cpu": "100m",
+									},
+								},
+								Timeout:           &prowapi.Duration{Duration: 1 * time.Minute},
+								BestEffort:        pointer.Bool(true),
+								OptionalOnSuccess: pointer.Bool(true),
+								Cli:               "latest",
+							},
+						},
+						{
+							LiteralTestStep: &cioperatorapi.LiteralTestStep{
 								As:       "knative-must-gather",
 								From:     sourceImageName,
 								Commands: `oc adm must-gather --image=quay.io/openshift-knative/must-gather --dest-dir "${ARTIFACT_DIR}/gather-knative"`,

--- a/pkg/prowgen/prowgen_tests_discovery_test.go
+++ b/pkg/prowgen/prowgen_tests_discovery_test.go
@@ -692,6 +692,22 @@ func mustGatherSteps(sourceImage string, optionalOnSuccess bool) []cioperatorapi
 	return []cioperatorapi.TestStep{
 		{
 			LiteralTestStep: &cioperatorapi.LiteralTestStep{
+				As:       "testlog-gather",
+				From:     sourceImage,
+				Commands: `cp -v ${SHARED_DIR}/debuglog-*.log ${SHARED_DIR}/stdout-*.log ${SHARED_DIR}/stderr-*.log "${ARTIFACT_DIR}/" || true`,
+				Resources: cioperatorapi.ResourceRequirements{
+					Requests: cioperatorapi.ResourceList{
+						"cpu": "100m",
+					},
+				},
+				Timeout:           &prowapi.Duration{Duration: 1 * time.Minute},
+				BestEffort:        pointer.Bool(true),
+				OptionalOnSuccess: &optionalOnSuccess,
+				Cli:               "latest",
+			},
+		},
+		{
+			LiteralTestStep: &cioperatorapi.LiteralTestStep{
 				As:       "knative-must-gather",
 				From:     sourceImage,
 				Commands: `oc adm must-gather --image=quay.io/openshift-knative/must-gather --dest-dir "${ARTIFACT_DIR}/gather-knative"`,


### PR DESCRIPTION
Depends on https://github.com/openshift-knative/serverless-operator/pull/3185

When a test container in CI is interrupted due to timeout or infrastructure failures the test log is lost. This change will gather logs from a shared dir where they're copied earlier by the "test" container (see the related PR)