### PR TITLE
:broom: Export the default param values to allow easy reuse

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/openshift-knative/hack/pkg/dockerfilegen"
 	"github.com/openshift-knative/hack/pkg/util/errors"
@@ -18,26 +17,27 @@ func main() {
 	}
 
 	params := dockerfilegen.Params{}
+	defs := dockerfilegen.DefaultParams(wd)
 
-	pflag.StringVar(&params.RootDir, "root-dir", wd, "Root directory to start scanning, default to current working directory")
-	pflag.StringArrayVar(&params.Includes, "includes", dockerfilegen.DefaultIncludes, "File or directory regex to include")
-	pflag.StringArrayVar(&params.Excludes, "excludes", dockerfilegen.DefaultExcludes, "File or directory regex to exclude")
-	pflag.StringVar(&params.Generators, "generators", dockerfilegen.GenerateDockerfileOption, fmt.Sprintf("Generate something supported: %q", []string{dockerfilegen.GenerateDockerfileOption, dockerfilegen.GenerateMustGatherDockerfileOption}))
-	pflag.StringVar(&params.DockerfilesDir, "dockerfile-dir", "ci-operator/knative-images", "Dockerfiles output directory for project images relative to output flag")
-	pflag.StringVar(&params.DockerfilesBuildDir, "dockerfile-build-dir", "ci-operator/build-image", "Dockerfiles output directory for build image relative to output flag")
-	pflag.StringVar(&params.DockerfilesSourceDir, "dockerfile-source-dir", "ci-operator/source-image", "Dockerfiles output directory for source image relative to output flag")
-	pflag.StringVar(&params.DockerfilesTestDir, "dockerfile-test-dir", "ci-operator/knative-test-images", "Dockerfiles output directory for test images relative to output flag")
-	pflag.StringVar(&params.Output, "output", "openshift", "Output directory")
-	pflag.StringVar(&params.ProjectFilePath, "project-file", filepath.Join("openshift", "project.yaml"), "Project metadata file path")
-	pflag.StringVar(&params.DockerfileImageBuilderFmt, "dockerfile-image-builder-fmt", dockerfilegen.BuilderImageFmt, "Dockerfile image builder format")
-	pflag.StringVar(&params.AppFileFmt, "app-file-fmt", "/usr/bin/%s", "Target application binary path format")
-	pflag.StringVar(&params.RegistryImageFmt, "registry-image-fmt", "registry.ci.openshift.org/openshift/%s:%s", "Container registry image format")
-	pflag.StringArrayVar(&params.ImagesFromRepositories, "images-from", nil, "Additional image references to be pulled from other midstream repositories matching the tag in project.yaml")
-	pflag.StringVar(&params.ImagesFromRepositoriesURLFmt, "images-from-url-format", "https://raw.githubusercontent.com/openshift-knative/%s/%s/openshift/images.yaml", "Additional images to be pulled from other midstream repositories matching the tag in project.yaml")
-	pflag.StringArrayVar(&params.AdditionalPackages, "additional-packages", nil, "Additional packages to be installed in the image")
-	pflag.StringArrayVar(&params.AdditionalBuildEnvVars, "additional-build-env", nil, "Additional env vars to be added to builder in the image")
-	pflag.StringVar(&params.TemplateName, "template-name", dockerfilegen.DefaultDockerfileTemplateName, fmt.Sprintf("Dockerfile template name to use. Supported values are [%s, %s]", dockerfilegen.DefaultDockerfileTemplateName, dockerfilegen.FuncUtilDockerfileTemplateName))
-	pflag.BoolVar(&params.RpmsLockFileEnabled, "generate-rpms-lock-file", false, "Enable the creation of the rpms.lock.yaml file")
+	pflag.StringVar(&params.RootDir, "root-dir", defs.RootDir, "Root directory to start scanning, default to current working directory")
+	pflag.StringArrayVar(&params.Includes, "includes", defs.Includes, "File or directory regex to include")
+	pflag.StringArrayVar(&params.Excludes, "excludes", defs.Excludes, "File or directory regex to exclude")
+	pflag.StringVar(&params.Generators, "generators", defs.Generators, fmt.Sprintf("Generate something supported: %q", []string{dockerfilegen.GenerateDockerfileOption, dockerfilegen.GenerateMustGatherDockerfileOption}))
+	pflag.StringVar(&params.DockerfilesDir, "dockerfile-dir", defs.DockerfilesDir, "Dockerfiles output directory for project images relative to output flag")
+	pflag.StringVar(&params.DockerfilesBuildDir, "dockerfile-build-dir", defs.DockerfilesBuildDir, "Dockerfiles output directory for build image relative to output flag")
+	pflag.StringVar(&params.DockerfilesSourceDir, "dockerfile-source-dir", defs.DockerfilesSourceDir, "Dockerfiles output directory for source image relative to output flag")
+	pflag.StringVar(&params.DockerfilesTestDir, "dockerfile-test-dir", defs.DockerfilesTestDir, "Dockerfiles output directory for test images relative to output flag")
+	pflag.StringVar(&params.Output, "output", defs.Output, "Output directory")
+	pflag.StringVar(&params.ProjectFilePath, "project-file", defs.ProjectFilePath, "Project metadata file path")
+	pflag.StringVar(&params.DockerfileImageBuilderFmt, "dockerfile-image-builder-fmt", defs.DockerfileImageBuilderFmt, "Dockerfile image builder format")
+	pflag.StringVar(&params.AppFileFmt, "app-file-fmt", defs.AppFileFmt, "Target application binary path format")
+	pflag.StringVar(&params.RegistryImageFmt, "registry-image-fmt", defs.RegistryImageFmt, "Container registry image format")
+	pflag.StringArrayVar(&params.ImagesFromRepositories, "images-from", defs.ImagesFromRepositories, "Additional image references to be pulled from other midstream repositories matching the tag in project.yaml")
+	pflag.StringVar(&params.ImagesFromRepositoriesURLFmt, "images-from-url-format", defs.ImagesFromRepositoriesURLFmt, "Additional images to be pulled from other midstream repositories matching the tag in project.yaml")
+	pflag.StringArrayVar(&params.AdditionalPackages, "additional-packages", defs.AdditionalPackages, "Additional packages to be installed in the image")
+	pflag.StringArrayVar(&params.AdditionalBuildEnvVars, "additional-build-env", defs.AdditionalBuildEnvVars, "Additional env vars to be added to builder in the image")
+	pflag.StringVar(&params.TemplateName, "template-name", defs.TemplateName, fmt.Sprintf("Dockerfile template name to use. Supported values are [%s, %s]", dockerfilegen.DefaultDockerfileTemplateName, dockerfilegen.FuncUtilDockerfileTemplateName))
+	pflag.BoolVar(&params.RpmsLockFileEnabled, "generate-rpms-lock-file", defs.RpmsLockFileEnabled, "Enable the creation of the rpms.lock.yaml file")
 	pflag.Parse()
 
 	if err = dockerfilegen.GenerateDockerfiles(params); err != nil {

--- a/pkg/dockerfilegen/generator.go
+++ b/pkg/dockerfilegen/generator.go
@@ -206,8 +206,10 @@ func generateDockerfile(params Params, mainPackagesPaths sets.String) error {
 		additionalInstructions = append(additionalInstructions, fmt.Sprintf("RUN microdnf install %s", strings.Join(params.AdditionalPackages, " ")))
 	}
 
+	buildEnvs := make([]string, 0, len(DefaultBuildEnvVars())+len(params.AdditionalBuildEnvVars))
+	buildEnvs = append(buildEnvs, DefaultBuildEnvVars()...)
 	if len(params.AdditionalBuildEnvVars) > 0 {
-		DefaultBuildEnvVar = append(DefaultBuildEnvVar, params.AdditionalBuildEnvVars...)
+		buildEnvs = append(buildEnvs, params.AdditionalBuildEnvVars...)
 	}
 
 	rpmsLockFileWritten := false
@@ -230,7 +232,7 @@ func generateDockerfile(params Params, mainPackagesPaths sets.String) error {
 			"component":               capitalize(p),
 			"component_dashcase":      dashcase(p),
 			"additional_instructions": additionalInstructions,
-			"build_env_vars":          DefaultBuildEnvVar,
+			"build_env_vars":          buildEnvs,
 		}
 
 		var DockerfileTemplate embed.FS

--- a/pkg/dockerfilegen/params.go
+++ b/pkg/dockerfilegen/params.go
@@ -1,5 +1,9 @@
 package dockerfilegen
 
+import (
+	"path"
+)
+
 type Params struct {
 	RootDir                      string
 	Includes                     []string
@@ -22,18 +26,40 @@ type Params struct {
 	RpmsLockFileEnabled          bool
 }
 
-var (
-	DefaultIncludes = []string{
-		"test/test_images.*",
-		"cmd.*",
+func DefaultParams(wd string) Params {
+	return Params{
+		RootDir: wd,
+		Includes: []string{
+			"test/test_images.*",
+			"cmd.*",
+		},
+		Excludes: []string{
+			".*k8s\\.io.*",
+			".*knative.dev/pkg/codegen.*",
+		},
+		Generators:                   GenerateDockerfileOption,
+		Output:                       "openshift",
+		DockerfilesDir:               path.Join("ci-operator", "knative-images"),
+		DockerfilesTestDir:           path.Join("ci-operator", "knative-test-images"),
+		DockerfilesBuildDir:          path.Join("ci-operator", "build-image"),
+		DockerfilesSourceDir:         path.Join("ci-operator", "source-image"),
+		ProjectFilePath:              path.Join("openshift", "project.yaml"),
+		DockerfileImageBuilderFmt:    BuilderImageFmt,
+		AppFileFmt:                   "/usr/bin/%s",
+		RegistryImageFmt:             "registry.ci.openshift.org/openshift/%s:%s",
+		ImagesFromRepositories:       nil,
+		ImagesFromRepositoriesURLFmt: "https://raw.githubusercontent.com/openshift-knative/%s/%s/openshift/images.yaml",
+		AdditionalPackages:           nil,
+		AdditionalBuildEnvVars:       nil,
+		TemplateName:                 DefaultDockerfileTemplateName,
+		RpmsLockFileEnabled:          false,
 	}
-	DefaultExcludes = []string{
-		".*k8s\\.io.*",
-		".*knative.dev/pkg/codegen.*",
-	}
-	// DefaultBuildEnvVar is default set of FIPS flags to be used per builds
-	DefaultBuildEnvVar = []string{
+}
+
+// DefaultBuildEnvVars is default set of FIPS flags to be used per builds
+func DefaultBuildEnvVars() []string {
+	return []string{
 		"ENV CGO_ENABLED=1",
 		"ENV GOEXPERIMENT=strictfipsruntime",
 	}
-)
+}


### PR DESCRIPTION
Exporting the defaults for usage from other packages

/kind cleanup

Part of [SRVCLI-405](https://issues.redhat.com/browse/SRVCLI-405)