### PR TITLE
Update bundle patch to use output image from build-image-index task

### DIFF
--- a/pkg/konfluxgen/bundle-build.yaml
+++ b/pkg/konfluxgen/bundle-build.yaml
@@ -121,6 +121,34 @@ spec:
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
   tasks:
+  - name: build-source-image
+    params:
+    - name: BINARY_IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: source-build-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:56fa2cbfc04bad4765b7fe1fa8022587f4042d4e8533bb5f65311d46b43226ee
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    - input: $(params.build-source-image)
+      operator: in
+      values:
+      - "true"
   - name: sast-snyk-check
     params:
     - name: ARGS
@@ -316,34 +344,6 @@ spec:
       resolver: bundles
     when:
     - input: $(tasks.init.results.build)
-      operator: in
-      values:
-      - "true"
-  - name: build-source-image
-    params:
-    - name: BINARY_IMAGE
-      value: $(params.output-image)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: source-build-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:c96a73714286564a02354fd52d866da24bcfe74aad8ed5fd2d77a617dd2983ba
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(tasks.init.results.build)
-      operator: in
-      values:
-      - "true"
-    - input: $(params.build-source-image)
       operator: in
       values:
       - "true"

--- a/pkg/konfluxgen/kustomize/kustomize-bundle-build/patch_build-image-index-param.patch.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-bundle-build/patch_build-image-index-param.patch.yaml
@@ -6,3 +6,8 @@ spec:
   params:
     - name: build-image-index
       default: "false"
+  tasks:
+    - name: build-source-image
+      params:
+        - name: BINARY_IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)


### PR DESCRIPTION
Following our discussion in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1747774005906779, we use the build-image-index result image in the build-source-image task.

Alternatively, we could have disabled the `IMAGE_APPEND_PLATFORM` in the build-image task (but that way we would lose this arch information from the image name and differ from the other builds)

Tested in https://github.com/openshift-knative/serverless-operator/pull/3701