### PR TITLE
Remove unneeded env config in create-release-cr workflow

### DIFF
--- a/.github/workflows/generate-release-crs.yaml
+++ b/.github/workflows/generate-release-crs.yaml
@@ -21,8 +21,6 @@ jobs:
   gen-release-cr:
     name: Apply Konflux Override Snapshot
     runs-on: ubuntu-latest
-    env:
-      KUBECONFIG: ~/.kube/config
     steps:
       - name: Checkout serverless operator
         uses: actions/checkout@v4


### PR DESCRIPTION
We're running into
```
error validating ".konflux-release/override-snapshot-fbc-414.yaml": error validating data: failed to download openapi: Get "http://localhost:8080/openapi/v2?timeout=32s": dial tcp [::1]:8080: connect: connection refused; if you choose to ignore these errors, turn validation off with --validate=false
```
when trying to apply the manifests. This is usually as the kubeconfig can't be found. Thus Unsetting the `KUBECONFIG` env var and use the default as in the [apply-konflux-manifests.yaml](https://github.com/openshift-knative/hack/blob/main/.github/workflows/apply-konflux-manifests.yaml) workflow