### PR TITLE
Bump default golang version to 1.23 in setup-go action

### DIFF
--- a/.github/workflows/apply-konflux-manifests.yaml
+++ b/.github/workflows/apply-konflux-manifests.yaml
@@ -20,9 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+        uses: ./actions/setup-go
 
       - name: Setup kubeconfig
         env:

--- a/.github/workflows/release-discover-branches.yaml
+++ b/.github/workflows/release-discover-branches.yaml
@@ -25,9 +25,7 @@ jobs:
           path: ./src/github.com/openshift-knative/hack
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: ./src/github.com/openshift-knative/hack/go.mod
+        uses: ./actions/setup-go
 
       - uses: tektoncd/actions/setup-tektoncd-cli@main
         with:

--- a/.github/workflows/release-discover-branches.yaml
+++ b/.github/workflows/release-discover-branches.yaml
@@ -25,7 +25,7 @@ jobs:
           path: ./src/github.com/openshift-knative/hack
 
       - name: Setup Golang
-        uses: ./actions/setup-go
+        uses: ./src/github.com/openshift-knative/hack/actions/setup-go
 
       - uses: tektoncd/actions/setup-tektoncd-cli@main
         with:

--- a/.github/workflows/release-generate-ci-template.yaml
+++ b/.github/workflows/release-generate-ci-template.yaml
@@ -30,7 +30,7 @@ jobs:
           path: ./src/github.com/openshift-knative/hack
 
       - name: Setup Golang
-        uses: ./actions/setup-go
+        uses: ./src/github.com/openshift-knative/hack/actions/setup-go
 
       - name: Install yq
         run: go install github.com/mikefarah/yq/v3@latest

--- a/.github/workflows/release-generate-ci-template.yaml
+++ b/.github/workflows/release-generate-ci-template.yaml
@@ -30,9 +30,7 @@ jobs:
           path: ./src/github.com/openshift-knative/hack
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: ./src/github.com/openshift-knative/hack/go.mod
+        uses: ./actions/setup-go
 
       - name: Install yq
         run: go install github.com/mikefarah/yq/v3@latest

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -109,9 +109,7 @@ jobs:
         with:
           path: ./src/github.com/openshift-knative/hack
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: ./src/github.com/openshift-knative/hack/go.mod
+        uses: ./actions/setup-go
       - name: Install yq
         run: go install github.com/mikefarah/yq/v3@latest
       - name: Install skopeo

--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -109,7 +109,7 @@ jobs:
         with:
           path: ./src/github.com/openshift-knative/hack
       - name: Setup Golang
-        uses: ./actions/setup-go
+        uses: ./src/github.com/openshift-knative/hack/actions/setup-go
       - name: Install yq
         run: go install github.com/mikefarah/yq/v3@latest
       - name: Install skopeo

--- a/actions/setup-go/action.yaml
+++ b/actions/setup-go/action.yaml
@@ -15,4 +15,4 @@ runs:
     - name: setup go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ inputs.go-version || '1.22' }}
+        go-version: ${{ inputs.go-version || '1.23' }}

--- a/cmd/sobranch/sobranch.go
+++ b/cmd/sobranch/sobranch.go
@@ -14,5 +14,5 @@ func main() {
 	soVersion := soversion.FromUpstreamVersion(*upstreamVersion)
 	soBranch := soversion.BranchName(soVersion)
 
-	fmt.Printf(soBranch)
+	fmt.Print(soBranch)
 }


### PR DESCRIPTION
Bumping the default golang version to 1.23 in setup-go action and use this action in the Konflux related workflows