### PR TITLE
Exclude enterprise contract runs from dashboard by default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,6 +181,9 @@
                 destroy: true,
                 paging: false,
                 data: data,
+                search: {
+                    search: '!-ec '
+                },
             })
         })
     })


### PR DESCRIPTION
For a better overview on the builds, we can filter the EC runs from the default view (can still be brought back, by adjusting the search query)