### PR TITLE
Run prowgen-konflux in parallel per repository

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -153,26 +153,36 @@ func Main() {
 	if err := repositoriesGenerateConfigs.Wait(); err != nil {
 		log.Fatalln("Failed waiting for repositories generator", err)
 	}
-	if *build {
-		if err := RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
-			log.Fatalln("Failed to run openshift/release generator:", err)
+
+	openshiftGeneratorGroup := errgroup.Group{}
+	openshiftGeneratorGroup.Go(func() error {
+		if *build {
+			if err := RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
+				return fmt.Errorf("failed running OpenShiftReleaseGenerator: %w", err)
+			}
+			if err := runJobConfigInjectors(inConfigs, openShiftRelease); err != nil {
+				return fmt.Errorf("failed running JobConfigInjectors: %w", err)
+			}
+			if err := RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
+				return fmt.Errorf("failed running OpenShiftReleaseGenerator (2): %w", err)
+			}
 		}
-		if err := runJobConfigInjectors(inConfigs, openShiftRelease); err != nil {
-			log.Fatalln("Failed to inject Slack reporter", err)
+		if *push {
+			if err := PushBranch(ctx, openShiftRelease, remote, *branch, "Sync Serverless CI "+*inputConfig); err != nil {
+				return fmt.Errorf("failed to push branch to openshift/release fork %s: %w", *remote, err)
+			}
 		}
-		if err := RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
-			log.Fatalln("Failed to run openshift/release generator after injecting Slack reporter", err)
-		}
-	}
-	if *push {
-		if err := PushBranch(ctx, openShiftRelease, remote, *branch, "Sync Serverless CI "+*inputConfig); err != nil {
-			log.Fatalln("Failed to push branch to openshift/release fork", *remote, err)
-		}
-	}
+		return nil
+	})
+
 	if *konflux {
 		if err := GenerateKonflux(ctx, openShiftRelease, inConfigs); err != nil {
 			log.Fatalln("Failed to generate Konflux configurations: %w", err)
 		}
+	}
+
+	if err := openshiftGeneratorGroup.Wait(); err != nil {
+		log.Fatalln(err)
 	}
 }
 


### PR DESCRIPTION
This improves running time as we can run the (slow) `make generate-release` per repository in parallel.

From the most recent runs on PRs, it takes 45 minutes
- https://github.com/openshift-knative/hack/actions/runs/13807089134/job/38620044286
- https://github.com/openshift-knative/hack/actions/runs/13809013855/job/38626082729

while this PR make it run in 30-35 minutes:
- https://github.com/openshift-knative/hack/actions/runs/13808751655/job/38625284339?pr=563
- https://github.com/openshift-knative/hack/actions/runs/13814087147/job/38642620084?pr=563