### PR TITLE
Bump oldest supported OCP version for 1.36/release-next to OCP 4.14

### DIFF
--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -22,7 +22,7 @@ config:
         version: "4.18"
       - version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-v1.17:
       konflux:
         enabled: true
@@ -33,7 +33,7 @@ config:
         version: "4.18"
       - version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
 repositories:
 - dockerfiles: {}
   e2e:

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -5,7 +5,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-v1.14:
       openShiftVersions:
       - useClusterPool: true
@@ -31,7 +31,7 @@ config:
       - useClusterPool: true
         version: "4.16"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-v1.17:
       konflux:
         enabled: true

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -9,7 +9,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
       skipDockerFilesMatches:
       - .*hermetic.*
     release-v1.14:
@@ -45,7 +45,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
       skipDockerFilesMatches:
       - .*hermetic.*
     release-v1.17:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -5,7 +5,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-v1.14:
       openShiftVersions:
       - useClusterPool: true
@@ -31,7 +31,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-v1.17:
       konflux:
         enabled: true

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -29,7 +29,7 @@ config:
         useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-1.35:
       konflux:
         enabled: true
@@ -75,7 +75,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
       prowgen:
         disabled: true
 repositories:

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -25,7 +25,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-v1.17:
       konflux:
         enabled: true

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -25,7 +25,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-v1.17:
       konflux:
         enabled: true

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -5,7 +5,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
       skipDockerFilesMatches:
       - openshift/ci-operator/knative-perf-images.*
       skipE2EMatches:
@@ -36,7 +36,7 @@ config:
       - useClusterPool: true
         version: "4.17"
       - onDemand: true
-        version: "4.13"
+        version: "4.14"
     release-v1.17:
       konflux:
         enabled: true


### PR DESCRIPTION
Bump oldest supported OCP version to OCP 4.14 for all [configs here](https://github.com/openshift-knative/hack/tree/main/config), for branches release-v1.16 / release-v1.17 / release-next / main / release-1.36.