### PR TITLE
Remove old approvers and reviewers from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,23 +1,18 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- alanfx
 - aliok
 - creydr
 - lberk
 - matzew
-- mgencur
 - pierDipi
 - rhuss
 - skonto
-- ReToCode
 
 reviewers:
 - aliok
 - creydr
 - matzew
-- mgencur
 - pierDipi
 - rhuss
 - skonto
-- ReToCode


### PR DESCRIPTION
Getting an `do-not-merge/invalid-owners-file` label on https://github.com/openshift/release/pull/62527 because Reto is not in the org anymore. Cleaning up the file