### PR TITLE
Fix CEL expression for SO components

### DIFF
--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -320,10 +320,7 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 						" files.all.exists(x, x.matches('^.tekton/'))" +
 						" )"
 				}
-				return "&& (" +
-					" files.all.exists(x, !x.matches('^olm-catalog/')) &&" + // do not run on catalog changes
-					" files.all.exists(x, !x.matches('^.konflux-release/'))" + // do not run on konflux release data changes (e.g override snapshot)
-					" )"
+				return "&& files.all.exists(x, !x.matches('^olm-catalog/') && !x.matches('^.konflux-release/'))"
 			},
 			Includes: []string{
 				fmt.Sprintf("ci-operator/config/%s/.*%s.*.yaml", r.RepositoryDirectory(), branch),


### PR DESCRIPTION
Currently all Konflux pipelines are run, even only on changes in `olm-catalog` or `.konflux-release`. This PR addresses it and fixes the CEL expression for the SO components.

https://playcel.undistro.io/?content=H4sIAAAAAAAAA3WSb0vDMBDGv8qtwrrB1r3fO5GBytShyBCKcGuvbVj%2BlCTdOsTv7qVWZ5HRFzny5J7nd2k%2BooxktIwWC9iSzIwi8AZ8RXCzWsNG4qm0ptH5KNV8ZLgHwgFqENqTxcyLA7HH7to5Ujt5gtocyVIOpA%2FCGq1I%2B%2BBNbS2NJe7MQ01WdMpR%2BOo71yhlNKza2pJzgss16rLBkmDC%2BdMkkHQ0c9ha4QlOprEdGp17Ko7uD7066ozREgJLoXYiJyiMZfi68ZCjxxnX8Hb9sAbevn95egy6Qt%2B7bIIzxM%2BNjrspDigbvBCOJQrtfJd0DuiNVv38oS8zUhLfHPeYgh1Q1ZJcD%2BZqYTFoKX%2BFYCFBKRNqhfNu0s5g1CbMl1XkJvG7kWqecYo05SKewng8lJO90YVs2rklSeiIz0xTHc2iQHYXGPkRXMEtX1v4rUPyCzeT%2FIItUw3AcN0KPORfGnR58bP%2FD2Mgetr7MC5jKZMTE4XH%2BfkFl8sQQ6QCAAA%3D