### PR TITLE
Default `build-image-index` param to false for bundle builds

### DIFF
--- a/pkg/konfluxgen/bundle-build.yaml
+++ b/pkg/konfluxgen/bundle-build.yaml
@@ -28,6 +28,10 @@ spec:
         value: task
       resolver: bundles
   params:
+  - default: "false"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
   - default: --all-projects --org=3e1a4cca-ebfb-495f-b64c-3cc960d566b4 --exclude=test*,vendor,third_party
     description: Append arguments to Snyk code command.
     name: snyk-args
@@ -84,10 +88,6 @@ spec:
     description: Image tag expiration time, time values could be something like 1h,
       2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
-  - default: "true"
-    description: Add built image into an OCI image index
-    name: build-image-index
-    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args

--- a/pkg/konfluxgen/kustomize/kustomize-bundle-build/kustomization.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-bundle-build/kustomization.yaml
@@ -22,6 +22,9 @@ patches:
   - path: ./patch_remove_ecosystem-cert-preflight-checks.patch.yaml
     target:
       kind: Pipeline
+  - path: ./patch_build-image-index-param.patch.yaml
+    target:
+      kind: Pipeline
   - patch: |-
       - op: replace
         path: /metadata/name

--- a/pkg/konfluxgen/kustomize/kustomize-bundle-build/patch_build-image-index-param.patch.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-bundle-build/patch_build-image-index-param.patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: docker-build
+spec:
+  params:
+    - name: build-image-index
+      default: "false"


### PR DESCRIPTION
`build-image-index` param needs to be false for bundle builds

https://redhat-internal.slack.com/archives/CKR568L8G/p1747745542971349?thread_ts=1747375927.922199&cid=CKR568L8G