### PR TITLE
Add SO 1.35.0 FBC release for 4.18 (2nd run)

### DIFF
--- a/.konflux/releases/serverless-operator-135-fbc-418-1350-prod.yaml
+++ b/.konflux/releases/serverless-operator-135-fbc-418-1350-prod.yaml
@@ -1,7 +1,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: serverless-operator-135-fbc-418-1350-prod
+  name: serverless-operator-135-fbc-418-1350-prod-2
 spec:
   releasePlan: serverless-operator-135-fbc-418-1350-prod
   snapshot: serverless-operator-135-fbc-418-override-snapshot-v4m6n


### PR DESCRIPTION
4.18 pipeline of #517 failed (https://console.redhat.com/application-pipeline/workspaces/rhtap-releng/applications/serverless-operator-135-fbc-418/pipelineruns/managed-c5ltr). So adding a 2nd release attempt