### PR TITLE
Increase timeouts in component RPA to 10h

### DIFF
--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -52,4 +52,4 @@ spec:
           value: "pipelines/rh-advisories/rh-advisories.yaml"
     serviceAccountName: {{{ .PipelineSA }}}
     timeouts:
-      pipeline: "6h0m0s"
+      pipeline: "10h0m0s"


### PR DESCRIPTION
Increasing as we're still getting timeouts in the release pipeline (EC validate takes > 3h already)