### PR TITLE
Add target branch name to renovate PR name

### DIFF
--- a/pkg/dependabotgen/renovate.template.json
+++ b/pkg/dependabotgen/renovate.template.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["tekton"],
+  "commitMessagePrefix": "[{{baseBranch}}]",
   "ignorePaths": [
     ".konflux-release/**",
     "third_party/**",


### PR DESCRIPTION
This adds the target name as a prefix to the name of the PR from renovate. This affects the `Update Konflux references` PRs and results in something like `[release-v1.15] Update Konflux references` and makes it thus clearer from the overview which branch a PR targets.

Tested for example in https://github.com/openshift-knative/eventing/pull/1368