### PR TITLE
Fix: Don't cleanup imageDigestMirrorSet file

### DIFF
--- a/pkg/konfluxgen/konfluxgen.go
+++ b/pkg/konfluxgen/konfluxgen.go
@@ -232,7 +232,8 @@ func Generate(cfg Config) error {
 	}
 
 	if !cfg.PipelinesOutputPathSkipRemove {
-		if err := removeAllExcept(cfg.PipelinesOutputPath, fbcBuildPipelinePath, containerBuildPipelinePath, containerJavaBuildPipelinePath); err != nil {
+		imageDigestMirrorSetPath := filepath.Join(cfg.PipelinesOutputPath, "images-mirror-set.yaml")
+		if err := removeAllExcept(cfg.PipelinesOutputPath, fbcBuildPipelinePath, containerBuildPipelinePath, containerJavaBuildPipelinePath, imageDigestMirrorSetPath); err != nil {
 			return fmt.Errorf("failed to clean %q directory: %w", cfg.PipelinesOutputPath, err)
 		}
 	}


### PR DESCRIPTION
As per title to prevent https://github.com/openshift-knative/serverless-operator/pull/3480#pullrequestreview-2665090911