### PR TITLE
Add imageOverride for `CLI_ARTIFACTS` image for 1.17 & 1.18

### DIFF
--- a/config/client.yaml
+++ b/config/client.yaml
@@ -42,6 +42,10 @@ config:
     release-v1.18:
       konflux:
         enabled: true
+        imageOverrides:
+          - name: CLI_ARTIFACTS
+            # TODO: swtich to 1.18 image once it is available in brew
+            pullSpec: brew.registry.redhat.io/rh-osbs/openshift-serverless-1-kn-cli-artifacts-rhel8:1.16.0
       openShiftVersions:
       - candidateRelease: true
         onDemand: true

--- a/config/client.yaml
+++ b/config/client.yaml
@@ -27,6 +27,10 @@ config:
     release-v1.17:
       konflux:
         enabled: true
+        imageOverrides:
+          - name: CLI_ARTIFACTS
+            # TODO: swtich to 1.17 image once it is available in brew
+            pullSpec: brew.registry.redhat.io/rh-osbs/openshift-serverless-1-kn-cli-artifacts-rhel8:1.16.0
       openShiftVersions:
       - candidateRelease: true
         onDemand: true


### PR DESCRIPTION
Adding the 1.16 kn-cli-artifacts image as an image override for the client 1.17 and 1.18 image, until the kn-cli-artifacts 1.17 / 1.18 image is available in brew.

As discussed in [slack](https://redhat-internal.slack.com/archives/CJPC4SQDP/p1746709288843479)