### PR TITLE
Fix eventing-integrations java-images config for > 1.17

### DIFF
--- a/config/eventing-integrations.yaml
+++ b/config/eventing-integrations.yaml
@@ -1,6 +1,16 @@
 config:
   branches:
     release-next:
+      konflux:
+        javaImages:
+          - .*eventing-integrations-aws-ddb-streams-source
+          - .*eventing-integrations-aws-s3-sink
+          - .*eventing-integrations-aws-s3-source
+          - .*eventing-integrations-aws-sns-sink
+          - .*eventing-integrations-aws-sqs-sink
+          - .*eventing-integrations-aws-sqs-source
+          - .*eventing-integrations-log-sink
+          - .*eventing-integrations-timer-source
       openShiftVersions:
       - useClusterPool: true
         version: "4.17"
@@ -34,6 +44,15 @@ config:
     release-v1.17:
       konflux:
         enabled: true
+        javaImages:
+          - .*eventing-integrations-aws-ddb-streams-source
+          - .*eventing-integrations-aws-s3-sink
+          - .*eventing-integrations-aws-s3-source
+          - .*eventing-integrations-aws-sns-sink
+          - .*eventing-integrations-aws-sqs-sink
+          - .*eventing-integrations-aws-sqs-source
+          - .*eventing-integrations-log-sink
+          - .*eventing-integrations-timer-source
       openShiftVersions:
       - useClusterPool: true
         version: "4.17"


### PR DESCRIPTION
eventing-integrations is missing the java-config for branches > 1.17. This leads to selecting the docker-build pipeline instead of the docker-java-build pipeline (see for example [here](https://github.com/openshift-knative/eventing-integrations/blob/bbda3101ffc0d696a817a4774bc395cdbf90ddc9/.tekton/kn-eventing-integrations-aws-ddb-streams-source-117-pull-request.yaml#L56))