### PR TITLE
Add SO 1.35.0 component release CR (3rd run)

### DIFF
--- a/.konflux/releases/serverless-operator-135-1350-prod-3.yaml
+++ b/.konflux/releases/serverless-operator-135-1350-prod-3.yaml
@@ -1,0 +1,7 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: serverless-operator-135-1350-prod-3
+spec:
+  releasePlan: serverless-operator-135-1350-prod
+  snapshot: serverless-operator-135-override-snapshot-zg96j


### PR DESCRIPTION
Same as #516 but with a release CR with another name (same `.spec` as in #516).
This is some preparation in case the release pipeline of #519 fails as a release pipeline can (yet) only be retriggered with a new release CR.

/hold to trigger only in case run of #519 failed