### PR TITLE
Remove release notes from releaseplan

### DIFF
--- a/pkg/konfluxgen/releaseplan.template.yaml
+++ b/pkg/konfluxgen/releaseplan.template.yaml
@@ -7,21 +7,5 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
   name: {{{ truncate ( sanitize .Name ) }}}
 spec:
-  releaseNotes:
-    type: "Product Enhancement Advisory"
-    synopsis: "Red Hat OpenShift Serverless Release"
-    topic: |
-      The {{{ .SOVersion }}} GA release of Red Hat OpenShift Serverless Operator.
-      For more details see [product documentation](https://docs.redhat.com/documentation/red_hat_openshift_serverless).
-    description: "The {{{ .SOVersion }}} release of Red Hat OpenShift Serverless Operator."
-    solution: |
-      The Red Hat OpenShift Serverless Operator provides a collection of APIs that
-      enables containers, microservices and functions to run "serverless".
-      Serverless applications can scale up and down (to zero) on demand and be triggered by a
-      number of event sources. OpenShift Serverless integrates with a number of
-      platform services, such as Monitoring and it is based on the open
-      source project Knative.
-    references:
-      - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
   application: {{{ truncate ( sanitize .ApplicationName ) }}}
   target: rhtap-releng-tenant

--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -17,11 +17,20 @@ spec:
       product_name: "OpenShift Serverless"
       product_version: "{{{ .SOVersion }}}"
       references:
-        - https://docs.redhat.com/en/documentation/red_hat_openshift_serverless
-      solution: "The container images provided by this update can be downloaded from the Red Hat container registry at registry.redhat.io"
-      description: "Release {{{ .SOVersion }}} of OpenShift Serverless"
-      topic: "Release {{{ .SOVersion }}} of OpenShift Serverless"
-      synopsis: "OpenShift Serverless Release {{{ .SOVersion }}}"
+        - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
+      type: "Product Enhancement Advisory"
+      solution: |
+        The Red Hat OpenShift Serverless Operator provides a collection of APIs that
+        enables containers, microservices and functions to run "serverless".
+        Serverless applications can scale up and down (to zero) on demand and be triggered by a
+        number of event sources. OpenShift Serverless integrates with a number of
+        platform services, such as Monitoring and it is based on the open
+        source project Knative.
+      description: "The {{{ .SOVersion }}} release of Red Hat OpenShift Serverless Operator."
+      topic: |
+        The {{{ .SOVersion }}} GA release of Red Hat OpenShift Serverless Operator.
+        For more details see [product documentation](https://docs.redhat.com/documentation/red_hat_openshift_serverless).
+      synopsis: "Red Hat OpenShift Serverless Release {{{ .SOVersion }}}"
     mapping:
       components:
       {{{- range $component := .Components }}}

--- a/pkg/konfluxgen/releaseplanadmission-component.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-component.template.yaml
@@ -18,7 +18,7 @@ spec:
       product_version: "{{{ .SOVersion }}}"
       references:
         - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
-      type: "Product Enhancement Advisory"
+      type: "RHEA"
       solution: |
         The Red Hat OpenShift Serverless Operator provides a collection of APIs that
         enables containers, microservices and functions to run "serverless".

--- a/pkg/konfluxgen/releaseplanadmission-fbc.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-fbc.template.yaml
@@ -21,7 +21,7 @@ spec:
       product_version: "{{{ .SOVersion }}}"
       references:
         - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
-      type: "Product Enhancement Advisory"
+      type: "RHEA"
       solution: |
         The Red Hat OpenShift Serverless Operator provides a collection of APIs that
         enables containers, microservices and functions to run "serverless".

--- a/pkg/konfluxgen/releaseplanadmission-fbc.template.yaml
+++ b/pkg/konfluxgen/releaseplanadmission-fbc.template.yaml
@@ -20,11 +20,20 @@ spec:
       product_name: "OpenShift Serverless"
       product_version: "{{{ .SOVersion }}}"
       references:
-        - https://docs.redhat.com/en/documentation/red_hat_openshift_serverless
-      solution: "The container images provided by this update can be downloaded from the Red Hat container registry at registry.redhat.io"
-      description: "Release {{{ .SOVersion }}} of OpenShift Serverless"
-      topic: "Release {{{ .SOVersion }}} of OpenShift Serverless"
-      synopsis: "OpenShift Serverless Release {{{ .SOVersion }}}"
+        - "https://docs.redhat.com/documentation/red_hat_openshift_serverless/"
+      type: "Product Enhancement Advisory"
+      solution: |
+        The Red Hat OpenShift Serverless Operator provides a collection of APIs that
+        enables containers, microservices and functions to run "serverless".
+        Serverless applications can scale up and down (to zero) on demand and be triggered by a
+        number of event sources. OpenShift Serverless integrates with a number of
+        platform services, such as Monitoring and it is based on the open
+        source project Knative.
+      description: "The {{{ .SOVersion }}} release of Red Hat OpenShift Serverless Operator."
+      topic: |
+        The {{{ .SOVersion }}} GA release of Red Hat OpenShift Serverless Operator.
+        For more details see [product documentation](https://docs.redhat.com/documentation/red_hat_openshift_serverless).
+      synopsis: "Red Hat OpenShift Serverless Release {{{ .SOVersion }}}"
     fbc:
       {{{- if .StagedIndex }}}
       stagedIndex: true


### PR DESCRIPTION
We are getting `strict decoding error: unknown field "spec.releaseNotes"` when applying the release plans (e.g. [here](https://github.com/openshift-knative/hack/actions/runs/12923372337/job/36040566849)). So removing this field from the RP and updating the releaseNotes in the RPA.