### PR TITLE
Increase Component Release Pipeline Timeout to 6h

### DIFF
--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -51,4 +51,4 @@ spec:
           value: "pipelines/rh-advisories/rh-advisories.yaml"
     serviceAccountName: {{{ .PipelineSA }}}
     timeouts:
-      pipeline: "4h0m0s"
+      pipeline: "6h0m0s"


### PR DESCRIPTION
The current timeout of 4h seems to be pretty tight given that the EC validation takes already 2h (see for example here: https://console.redhat.com/application-pipeline/workspaces/rhtap-releng/applications/serverless-operator-135/pipelineruns/managed-wm648)