### PR TITLE
Increase resources of sast-shell-check task to prevent OOM

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -74,6 +74,17 @@ spec:
     - name: prefetch-input-dev-package-managers
       value: '{{{ .PrefetchDeps.DevPackageManagers }}}'
     {{{- end }}}
+  {{{- if eq .Pipeline "docker-build" }}}
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      stepSpecs:
+        - name: sast-shell-check
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 4Gi
+  {{{- end }}}
   pipelineRef:
     name: {{{ .Pipeline }}}
   taskRunTemplate: {}

--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -74,7 +74,7 @@ spec:
     - name: prefetch-input-dev-package-managers
       value: '{{{ .PrefetchDeps.DevPackageManagers }}}'
     {{{- end }}}
-  {{{- if eq .Pipeline "docker-build" }}}
+  {{{- if or (eq .Pipeline "docker-build") (eq .Pipeline "docker-java-build")}}}
   taskRunSpecs:
     - pipelineTaskName: sast-shell-check
       stepSpecs:


### PR DESCRIPTION
Currently we see sast-shell-check tasks getting OOM killed: https://github.com/openshift-knative/eventing-kafka-broker/pull/1568 (especially in https://github.com/openshift-knative/eventing-kafka-broker/pull/1568)

To prevent this, we can increase the requests&limits (see [slack](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1741366316595669?thread_ts=1741247105.265979&cid=C04PZ7H0VA8)).

Tested with the new limits (only dispatcher): https://github.com/openshift-knative/eventing-kafka-broker/pull/1593