### PR TITLE
Update go version in go.mod to latest patch release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-knative/hack
 
-go 1.22.4
+go 1.22.11
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Seeing issues with license checker in generate-ci [job](https://github.com/openshift-knative/hack/actions/runs/13107571744):

```
Command '__go_update_deps_for_module' failed in module /home/runner/work/hack/hack/src/github.com/openshift-knative/hack/openshift-knative/eventing-istio: 1
```
Which is usually related to the Go version

https://github.com/openshift-knative/hack/blob/80c8104ea74e6001b04fa2b64ff00b59ca336855/.github/workflows/release-generate-ci.yaml#L114