### PR TITLE
Switch to `kubectl` to apply konflux manifests

### DIFF
--- a/pkg/konfluxapply/konflux_apply.go
+++ b/pkg/konfluxapply/konflux_apply.go
@@ -96,7 +96,7 @@ func apply(ctx context.Context, cfg ApplyConfig, config *prowgen.Config) error {
 				return fmt.Errorf("[%s] failed to stat Konflux directory %q for branch %q: %w", r.RepositoryDirectory(), cfg.KonfluxDir, bn, err)
 			}
 
-			if _, err := prowgen.Run(ctx, r, "oc", "apply", "-Rf", cfg.KonfluxDir); err != nil {
+			if _, err := prowgen.Run(ctx, r, "kubectl", "apply", "-Rf", cfg.KonfluxDir); err != nil {
 				return fmt.Errorf("[%s] failed to apply dir %q in branch %q: %w", cfg.KonfluxDir, r.RepositoryDirectory(), bn, err)
 			}
 		}


### PR DESCRIPTION
We're getting 
```
2025/01/17 06:13:17 Failed to apply dir ".konflux/applications": failed to apply konflux for hack repo: [.konflux/applications] failed to apply dir "openshift-knative/hack" in branch "main": [openshift-knative/hack] failed to run oc [apply -Rf .konflux/applications]: exec: "oc": executable file not found in $PATH
exit status 1
make: *** [Makefile:54: konflux-apply-no-clean] Error 1
```
In the [latest](https://github.com/openshift-knative/hack/actions/runs/12823710855/job/35758674428) konflux-apply runs.
So switching to use `kubectl` to apply the manifests, which is contained in `ubuntu-latest` (https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)