### PR TITLE
Add Serverless Operator 1.35.0 FBC release CRs

### DIFF
--- a/.konflux/releases/serverless-operator-135-fbc-414-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-414-1350-prod.yaml
@@ -2,8 +2,6 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
   name: serverless-operator-135-fbc-414-1350-prod
-  labels:
-    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
 spec:
   releasePlan: serverless-operator-135-fbc-414-1350-prod
   snapshot: serverless-operator-135-fbc-414-override-snapshot-7r7h6

--- a/.konflux/releases/serverless-operator-135-fbc-414-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-414-1350-prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: serverless-operator-135-fbc-414-1350-prod
+  labels:
+    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
+spec:
+  releasePlan: serverless-operator-135-fbc-414-1350-prod
+  snapshot: serverless-operator-135-fbc-414-override-snapshot-7r7h6

--- a/.konflux/releases/serverless-operator-135-fbc-415-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-415-1350-prod.yaml
@@ -2,8 +2,6 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
   name: serverless-operator-135-fbc-415-1350-prod
-  labels:
-    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
 spec:
   releasePlan: serverless-operator-135-fbc-415-1350-prod
   snapshot: serverless-operator-135-fbc-415-override-snapshot-cr6th

--- a/.konflux/releases/serverless-operator-135-fbc-415-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-415-1350-prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: serverless-operator-135-fbc-415-1350-prod
+  labels:
+    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
+spec:
+  releasePlan: serverless-operator-135-fbc-415-1350-prod
+  snapshot: serverless-operator-135-fbc-415-override-snapshot-cr6th

--- a/.konflux/releases/serverless-operator-135-fbc-416-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-416-1350-prod.yaml
@@ -2,8 +2,6 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
   name: serverless-operator-135-fbc-416-1350-prod
-  labels:
-    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
 spec:
   releasePlan: serverless-operator-135-fbc-416-1350-prod
   snapshot: serverless-operator-135-fbc-416-override-snapshot-4hxk6

--- a/.konflux/releases/serverless-operator-135-fbc-416-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-416-1350-prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: serverless-operator-135-fbc-416-1350-prod
+  labels:
+    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
+spec:
+  releasePlan: serverless-operator-135-fbc-416-1350-prod
+  snapshot: serverless-operator-135-fbc-416-override-snapshot-4hxk6

--- a/.konflux/releases/serverless-operator-135-fbc-417-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-417-1350-prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: serverless-operator-135-fbc-417-1350-prod
+  labels:
+    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
+spec:
+  releasePlan: serverless-operator-135-fbc-417-1350-prod
+  snapshot: serverless-operator-135-fbc-417-override-snapshot-wqfg6

--- a/.konflux/releases/serverless-operator-135-fbc-417-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-417-1350-prod.yaml
@@ -2,8 +2,6 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
   name: serverless-operator-135-fbc-417-1350-prod
-  labels:
-    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
 spec:
   releasePlan: serverless-operator-135-fbc-417-1350-prod
   snapshot: serverless-operator-135-fbc-417-override-snapshot-wqfg6

--- a/.konflux/releases/serverless-operator-135-fbc-418-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-418-1350-prod.yaml
@@ -2,8 +2,6 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
   name: serverless-operator-135-fbc-418-1350-prod
-  labels:
-    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
 spec:
   releasePlan: serverless-operator-135-fbc-418-1350-prod
   snapshot: serverless-operator-135-fbc-418-override-snapshot-v4m6n

--- a/.konflux/releases/serverless-operator-135-fbc-418-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-418-1350-prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: serverless-operator-135-fbc-418-1350-prod
+  labels:
+    release.appstudio.openshift.io/author: 'system_serviceaccount_ocp-serverless-tenant_gh-action'
+spec:
+  releasePlan: serverless-operator-135-fbc-418-1350-prod
+  snapshot: serverless-operator-135-fbc-418-override-snapshot-v4m6n


### PR DESCRIPTION
Adding the FBC release CRs for Serverless Operator 1.35.0 for the supported OCP versions (4.14 - 4.18)

FBC stage releases with their override snapshot:
```
$ k get release --sort-by=.metadata.creationTimestamp | grep -i succeeded
...
serverless-operator-135-fbc-418-override-snapshot-v4m6n-kxtgr   serverless-operator-135-fbc-418-override-snapshot-v4m6n   serverless-operator-135-fbc-418-1350-stage   Succeeded        3d21h
serverless-operator-135-fbc-415-override-snapshot-cr6th-x4khw   serverless-operator-135-fbc-415-override-snapshot-cr6th   serverless-operator-135-fbc-415-1350-stage   Succeeded        3d21h
serverless-operator-135-fbc-414-override-snapshot-7r7h6-fwd4h   serverless-operator-135-fbc-414-override-snapshot-7r7h6   serverless-operator-135-fbc-414-1350-stage   Succeeded        3d21h
serverless-operator-135-fbc-417-override-snapshot-wqfg6-n9vrj   serverless-operator-135-fbc-417-override-snapshot-wqfg6   serverless-operator-135-fbc-417-1350-stage   Succeeded        3d21h
serverless-operator-135-fbc-416-override-snapshot-4hxk6-6xsqj   serverless-operator-135-fbc-416-override-snapshot-4hxk6   serverless-operator-135-fbc-416-1350-stage   Succeeded        3d21h
...
```

**Merging this will trigger a production release pipeline of the SO 1.35.0 catalog when #515 is in!**

/hold to wait for all approvals (QE, docs & P/Z) and until the release pipeline of #516 succeeded