### PR TITLE
Use `--title` and `--body` for release CR PR metadata

### DIFF
--- a/.github/workflows/generate-release-crs.yaml
+++ b/.github/workflows/generate-release-crs.yaml
@@ -63,6 +63,7 @@ jobs:
           git remote add fork "https://github.com/serverless-qe/hack.git"
           branch="release-crs-${{inputs.revision}}-component-${{inputs.environment}}"
           branch=${branch,,} #lower case of branch name
+          title="Add component Release CRs from ${{inputs.revision}} revision for ${{inputs.environment}}"
           remote_exists=$(git ls-remote --heads fork "$branch")
           if [ -z "$remote_exists" ]; then
             # remote doesn't exist.
@@ -74,7 +75,7 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" "$branch:$branch" -f
           fi
-          gh pr create --base main --head "serverless-qe:$branch" --fill --label "do-not-merge/hold" || true
+          gh pr create --base main --head "serverless-qe:$branch" --title "$title" --body "$title" --label "do-not-merge/hold" || true
         # Use the repository cloned by the konflux-release-gen tool
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/hack
 
@@ -92,6 +93,7 @@ jobs:
           git remote add fork "https://github.com/serverless-qe/hack.git"
           branch="release-crs-${{inputs.revision}}-fbc-${{inputs.environment}}"
           branch=${branch,,} #lower case of branch name
+          title="Add FBC Release CRs from ${{inputs.revision}} revision for ${{inputs.environment}}"
           remote_exists=$(git ls-remote --heads fork "$branch")
           if [ -z "$remote_exists" ]; then
             # remote doesn't exist.
@@ -103,6 +105,6 @@ jobs:
           else
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/hack.git" "$branch:$branch" -f
           fi
-          gh pr create --base main --head "serverless-qe:$branch" --fill --label "do-not-merge/hold" || true
+          gh pr create --base main --head "serverless-qe:$branch" --title "$title" --body "$title" --label "do-not-merge/hold" || true
         # Use the repository cloned by the konflux-release-gen tool
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/hack


### PR DESCRIPTION
We're running into the following in the release CR creation:
```
gh pr create --base main --head serverless-qe:release-crs-main-component-stage --fill --label do-not-merge/hold
could not compute title or body defaults: failed to run git: fatal: ambiguous argument 'origin/main...release-crs-main-component-stage': unknown revision or path not in the working tree.
```
So switching to `--title` and `--body` arg