### PR TITLE
Fix run name in dashboard UI to re-run tests

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -154,7 +154,11 @@
                                     .filter(run => run.name.includes('Konflux'))
                                     .map((run) => {
 
-                                        const testName = run.name.slice(run.app.name.length).replace(/[\t /]+/, '').trim()
+                                        const separator = run.name.indexOf('/')
+                                        let testName = run.name
+                                        if (separator >= 0 && separator < run.name.length - 1) {
+                                            testName = run.name.slice(separator+1).trim()
+                                        }
 
                                         return [
                                             branch,


### PR DESCRIPTION
The migration to the new cluster broke the logic to retrieve the test name to re-run.

See example broken name: https://github.com/openshift-knative/eventing/commit/bf54a5336fe39d2097336ad03dfb7c1fab2b6782#commitcomment-151851523

Names are like `Konflux kflux-prd-rh02 / kn-eventing-controller-116-on-push`