### PR TITLE
Update rpm lockfile prototype ref to v0.15.0

### DIFF
--- a/.github/workflows/release-discover-branches.yaml
+++ b/.github/workflows/release-discover-branches.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: 'konflux-ci/rpm-lockfile-prototype'
           path: ./src/github.com/openshift-knative/rpm-lockfile-prototype
-          ref: '6d222512f5e7b89c59fdcf9bddc9f4d535f3f255'
+          ref: 'v0.15.0'
 
       - name: Install podman
         run: |

--- a/.github/workflows/release-discover-branches.yaml
+++ b/.github/workflows/release-discover-branches.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: 'konflux-ci/rpm-lockfile-prototype'
           path: ./src/github.com/openshift-knative/rpm-lockfile-prototype
-          ref: '283ee2cd7938a2142d8ac98de33ba0d0e3ac146f'
+          ref: '6d222512f5e7b89c59fdcf9bddc9f4d535f3f255'
 
       - name: Install podman
         run: |

--- a/pkg/dockerfilegen/ubi8.rpms.in.yaml
+++ b/pkg/dockerfilegen/ubi8.rpms.in.yaml
@@ -12,6 +12,9 @@ packages:
 reinstallPackages:
   - tzdata
 
+upgradePackages:
+  - tzdata
+
 arches:
   # The list of architectures can be set in the config file. Any `--arch` option set
   # on the command line will override this list.


### PR DESCRIPTION
Updating ref to v0.15.0 tag to have updates from https://github.com/konflux-ci/rpm-lockfile-prototype/pull/90/files

This should help on issues like https://github.com/openshift-knative/hack/actions/runs/14239958985/job/39922767359