### PR TITLE
update build-source-image param change it to IMAGE_REF

### DIFF
--- a/pkg/konfluxgen/docker-build.yaml
+++ b/pkg/konfluxgen/docker-build.yaml
@@ -325,7 +325,7 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(params.output-image)
+      value: $(tasks.build-image-index.results.IMAGE_REF)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT


### PR DESCRIPTION
Update build-source-image param, change it to IMAGE_REF

as per https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1749839842845389?thread_ts=1749554020.206169&cid=C04PZ7H0VA8