### PR TITLE
Fix Konflux bot user name

### DIFF
--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -421,7 +421,7 @@ func NewProwConfig(r Repository) shardprowconfig.ProwConfigWithPointers {
 					Repos: []string{
 						fmt.Sprintf("%s/%s", r.Org, r.Repo),
 					},
-					Author:                 "app/red-hat-konflux-kflux-prd-rh02",
+					Author:                 "red-hat-konflux-kflux-prd-rh02[bot]",
 					ReviewApprovedRequired: false,
 				},
 				config.TideQuery{


### PR DESCRIPTION
The Github user name of the Konflux bot seems to be red-hat-konflux-kflux-prd-rh02[bot] (e.g. from https://api.github.com/repos/openshift-knative/net-kourier/pulls/296)