### PR TITLE
Don't generate branch protection for SO

### DIFF
--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -367,22 +367,21 @@ func NewProwConfig(r Repository) shardprowconfig.ProwConfigWithPointers {
 		"jira/invalid-bug",
 		"needs-rebase",
 	}
-	return shardprowconfig.ProwConfigWithPointers{
-		BranchProtection: &config.BranchProtection{
-			Orgs: map[string]config.Org{
-				r.Org: config.Org{
-					Repos: map[string]config.Repo{
-						r.Repo: config.Repo{
-							Branches: map[string]config.Branch{
-								"release-next": config.Branch{
-									Policy: config.Policy{
-										Protect: ptr.To(false),
-									},
+
+	branchProtection := &config.BranchProtection{
+		Orgs: map[string]config.Org{
+			r.Org: config.Org{
+				Repos: map[string]config.Repo{
+					r.Repo: config.Repo{
+						Branches: map[string]config.Branch{
+							"release-next": config.Branch{
+								Policy: config.Policy{
+									Protect: ptr.To(false),
 								},
-								"release-next-ci": config.Branch{
-									Policy: config.Policy{
-										Protect: ptr.To(false),
-									},
+							},
+							"release-next-ci": config.Branch{
+								Policy: config.Policy{
+									Protect: ptr.To(false),
 								},
 							},
 						},
@@ -390,6 +389,15 @@ func NewProwConfig(r Repository) shardprowconfig.ProwConfigWithPointers {
 				},
 			},
 		},
+	}
+
+	if r.IsServerlessOperator() {
+		// SO does not have release-next nor release-next-ci branches
+		branchProtection = nil
+	}
+
+	return shardprowconfig.ProwConfigWithPointers{
+		BranchProtection: branchProtection,
 		Tide: &shardprowconfig.TideConfig{
 			MergeType: map[string]types.PullRequestMergeType{
 				fmt.Sprintf("%s/%s", r.Org, r.Repo): types.MergeSquash,


### PR DESCRIPTION
SO does not have branch protection rules for release-next and release-next-ci. So we don't set those for SO

https://github.com/openshift/release/blob/363307d181d1cf4734191bb794be20df54431b7d/core-services/prow/02_config/openshift-knative/serverless-operator/_prowconfig.yaml