### PR TITLE
Fix: Use correct policy for override-snapshot EC

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -472,7 +472,7 @@ func Generate(cfg Config) error {
 		if len(cfg.FBCImages) > 0 {
 			config.ECPolicyConfiguration = "rhtap-releng-tenant/fbc-standard"
 		} else {
-			config.ECPolicyConfiguration = "rhtap-releng-tenant/registry-ocp-serverless"
+			config.ECPolicyConfiguration = "rhtap-releng-tenant/registry-ocp-serverless-prod"
 		}
 
 		if err := os.MkdirAll(ecTestDir, 0777); err != nil {


### PR DESCRIPTION
I missed this fix in #488, when I had to add the `-prod` suffix to the policy :(