### PR TITLE
Fix renovate template to use correct delimiters for vars

### DIFF
--- a/pkg/dependabotgen/dependabotgen.go
+++ b/pkg/dependabotgen/dependabotgen.go
@@ -292,6 +292,7 @@ func (cfg *DependabotConfig) Write(repoDir string, run string) error {
 	buf := &bytes.Buffer{}
 	renovateTemplate, err := template.
 		New("renovate.template.json").
+		Delims("{{{", "}}}").
 		ParseFS(RenovateTemplate, "*.json")
 	if err != nil {
 		return fmt.Errorf("failed to parse renovate template: %w", err)


### PR DESCRIPTION
Should avoid `failed to parse renovate template: template: renovate.template.json:4: function "baseBranch" not defined` like in https://github.com/openshift-knative/hack/actions/runs/14852438606/job/41698417657