### PR TITLE
Add Serving's schema-tweak image exclude

### DIFF
--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -51,6 +51,8 @@ repositories:
     - openshift/ci-operator/knative-images.*
     - openshift/ci-operator/knative-test-images.*
     - openshift/ci-operator/knative-perf-images.*
+    excludes:
+    - openshift/ci-operator/knative-images/schema-tweak.*
   e2e:
   - match: .*e2e$
     skipImages:


### PR DESCRIPTION
Per our chat earlier. This is upstream addition, however it's util cmd that doesn't need image to build for it. 


/cc @skonto 