### PR TITLE
Downgrade Go patch version to 1.22.9 again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-knative/hack
 
-go 1.22.11
+go 1.22.9
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
After #551 we're seeing `go: github.com/openshift-knative/hack/cmd/sobranch@latest: github.com/openshift-knative/hack@v0.0.0-20250203094031-183913a46ca1 requires go >= 1.22.11 (running go 1.22.9; GOTOOLCHAIN=local)` in prow CI, as we have only go 1.22.9 in those images