### PR TITLE
add override for func plugin repo in for release 1.17

### DIFF
--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -26,6 +26,9 @@ config:
     release-v1.17:
       konflux:
         enabled: true
+        imagesOverrides:
+        - name: GO_BUILDER
+          pullSpec: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.23
       openShiftVersions:
       - candidateRelease: true
         onDemand: true


### PR DESCRIPTION
bump golang builder image with version `1.23` as override for func plugin repo release branch `v1.17`

failing konflux action: https://github.com/openshift-knative/kn-plugin-func/pull/1089/checks?check_run_id=37081328584

on this PR: https://github.com/openshift-knative/kn-plugin-func/pull/1089