### PR TITLE
Konflux Dashboard: Filter out test builds by default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -183,7 +183,7 @@
                 paging: false,
                 data: data,
                 search: {
-                    search: '!-ec '
+                    search: '!-ec !-test-'
                 },
             })
         })


### PR DESCRIPTION
Don't show builds for tests by default in the Konflux dashboard