### PR TITLE
:broom: Skipping source dockerfile for vendorless projects

### DIFF
--- a/pkg/dockerfilegen/generator.go
+++ b/pkg/dockerfilegen/generator.go
@@ -182,8 +182,12 @@ func generateDockerfile(params Params, mainPackagesPaths sets.String) error {
 		return err
 	}
 
-	if _, err = saveDockerfile(d, DockerfileSourceImageTemplate, params.Output, params.DockerfilesSourceDir); err != nil {
-		return err
+	if dirExists(path.Join(params.RootDir, "vendor")) {
+		if _, err = saveDockerfile(d, DockerfileSourceImageTemplate, params.Output, params.DockerfilesSourceDir); err != nil {
+			return err
+		}
+	} else {
+		log.Println("Skipping source dockerfile for vendorless projects")
 	}
 
 	var additionalInstructions []string
@@ -547,4 +551,9 @@ func writeRPMLockFile(rpmsLockTemplate fs.FS, rootDir string) error {
 			ErrIO, errors.WithStack(err))
 	}
 	return nil
+}
+
+func dirExists(pth string) bool {
+	fi, err := os.Stat(pth)
+	return err == nil && fi.IsDir()
 }


### PR DESCRIPTION
Just skipping the source Dockerfile if it is not needed.

/kind cleanup

Part of [SRVCLI-405](https://issues.redhat.com/browse/SRVCLI-405)