### PR TITLE
Run make generate-release before running konfluxgen

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -212,14 +212,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/backstage-plugins
-      - name: '[backstage-plugins - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/backstage-plugins
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -243,14 +235,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/backstage-plugins
-      - name: '[backstage-plugins - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/backstage-plugins
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -300,14 +284,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/client
-      - name: '[client - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/client
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -331,14 +307,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/client
-      - name: '[client - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/client
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -388,14 +356,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
-      - name: '[eventing-istio - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -419,14 +379,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
-      - name: '[eventing-istio - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -476,14 +428,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
-      - name: '[eventing-kafka-broker - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -507,14 +451,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
-      - name: '[eventing-kafka-broker - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -564,14 +500,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
-      - name: '[eventing - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -595,14 +523,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
-      - name: '[eventing - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -724,14 +644,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/kn-plugin-func
-      - name: '[kn-plugin-func - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          ./openshift/scripts/generate-dockerfiles.sh
-          git add .
-          git commit -m "Run ./openshift/scripts/generate-dockerfiles.sh" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/kn-plugin-func
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -755,14 +667,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/kn-plugin-func
-      - name: '[kn-plugin-func - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          ./openshift/scripts/generate-dockerfiles.sh
-          git add .
-          git commit -m "Run ./openshift/scripts/generate-dockerfiles.sh" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/kn-plugin-func
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -884,14 +788,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
-      - name: '[net-istio - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -915,14 +811,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
-      - name: '[net-istio - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -972,14 +860,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
-      - name: '[net-kourier - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -1003,14 +883,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
-      - name: '[net-kourier - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -1060,14 +932,6 @@ jobs:
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" --label needs-ok-to-test || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving
-      - name: '[serving - release-v1.15] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.15
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -1091,14 +955,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update Konflux configurations" --body "Update Konflux components and pipelines" --label needs-ok-to-test || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving
-      - name: '[serving - release-v1.16] Update codegen'
-        run: |
-          set -euox
-          git checkout sync-konflux-release-v1.16
-          make generate-release
-          git add .
-          git commit -m "Run make generate-release" || true # ignore: nothing to commit
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}

--- a/pkg/action/update_action.go
+++ b/pkg/action/update_action.go
@@ -177,19 +177,6 @@ gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$t
 
 				localBranch := fmt.Sprintf("%s%s", prowgen.KonfluxBranchPrefix, branchName)
 
-				if run := r.RunDockefileGenCommand(); run != "" && !r.IsServerlessOperator() {
-					steps = append(steps, map[string]interface{}{
-						"name":              fmt.Sprintf("[%s - %s] Update codegen", r.Repo, branchName),
-						"working-directory": fmt.Sprintf("./src/github.com/openshift-knative/hack/%s", r.RepositoryDirectory()),
-						"run": fmt.Sprintf(`set -euox
-git checkout %s
-%s
-git add .
-git commit -m "Run %s" || true # ignore: nothing to commit
-`, localBranch, run, run),
-					})
-				}
-
 				steps = append(steps, map[string]interface{}{
 					"name": fmt.Sprintf("[%s - %s] Create Konflux PR", r.Repo, branchName),
 					"if":   "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}",

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -155,6 +155,23 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						return err
 					}
 
+					pushBranch := fmt.Sprintf("%s%s", KonfluxBranchPrefix, branchName)
+
+					if run := r.RunDockefileGenCommand(); run != "" {
+						commitMsg := fmt.Sprintf("Generate dockerfiles with %q", run)
+						commands := strings.Split(run, " ")
+						var args []string
+						if len(commands) > 1 {
+							args = commands[1:]
+						}
+						if out, err := Run(ctx, r, commands[0], args...); err != nil {
+							return fmt.Errorf("failed to %s for %q [%s]: %w - %s", commitMsg, r.RepositoryDirectory(), targetBranch, err, string(out))
+						}
+						if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
+							return err
+						}
+					}
+
 					nudges := b.Konflux.Nudges
 					if soBranchName != "release-next" {
 						_, ok := operatorVersions[soBranchName]
@@ -198,9 +215,7 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						return fmt.Errorf("failed to generate Konflux configurations for %s (%s): %w", r.RepositoryDirectory(), branchName, err)
 					}
 
-					pushBranch := fmt.Sprintf("%s%s", KonfluxBranchPrefix, branchName)
 					commitMsg := fmt.Sprintf("[%s] Sync Konflux configurations", targetBranch)
-
 					if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
 						return err
 					}


### PR DESCRIPTION
We're running `make generate-release` (or equivalent) after running konfluxgen. The issue with that is that the dockerfile generator is also generating the `rpms` lock file which is necessary to enable the prefetch dependencies task for rpms.

If we run it before, the RPMs lock file would be present.