### PR TITLE
Set AlwaysRun to false, if SkipIfOnlyChanged is set as both are mutual exclusive

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -343,6 +343,7 @@ func SkipIfOnlyKonfluxChangedInjector() JobConfigInjector {
 			for k := range jobConfig.PresubmitsStatic {
 				for i := range jobConfig.PresubmitsStatic[k] {
 					jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = "^.tekton/.*|^.konflux.*|^.github/.*"
+					jobConfig.PresubmitsStatic[k][i].AlwaysRun = false
 				}
 			}
 			return nil


### PR DESCRIPTION
We're getting the following in our current ci-config checks:
```
job pull-ci-openshift-knative-eventing-istio-release-next-417-e2e-tests is set to always run but also declares skip_if_only_changed targets, which are mutually exclusive
```
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/61453/pull-ci-openshift-release-master-config/1889595034622234624

So setting `AlwaysRun` to false in case `SkipIfOnlyChanged` is set