### PR TITLE
Propagate dependabot-deps workflow to every release branch

### DIFF
--- a/pkg/dependabotgen/dependabotgen.go
+++ b/pkg/dependabotgen/dependabotgen.go
@@ -164,6 +164,11 @@ func (cfg *DependabotConfig) WithMaven(dirs []string, branch string) {
 	*cfg.Updates = append(*cfg.Updates, u)
 }
 
+const (
+	ghDir        = ".github"
+	workflowsDir = "workflows"
+)
+
 func (cfg *DependabotConfig) Write(repoDir string, run string) error {
 	log.Printf("Writing dependabot config %#v\n", *cfg)
 
@@ -181,9 +186,6 @@ func (cfg *DependabotConfig) Write(repoDir string, run string) error {
 		return fmt.Errorf("failed to marshal dependabot config: %w", err)
 	}
 
-	const ghDir = ".github"
-	const workflowsDir = "workflows"
-
 	if err := os.MkdirAll(filepath.Join(repoDir, ghDir, workflowsDir), 0755); err != nil {
 		return fmt.Errorf("failed to create .github directory: %w", err)
 	}
@@ -191,6 +193,14 @@ func (cfg *DependabotConfig) Write(repoDir string, run string) error {
 		return fmt.Errorf("failed to write dependabot config file: %w", err)
 	}
 
+	if err := WriteDependabotWorkflow(repoDir, run); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func WriteDependabotWorkflow(repoDir string, run string) error {
 	if run == "" {
 		return nil
 	}
@@ -241,7 +251,7 @@ jobs:
           fi
 `, run))
 	if err := os.WriteFile(filepath.Join(repoDir, ghDir, workflowsDir, "dependabot-deps.yaml"), workflow, 0644); err != nil {
-		return fmt.Errorf("failed to write dependabot workflow file: %w", err)
+		return fmt.Errorf("failed to write dependabot workflow file in %q: %w", repoDir, err)
 	}
 
 	return nil

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -223,6 +223,10 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						return fmt.Errorf("failed to generate Konflux configurations for %s (%s): %w", r.RepositoryDirectory(), branchName, err)
 					}
 
+					if err := dependabotgen.WriteDependabotWorkflow(r.RepositoryDirectory(), r.RunCodegenCommand()); err != nil {
+						return fmt.Errorf("[%s][%s] failed to write dependabot workflow: %w", r.RepositoryDirectory(), branchName, err)
+					}
+
 					commitMsg := fmt.Sprintf("[%s] Sync Konflux configurations", targetBranch)
 					if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
 						return err
@@ -436,6 +440,10 @@ func GenerateKonfluxServerlessOperator(ctx context.Context, openshiftRelease Rep
 
 		if err := generateFBCApplications(soMetadata, openshiftRelease, r, branch, release, resourceOutputPath, buildArgs); err != nil {
 			return fmt.Errorf("failed to generate FBC applications for %s (%s): %w", r.RepositoryDirectory(), branch, err)
+		}
+
+		if err := dependabotgen.WriteDependabotWorkflow(r.RepositoryDirectory(), r.RunCodegenCommand()); err != nil {
+			return fmt.Errorf("[%s][%s] failed to write dependabot workflow: %w", r.RepositoryDirectory(), branch, err)
 		}
 
 		pushBranch := fmt.Sprintf("%s%s", KonfluxBranchPrefix, branch)


### PR DESCRIPTION
This will re-run `make generate-release` or equivalent when deps update PRs are opened by Dependabot