### PR TITLE
Add build pipeline service account

### DIFF
--- a/pkg/konfluxgen/pipeline-run.template.yaml
+++ b/pkg/konfluxgen/pipeline-run.template.yaml
@@ -87,7 +87,8 @@ spec:
   {{{- end }}}
   pipelineRef:
     name: {{{ .Pipeline }}}
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-{{{ sanitize .ComponentName }}}
   workspaces:
     - name: git-auth
       secret:


### PR DESCRIPTION
Adding the build pipeline service account to the pipeline-run template according to https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1745488131410119

Automated migration PR example: https://github.com/openshift-knative/backstage-plugins/pull/421


This results for example in a pipeline-run file like 
```
  ...
  taskRunTemplate:
    serviceAccountName: build-pipeline-serverless-openshift-kn-operator-137
  ...
```