### PR TITLE
Add Serverless Operator 1.35.0 component release CR

### DIFF
--- a/.konflux/releases/serverless-operator-135-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-1350-prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: serverless-operator-135-1350-prod
+  labels:
+    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
+spec:
+  releasePlan: serverless-operator-135-1350-prod
+  snapshot: serverless-operator-135-override-snapshot-zg96j

--- a/.konflux/releases/serverless-operator-135-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-1350-prod.yaml
@@ -2,8 +2,6 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
   name: serverless-operator-135-1350-prod
-  labels:
-    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
 spec:
   releasePlan: serverless-operator-135-1350-prod
   snapshot: serverless-operator-135-override-snapshot-zg96j


### PR DESCRIPTION
Adding the component release CR for Serverless Operator 1.35.0 (override snapshot `serverless-operator-135-override-snapshot-zg96j`).

Stage release with the override snapshot:
```
$ k get release --sort-by=.metadata.creationTimestamp | grep -i serverless-operator-135-override-snapshot-zg96j
manual-stage-release-override-snapshot-zg96j-g2gg2              serverless-operator-135-override-snapshot-zg96j           serverless-operator-135-1350-stage           Failed           3d21h
manual-stage-release-override-snapshot-zg96j-xvwtn              serverless-operator-135-override-snapshot-zg96j           serverless-operator-135-1350-stage           Failed           3d7h
manual-stage-release-override-snapshot-zg96j-rtk9c              serverless-operator-135-override-snapshot-zg96j           serverless-operator-135-1350-stage           Failed           3d6h
manual-stage-release-override-snapshot-zg96j-cjj2n              serverless-operator-135-override-snapshot-zg96j           serverless-operator-135-1350-stage           Failed           3d3h
manual-stage-release-override-snapshot-zg96j-wz9qm              serverless-operator-135-override-snapshot-zg96j           serverless-operator-135-1350-stage           Failed           2d21h
manual-stage-release-override-snapshot-zg96j-zcbzz              serverless-operator-135-override-snapshot-zg96j           serverless-operator-135-1350-stage           Succeeded        2d6h
```

**Merging this will trigger a production release pipeline of the SO 1.35.0 components when #515 is in!**

/hold to wait for all approvals (QE, docs & P/Z)