### PR TITLE
Run EC tests on push

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -454,7 +454,7 @@ func Generate(cfg Config) error {
 			Name:            fmt.Sprintf("%s-ec", appKey),
 			ApplicationName: cfg.ApplicationName,
 			Contexts: []IntegrationTestContext{{
-				Name:        "application",
+				Name:        "push",
 				Description: "Application testing",
 			}},
 		}


### PR DESCRIPTION
EC tests on PRs is constantly failing and it doesn't make sense as it's now just noise. We can re-evaluate if running it on PRs makes sense in the future but now it's just not working.