### PR TITLE
Enable NPM pre-fetch and dependabot updates for Eventing Integrations

### DIFF
--- a/pkg/dependabotgen/dependabotgen.go
+++ b/pkg/dependabotgen/dependabotgen.go
@@ -213,6 +213,49 @@ func (cfg *DependabotConfig) WithMaven(dirs []string, branch string) {
 	*cfg.Updates = append(*cfg.Updates, u)
 }
 
+func (cfg *DependabotConfig) WithNPM(dirs []string, branch string) {
+	if len(dirs) == 0 {
+		dirs = []string{"/"}
+	}
+
+	u := DependabotUpdate{
+		PackageEcosystem: "npm",
+		Directories:      dirs,
+		Schedule: ScheduleUpdate{
+			Interval: "weekly",
+		},
+		TargetBranch: branch,
+		CommitMessage: CommitMessageUpdate{
+			Prefix: fmt.Sprintf("[%s][%s]", branch, "npm"),
+		},
+		OpenPullRequestLimit: 10,
+		Groups: map[string]Group{
+			"patch": {
+				UpdateTypes: []string{"patch"},
+				Patterns:    []string{"*"},
+				AppliesTo:   "version-updates",
+			},
+			"minor": {
+				UpdateTypes: []string{"minor"},
+				Patterns:    []string{"*"},
+				AppliesTo:   "version-updates",
+			},
+			"major": {
+				UpdateTypes: []string{"major"},
+				Patterns:    []string{"*"},
+				AppliesTo:   "version-updates",
+			},
+			"security": {
+				UpdateTypes: []string{"patch", "minor", "major"},
+				Patterns:    []string{"*"},
+				AppliesTo:   "security-updates",
+			},
+		},
+	}
+
+	*cfg.Updates = append(*cfg.Updates, u)
+}
+
 const (
 	ghDir        = ".github"
 	workflowsDir = "workflows"

--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -177,6 +177,24 @@ func (pd *PrefetchDeps) WithUnvendoredGo(path string) {
 	pd.PrefetchInput = string(b)
 }
 
+func (pd *PrefetchDeps) WithNPM(path string) {
+	types := make([]map[string]interface{}, 0)
+	if pd.PrefetchInput != "" {
+		if err := json.Unmarshal([]byte(pd.PrefetchInput), &types); err != nil {
+			log.Fatal("Failed to unmarshal prefetch input: ", err)
+		}
+	}
+	types = append(types, map[string]interface{}{
+		"type": "npm",
+		"path": path,
+	})
+	b, err := json.Marshal(types)
+	if err != nil {
+		log.Fatal("Failed to marshal prefetch input: ", err)
+	}
+	pd.PrefetchInput = string(b)
+}
+
 func Generate(cfg Config) error {
 	fbcBuildPipelinePath := filepath.Join(cfg.PipelinesOutputPath, "fbc-builder.yaml")
 	containerBuildPipelinePath := filepath.Join(cfg.PipelinesOutputPath, "docker-build.yaml")

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -461,6 +461,10 @@ func (r Repository) IsServerlessOperator() bool {
 	return r.Org == "openshift-knative" && r.Repo == "serverless-operator"
 }
 
+func (r Repository) IsEventingIntegrations() bool {
+	return r.Org == "openshift-knative" && r.Repo == "eventing-integrations"
+}
+
 func (r Repository) IsEKB() bool {
 	return r.Org == "openshift-knative" && r.Repo == "eventing-kafka-broker"
 }

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -77,6 +77,12 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 							if r.IsEKB() {
 								dependabotConfig.WithMaven([]string{"/data-plane"}, branchName)
 							}
+							if r.IsEventingIntegrations() {
+								dependabotConfig.WithNPM([]string{
+									"/transform-jsonata",
+								}, branchName)
+								dependabotConfig.WithMaven([]string{"/"}, branchName)
+							}
 							if r.IsFunc() {
 								dependabotConfig.WithMaven([]string{
 									"/templates/quarkus/http",
@@ -502,6 +508,10 @@ func getPrefetchDeps(repo Repository, branch string) (*konfluxgen.PrefetchDeps, 
 			// If it's a Go project and no vendor dir is present enable Go caching
 			prefetchDeps.WithUnvendoredGo("." /* root of the repository */)
 		}
+	}
+
+	if repo.IsEventingIntegrations() {
+		prefetchDeps.WithNPM("transform-jsonata")
 	}
 
 	return &prefetchDeps, nil


### PR DESCRIPTION
- Enable NPM cachi2 pre-fetch
- Maven and NPM dependabot updates