### PR TITLE
Bump to go 1.24

### DIFF
--- a/cmd/sobranch/sobranch.go
+++ b/cmd/sobranch/sobranch.go
@@ -14,5 +14,5 @@ func main() {
 	soVersion := soversion.FromUpstreamVersion(*upstreamVersion)
 	soBranch := soversion.BranchName(soVersion)
 
-	fmt.Printf(soBranch)
+	fmt.Print(soBranch)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-knative/hack
 
-go 1.22.9
+go 1.24.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.19 as builder
 
 ARG TARGETARCH
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/discover.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.19
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder


### PR DESCRIPTION
Bumping Golang, as we have some midstream repos with 1.23 now (bumping here directly to 1.24)