### PR TITLE
Align kustomize for java build to latest build pipeline spec

### DIFF
--- a/pkg/konfluxgen/kustomize/kustomize-java-docker-build/kustomization.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-java-docker-build/kustomization.yaml
@@ -31,22 +31,5 @@ patches:
         value: docker-java-build
     target:
       kind: Pipeline
-replacements:
-  - source:
-      kind: Pipeline
-      fieldPath: spec.tasks.[name=build-images].taskRef.params.[name=bundle].value
-    targets:
-      - select:
-          kind: Pipeline
-        fieldPaths:
-          - spec.tasks.[name=build-images-deps].taskRef.params.[name=bundle].value
-  - source:
-      kind: Pipeline
-      fieldPath: spec.tasks.[name=build-image-index].taskRef.params.[name=bundle].value
-    targets:
-      - select:
-          kind: Pipeline
-        fieldPaths:
-          - spec.tasks.[name=build-image-index-deps].taskRef.params.[name=bundle].value
 openapi:
   path: ../pipeline_schema.json

--- a/pkg/konfluxgen/kustomize/kustomize-java-docker-build/patch_java_build.patch.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-java-docker-build/patch_java_build.patch.yaml
@@ -39,14 +39,7 @@ spec:
       runAfter:
         - prefetch-dependencies
       taskRef:
-        params:
-          - name: name
-            value: buildah-remote-oci-ta
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:a01ac7eef5b4e889b5619fe397c115e16a70eafe1d39315b5654a781f2e294e1
-          - name: kind
-            value: task
-        resolver: bundles
+        name: buildah-remote-oci-ta
       when:
         - input: $(tasks.init.results.build)
           operator: in
@@ -69,14 +62,7 @@ spec:
       runAfter:
         - build-images-deps
       taskRef:
-        params:
-          - name: name
-            value: build-image-index
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:e4871851566d8b496966b37bcb8c5ce9748a52487f116373d96c6cd28ef684c6
-          - name: kind
-            value: task
-        resolver: bundles
+        name: build-image-index
       when:
         - input: $(tasks.init.results.build)
           operator: in


### PR DESCRIPTION
Currently the java kustomize patches can't be applied due to 
```
Run make konflux-update-pipelines
tkn bundle list quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel -o=yaml > pkg/konfluxgen/kustomize/docker-build.yaml
*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
tkn bundle list quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder:devel -o=yaml > pkg/konfluxgen/kustomize/fbc-builder.yaml
*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
kustomize build pkg/konfluxgen/kustomize/kustomize-docker-build/ --output pkg/konfluxgen/docker-build.yaml --load-restrictor LoadRestrictionsNone
kustomize build pkg/konfluxgen/kustomize/kustomize-java-docker-build/ --output pkg/konfluxgen/docker-java-build.yaml --load-restrictor LoadRestrictionsNone
Error: fieldPath `spec.tasks.[name=build-images].taskRef.params.[name=bundle].value` is missing for replacement source Pipeline.[noVer].[noGrp]/[noName].[noNs]
make: *** [Makefile:[6](https://github.com/openshift-knative/hack/actions/runs/14303493100/job/40082134190#step:8:7)6: konflux-update-pipelines] Error 1
Error: Process completed with exit code 2.
```

This is, because the docker buildpipelines got adjusted.


/hold as not sure if this is only a temporary flake in the `devel` tekton bundle images