### PR TITLE
Update skip if only changed for Konflux configs

### DIFF
--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -258,7 +258,6 @@ func (jcis JobConfigCopiedInjectors) Inject(prowcopyCfg *Config, prowgenCfg *pro
 func runProwCopyInjectors(config *Config, inConfig *prowgen.Config, openShiftRelease prowgen.Repository) error {
 	injectors := JobConfigCopiedInjectors{
 		prowgen.AlwaysRunInjector(),
-		prowgen.SkipIfOnlyKonfluxChangedInjector(),
 	}
 	return injectors.Inject(config, inConfig, openShiftRelease)
 }

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -327,27 +327,12 @@ func runJobConfigInjectors(inConfigs []*Config, openShiftRelease Repository) err
 		injectors := JobConfigInjectors{
 			AlwaysRunInjector(),
 			slackInjector(),
-			SkipIfOnlyKonfluxChangedInjector(),
 		}
 		if err := injectors.Inject(inConfig, openShiftRelease); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func SkipIfOnlyKonfluxChangedInjector() JobConfigInjector {
-	return JobConfigInjector{
-		Type: PreSubmit,
-		Update: func(r *Repository, b *Branch, branchName string, jobConfig *prowconfig.JobConfig) error {
-			for k := range jobConfig.PresubmitsStatic {
-				for i := range jobConfig.PresubmitsStatic[k] {
-					jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = "^.tekton/.*|^.konflux.*|^.github/.*"
-				}
-			}
-			return nil
-		},
-	}
 }
 
 func slackInjector() JobConfigInjector {
@@ -415,17 +400,22 @@ func AlwaysRunInjector() JobConfigInjector {
 
 					// Prevent sneaking in wrong settings from previous runs of "make jobs".
 					// Make sure we reset it to default.
-					jobConfig.PresubmitsStatic[k][i].AlwaysRun = true
+					jobConfig.PresubmitsStatic[k][i].AlwaysRun = false
+					jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = "^.tekton/.*|^.konflux.*|^.github/.*"
 
 					// Build images in pre-submit phase only for OpenShift versions that are mandatory to test.
 					if strings.HasSuffix(jobConfig.PresubmitsStatic[k][i].Name, "-images") {
-						jobConfig.PresubmitsStatic[k][i].AlwaysRun = !onDemandForOpenShift && strings.HasSuffix(jobConfig.PresubmitsStatic[k][i].Name, ocpVersion+"-images")
+						if onDemandForOpenShift && strings.HasSuffix(jobConfig.PresubmitsStatic[k][i].Name, ocpVersion+"-images") {
+							// On demand jobs don't run even when specific dir changes.
+							jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = ""
+						}
 					}
 
 					for _, t := range tests {
 						name := ToName(*r, &t)
 						if (t.OnDemand || t.RunIfChanged != "" || onDemandForOpenShift) && strings.Contains(jobConfig.PresubmitsStatic[k][i].Name, name) {
-							jobConfig.PresubmitsStatic[k][i].AlwaysRun = false
+							// On demand jobs don't run even when specific dir changes.
+							jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = ""
 						}
 					}
 				}


### PR DESCRIPTION
There is a misconfiguration https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/61453/pull-ci-openshift-release-master-config/1889595034622234624

```
is set to always run but also declares skip_if_only_changed targets
```