### PR TITLE
Skip presubmit OCP CI jobs when only Konflux configs change

### DIFF
--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -258,6 +258,7 @@ func (jcis JobConfigCopiedInjectors) Inject(prowcopyCfg *Config, prowgenCfg *pro
 func runProwCopyInjectors(config *Config, inConfig *prowgen.Config, openShiftRelease prowgen.Repository) error {
 	injectors := JobConfigCopiedInjectors{
 		prowgen.AlwaysRunInjector(),
+		prowgen.SkipIfOnlyKonfluxChangedInjector(),
 	}
 	return injectors.Inject(config, inConfig, openShiftRelease)
 }

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -327,12 +327,27 @@ func runJobConfigInjectors(inConfigs []*Config, openShiftRelease Repository) err
 		injectors := JobConfigInjectors{
 			AlwaysRunInjector(),
 			slackInjector(),
+			SkipIfOnlyKonfluxChangedInjector(),
 		}
 		if err := injectors.Inject(inConfig, openShiftRelease); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func SkipIfOnlyKonfluxChangedInjector() JobConfigInjector {
+	return JobConfigInjector{
+		Type: PreSubmit,
+		Update: func(r *Repository, b *Branch, branchName string, jobConfig *prowconfig.JobConfig) error {
+			for k := range jobConfig.PresubmitsStatic {
+				for i := range jobConfig.PresubmitsStatic[k] {
+					jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = "^.tekton/.*|^.konflux.*|^.github/.*"
+				}
+			}
+			return nil
+		},
+	}
 }
 
 func slackInjector() JobConfigInjector {


### PR DESCRIPTION
We don't need to run expensive tests when only Konflux config change