### PR TITLE
Add eventing-integrations release-next branch config

### DIFF
--- a/config/eventing-integrations.yaml
+++ b/config/eventing-integrations.yaml
@@ -1,5 +1,13 @@
 config:
   branches:
+    release-next:
+      openShiftVersions:
+        - useClusterPool: true
+          version: "4.17"
+        - onDemand: true
+          version: "4.14"
+      skipDockerFilesMatches:
+        - .*hermetic.*
     release-v1.16:
       konflux:
         enabled: true


### PR DESCRIPTION
Since we have the update-to-head and branch mirroring, we can add the config for release-next to have the prow jobs running there too