### PR TITLE
Fix commit message for dependabot PR update

### DIFF
--- a/pkg/dependabotgen/dependabotgen.go
+++ b/pkg/dependabotgen/dependabotgen.go
@@ -188,7 +188,7 @@ jobs:
 
       - name: Generate files
         working-directory: ./src/github.com/${{ github.repository }}
-        run: %s
+        run: %[1]s
 
       - name: git push
         working-directory: ./src/github.com/${{ github.repository }}
@@ -198,7 +198,7 @@ jobs:
             git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git config --local user.name "github-actions[bot]"
             git add .
-            git commit -m "Run generate release"
+            git commit -m "Run %[1]s"
             git push
           fi
 `, run))


### PR DESCRIPTION
Uses executed command in commit message, so it's a bit clearer and we don't have something like https://github.com/openshift-knative/serverless-operator/pull/3330/files#diff-f3e87f564ac7fc73df0a993a3baab40cbf2ba0c3023bb05ff4d3be55df5d04b1R42