### PR TITLE
Update reference to UBI8 repofile for rpms.lock file

### DIFF
--- a/pkg/dockerfilegen/ubi8.rpms.in.yaml
+++ b/pkg/dockerfilegen/ubi8.rpms.in.yaml
@@ -2,7 +2,7 @@ contentOrigin:
   # Define at least one source of packages, but you can have as many as you want.
   repofiles:
     # Either local path or url pointing to .repo file
-    - 'https://raw.githubusercontent.com/konflux-ci/bazel-builder/0401ac3b893532a8e2afabd1cd3814cd5b962f69/bazel5-ubi8/ubi8.repo'
+    - 'https://raw.githubusercontent.com/konflux-ci/bazel-builder/d712bf2dbac5e5aa714ed91dfc8f7309d1cb2902/bazel5-ubi8/ubi8.repo'
 packages:
   # list of rpm names to resolve
   - socat


### PR DESCRIPTION
Our rpms.lock files seem to reference old repoids. E.g.:

```
✕ [Violation] rpm_repos.ids_known
  ImageRef: quay.io/redhat-user-workloads/ocp-serverless-tenant/serverless-operator-135/serverless-openshift-kn-operator@sha256:eca38d29563934ce008329c7022627db66d433621d5f78bdd049b9ce1d688055
  Reason: RPM repo id check failed: An RPM component in the SBOM specified an unknown or disallowed repository_id:
  pkg:rpm/redhat/rsync@3.1.3-21.el8_10?arch=aarch64&checksum=sha256:c2abdc201cedd3e1831955ae628c644ab670214126697695c77657edbbeaecb2&repository_id=ubi-8-baseos-rpms
  (7 additional similar violations not separately listed)
  Title: All rpms have known repo ids
  Description: Each RPM package listed in an SBOM must specify the repository id that it comes from, and that repository id must
  be present in the list of known and permitted repository ids. Currently this is rule enforced only for SBOM components created
  by cachi2. To exclude this rule add
  "rpm_repos.ids_known:pkg:rpm/redhat/rsync@3.1.3-21.el8_10?arch=aarch64&checksum=sha256:c2abdc201cedd3e1831955ae628c644ab670214126697695c77657edbbeaecb2&repository_id=ubi-8-baseos-rpms"
  to the `exclude` section of the policy configuration.
  Solution: Ensure every rpm comes from a known and permitted repository, and that the data in the SBOM correctly records that.
```

So updating to the latest reference, as the repoids got updated. See [Slack](https://redhat-internal.slack.com/archives/CKR568L8G/p1742976005765229?thread_ts=1742970581.456019&cid=CKR568L8G)