### PR TITLE
Increase workers for EC IntegrationTestScenarios runs

### DIFF
--- a/pkg/konfluxgen/integration-test-scenario.template.yaml
+++ b/pkg/konfluxgen/integration-test-scenario.template.yaml
@@ -8,6 +8,8 @@ spec:
       value: {{{ .ECPolicyConfiguration }}}
     - name: TIMEOUT
       value: "120m"
+    - name: WORKERS
+      value: "8"
   application: {{{ truncate ( sanitize .ApplicationName ) }}}
   contexts:
     {{{- range .Contexts }}}


### PR DESCRIPTION
Since we run very often into timeouts for our EC runs, we increase the worker count from ([default](https://github.com/konflux-ci/release-service-catalog/blob/f1066a9daecf27ed55147ae87dc33565989c33f7/pipelines/managed/rh-advisories/rh-advisories.yaml#L47)) 4 to 8