### PR TITLE
Pass KUBECONFIG env to make generate-konflux-release

### DIFF
--- a/.github/workflows/generate-release-crs.yaml
+++ b/.github/workflows/generate-release-crs.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Generate Konflux component release CR
         working-directory: ./src/github.com/openshift-knative/hack
         run: |
-          make generate-konflux-release ARGS="--environment ${{ inputs.environment }} --so-revision ${{ inputs.revision }} --type component"
+          KUBECONFIG=$HOME/.kube/config make generate-konflux-release ARGS="--environment ${{ inputs.environment }} --so-revision ${{ inputs.revision }} --type component"
 
       - name: Create component release CR Pull Request
         env:
@@ -87,7 +87,7 @@ jobs:
       - name: Generate Konflux FBC release CRs
         working-directory: ./src/github.com/openshift-knative/hack
         run: |
-          make generate-konflux-release ARGS="--environment ${{ inputs.environment }} --so-revision ${{ inputs.revision }} --type fbc"
+          KUBECONFIG=$HOME/.kube/config make generate-konflux-release ARGS="--environment ${{ inputs.environment }} --so-revision ${{ inputs.revision }} --type fbc"
 
       - name: Create FBC release CR Pull Request
         env:


### PR DESCRIPTION
In the generate-konflux-release workflow, we're seeing 
```
2025/03/14 12:58:43 could not generate release: failed to get release name for "serverless-operator-135-1351-stage": failed to get release from cluster "serverless-operator-135-1351-stage": KUBECONFIG environment variable not set
exit status 1
make: *** [Makefile:48: generate-konflux-release] Error 1
```
e.g. [here](https://github.com/openshift-knative/hack/actions/runs/13857051198/job/38776108934)

So passing the KUBECONFIG env directly to the make target