### PR TITLE
Bump skopeo to 1.17

### DIFF
--- a/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
+++ b/cmd/generate/dockerfile-templates/BuildImageDockerfile.template
@@ -19,7 +19,7 @@ RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && 
 RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
-RUN GOFLAGS='' go install -tags="exclude_graphdriver_btrfs containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@v1.16.1
+RUN GOFLAGS='' go install -tags="exclude_graphdriver_btrfs containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@v1.17.0
 
 # go install creates $GOPATH/.cache with root permissions, we delete it here
 # to avoid permission issues with the runtime users

--- a/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
@@ -19,7 +19,7 @@ RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && 
 RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
-RUN GOFLAGS='' go install -tags="exclude_graphdriver_btrfs containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@v1.16.1
+RUN GOFLAGS='' go install -tags="exclude_graphdriver_btrfs containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@v1.17.0
 
 # go install creates $GOPATH/.cache with root permissions, we delete it here
 # to avoid permission issues with the runtime users


### PR DESCRIPTION
1.17 has a `--num-retry` flag which improves reliability of our pipelines.