### PR TITLE
migrate apply-tag from 0.1 to 0.2

### DIFF
--- a/pkg/konfluxgen/bundle-build.yaml
+++ b/pkg/konfluxgen/bundle-build.yaml
@@ -231,8 +231,10 @@ spec:
     params:
     - name: ADDITIONAL_TAGS
       value: $(params.additional-tags[*])
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-image-index
     taskRef:

--- a/pkg/konfluxgen/bundle-build.yaml
+++ b/pkg/konfluxgen/bundle-build.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  creationTimestamp: null
+  creationTimestamp:
   labels:
     pipelines.openshift.io/runtime: generic
     pipelines.openshift.io/strategy: docker
@@ -28,7 +28,7 @@ spec:
         value: task
       resolver: bundles
   params:
-  - default: "false"
+  - default: 'false'
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
@@ -36,13 +36,12 @@ spec:
     description: Append arguments to Snyk code command.
     name: snyk-args
     type: string
-  - default: "true"
+  - default: 'true'
     description: Build a source image.
     name: build-source-image
     type: string
-  - default: "false"
-    description: 'Enable in-development package managers. WARNING: the behavior may
-      change at any time without notice. Use at your own risk.'
+  - default: 'false'
+    description: 'Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk.'
     name: prefetch-input-dev-package-managers
   - default: []
     description: Additional image tags
@@ -51,7 +50,7 @@ spec:
   - description: Source Repository URL
     name: git-url
     type: string
-  - default: ""
+  - default: ''
     description: Revision of the Source Repository
     name: revision
     type: string
@@ -59,65 +58,60 @@ spec:
     name: output-image
     type: string
   - default: .
-    description: Path to the source code of an application's component from where
-      to build image.
+    description: Path to the source code of an application's component from where to build image.
     name: path-context
     type: string
   - default: Dockerfile
-    description: Path to the Dockerfile inside the context specified by parameter
-      path-context
+    description: Path to the Dockerfile inside the context specified by parameter path-context
     name: dockerfile
     type: string
-  - default: "false"
+  - default: 'false'
     description: Force rebuild image
     name: rebuild
     type: string
-  - default: "false"
+  - default: 'false'
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: "false"
+  - default: 'false'
     description: Execute the build with network isolation
     name: hermetic
     type: string
-  - default: ""
+  - default: ''
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
-  - default: ""
-    description: Image tag expiration time, time values could be something like 1h,
-      2d, 3w for hours, days, and weeks, respectively.
+  - default: ''
+    description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
-  - default: ""
+  - default: ''
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "false"
-    description: Whether to enable privileged mode, should be used only with remote
-      VMs
+  - default: 'false'
+    description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
     type: string
   - default:
     - linux/x86_64
-    description: List of platforms to build the container images on. The available
-      set of values is determined by the configuration of the multi-platform-controller.
+    description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
   results:
-  - description: ""
+  - description: ''
     name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
-  - description: ""
+  - description: ''
     name: IMAGE_DIGEST
     value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-  - description: ""
+  - description: ''
     name: CHAINS-GIT_URL
     value: $(tasks.clone-repository.results.url)
-  - description: ""
+  - description: ''
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
   tasks:
@@ -129,7 +123,7 @@ spec:
     name: build-images
     params:
     - name: IMAGE_APPEND_PLATFORM
-      value: "false"
+      value: 'false'
     - name: IMAGE
       value: $(params.output-image)
     - name: DOCKERFILE
@@ -162,7 +156,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:6a5f714dd0c301ac421c232d2658e336b862681cf0bcbcbf01ef38d8969664e0
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:28d8a4f7c1ff6e8bb09d89b06c7c8769093ac7e9325ad9edfe7b2d766f643b87
       - name: kind
         value: task
       resolver: bundles
@@ -170,7 +164,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: sast-snyk-check
     params:
     - name: ARGS
@@ -190,7 +184,7 @@ spec:
       - name: name
         value: sast-snyk-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:89aead32dc21404e4e0913be9668bdd2eea795db3e4caa762fb619044e479cb8
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:e61f541189b30d14292ef8df36ccaf13f7feb2378fed5f74cb6293b3e79eb687
       - name: kind
         value: task
       resolver: bundles
@@ -198,7 +192,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: prefetch-dependencies
     params:
     - name: dev-package-managers
@@ -218,7 +212,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3a1b3280d6300ebedb9923ddc441b91b6980512be5dae8da4b9d3be21feeb48e
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d0cbc492da865be336d09926eb6e3494403dccaa4a212bbdf472d8adbf80ab08
       - name: kind
         value: task
       resolver: bundles
@@ -242,7 +236,7 @@ spec:
       - name: name
         value: apply-tags
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:53934b9d7649273d1bf99525f3c92da518842697f525cdb9502280f5c395b9fd
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:517a51e260c0b59654a9d7b842e1ab07d76bce15ca7ce9c8fd2489a19be6463d
       - name: kind
         value: task
       resolver: bundles
@@ -259,7 +253,7 @@ spec:
       - name: name
         value: init
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:de2d7b8cff0ea9d7f4563fffaaea0b0955dd6d81a1f7e323e1668f7d876e4191
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:66e90d31e1386bf516fb548cd3e3f0082b5d0234b8b90dbf9e0d4684b70dbe1a
       - name: kind
         value: task
       resolver: bundles
@@ -280,7 +274,7 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0e512b12775b2bcc4eb47bb34b7a2db2e91c3ceef04b2f2487fa421032d8859a
       - name: kind
         value: task
       resolver: bundles
@@ -288,7 +282,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
     workspaces:
     - name: basic-auth
       workspace: git-auth
@@ -312,7 +306,7 @@ spec:
       - name: name
         value: build-image-index
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3cf3dcc0bf7b674b940063b4d55e41fe7d43636a1d82572e3850228aa5350fa8
       - name: kind
         value: task
       resolver: bundles
@@ -320,7 +314,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
@@ -336,7 +330,7 @@ spec:
       - name: name
         value: source-build-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:c96a73714286564a02354fd52d866da24bcfe74aad8ed5fd2d77a617dd2983ba
+        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:f0784e8e0e396f40a6523693825b5966c3c615ba3d342350165e83cb72a24ef7
       - name: kind
         value: task
       resolver: bundles
@@ -344,11 +338,11 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
     - input: $(params.build-source-image)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL
@@ -362,7 +356,7 @@ spec:
       - name: name
         value: deprecated-image-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:270a79138a98e43c366d3722978cb5940d2bcb822ba6b60377330f863b7a1e62
       - name: kind
         value: task
       resolver: bundles
@@ -370,7 +364,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: clair-scan
     params:
     - name: image-digest
@@ -384,7 +378,7 @@ spec:
       - name: name
         value: clair-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
+        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:d354939892f3a904223ec080cc3771bd11931085a5d202323ea491ee8e8c5e43
       - name: kind
         value: task
       resolver: bundles
@@ -392,7 +386,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: clamav-scan
     params:
     - name: image-digest
@@ -406,7 +400,7 @@ spec:
       - name: name
         value: clamav-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:11b1684965b64f1fa7c65f90a3524413022246a3863eaba188c84eb4bf0b687a
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:9cab95ac9e833d77a63c079893258b73b8d5a298d93aaf9bdd6722471bc2f338
       - name: kind
         value: task
       resolver: bundles
@@ -414,7 +408,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: sast-shell-check
     params:
     - name: image-digest
@@ -432,7 +426,7 @@ spec:
       - name: name
         value: sast-shell-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:1e8f18f892e16f5d0fc0f42ae8512e3c78251d43cd9d9f7cfd3f6667242bf619
       - name: kind
         value: task
       resolver: bundles
@@ -440,7 +434,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: sast-unicode-check
     params:
     - name: image-digest
@@ -458,7 +452,7 @@ spec:
       - name: name
         value: sast-unicode-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:df185dbe4e2852668f9c46f938dd752e90ea9c79696363378435a6499596c319
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:24ad71fde435fc25abba2c4c550beb088b1530f738d3c377e2f635b5f320d57b
       - name: kind
         value: task
       resolver: bundles
@@ -466,7 +460,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: push-dockerfile
     params:
     - name: IMAGE
@@ -486,7 +480,7 @@ spec:
       - name: name
         value: push-dockerfile-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:278f84550844c1c050a65536799f4b54e7c203e0ac51393aa75379dd974c82e9
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:5d8013b6a27bbc5e4ff261144616268f28417ed0950d583ef36349fcd59d3d3d
       - name: kind
         value: task
       resolver: bundles
@@ -503,7 +497,7 @@ spec:
       - name: name
         value: rpms-signature-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:d01508e7a0df9059af2ef455e3e81588a70e0b24cd4a5def35af3cc1537bf84a
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
       - name: kind
         value: task
       resolver: bundles
@@ -511,7 +505,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   workspaces:
   - name: git-auth
     optional: true

--- a/pkg/konfluxgen/docker-build.yaml
+++ b/pkg/konfluxgen/docker-build.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  creationTimestamp: null
+  creationTimestamp:
   labels:
     pipelines.openshift.io/runtime: generic
     pipelines.openshift.io/strategy: docker
@@ -33,21 +33,19 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
-    description: List of platforms to build the container images on. The available
-      set of values is determined by the configuration of the multi-platform-controller.
+    description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
   - default: --all-projects --org=3e1a4cca-ebfb-495f-b64c-3cc960d566b4 --exclude=test*,vendor,third_party
     description: Append arguments to Snyk code command.
     name: snyk-args
     type: string
-  - default: "true"
+  - default: 'true'
     description: Build a source image.
     name: build-source-image
     type: string
-  - default: "false"
-    description: 'Enable in-development package managers. WARNING: the behavior may
-      change at any time without notice. Use at your own risk.'
+  - default: 'false'
+    description: 'Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk.'
     name: prefetch-input-dev-package-managers
   - default: []
     description: Additional image tags
@@ -56,7 +54,7 @@ spec:
   - description: Source Repository URL
     name: git-url
     type: string
-  - default: ""
+  - default: ''
     description: Revision of the Source Repository
     name: revision
     type: string
@@ -64,36 +62,33 @@ spec:
     name: output-image
     type: string
   - default: .
-    description: Path to the source code of an application's component from where
-      to build image.
+    description: Path to the source code of an application's component from where to build image.
     name: path-context
     type: string
   - default: Dockerfile
-    description: Path to the Dockerfile inside the context specified by parameter
-      path-context
+    description: Path to the Dockerfile inside the context specified by parameter path-context
     name: dockerfile
     type: string
-  - default: "false"
+  - default: 'false'
     description: Force rebuild image
     name: rebuild
     type: string
-  - default: "false"
+  - default: 'false'
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: "false"
+  - default: 'false'
     description: Execute the build with network isolation
     name: hermetic
     type: string
-  - default: ""
+  - default: ''
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
-  - default: ""
-    description: Image tag expiration time, time values could be something like 1h,
-      2d, 3w for hours, days, and weeks, respectively.
+  - default: ''
+    description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
-  - default: "true"
+  - default: 'true'
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
@@ -101,26 +96,25 @@ spec:
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
-  - default: ""
+  - default: ''
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "false"
-    description: Whether to enable privileged mode, should be used only with remote
-      VMs
+  - default: 'false'
+    description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
     type: string
   results:
-  - description: ""
+  - description: ''
     name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
-  - description: ""
+  - description: ''
     name: IMAGE_DIGEST
     value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-  - description: ""
+  - description: ''
     name: CHAINS-GIT_URL
     value: $(tasks.clone-repository.results.url)
-  - description: ""
+  - description: ''
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
   tasks:
@@ -143,7 +137,7 @@ spec:
       - name: name
         value: sast-snyk-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:89aead32dc21404e4e0913be9668bdd2eea795db3e4caa762fb619044e479cb8
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:e61f541189b30d14292ef8df36ccaf13f7feb2378fed5f74cb6293b3e79eb687
       - name: kind
         value: task
       resolver: bundles
@@ -151,7 +145,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: prefetch-dependencies
     params:
     - name: dev-package-managers
@@ -171,7 +165,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3a1b3280d6300ebedb9923ddc441b91b6980512be5dae8da4b9d3be21feeb48e
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d0cbc492da865be336d09926eb6e3494403dccaa4a212bbdf472d8adbf80ab08
       - name: kind
         value: task
       resolver: bundles
@@ -195,7 +189,7 @@ spec:
       - name: name
         value: apply-tags
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:53934b9d7649273d1bf99525f3c92da518842697f525cdb9502280f5c395b9fd
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:517a51e260c0b59654a9d7b842e1ab07d76bce15ca7ce9c8fd2489a19be6463d
       - name: kind
         value: task
       resolver: bundles
@@ -212,7 +206,7 @@ spec:
       - name: name
         value: init
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:de2d7b8cff0ea9d7f4563fffaaea0b0955dd6d81a1f7e323e1668f7d876e4191
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:66e90d31e1386bf516fb548cd3e3f0082b5d0234b8b90dbf9e0d4684b70dbe1a
       - name: kind
         value: task
       resolver: bundles
@@ -233,7 +227,7 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0e512b12775b2bcc4eb47bb34b7a2db2e91c3ceef04b2f2487fa421032d8859a
       - name: kind
         value: task
       resolver: bundles
@@ -241,7 +235,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
     workspaces:
     - name: basic-auth
       workspace: git-auth
@@ -278,7 +272,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
-      value: "true"
+      value: 'true'
     runAfter:
     - prefetch-dependencies
     taskRef:
@@ -286,7 +280,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:3141de71b1b98725e37c15c4287b8aa10008b755403a6d2518b85c6f19194fcc
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:28d8a4f7c1ff6e8bb09d89b06c7c8769093ac7e9325ad9edfe7b2d766f643b87
       - name: kind
         value: task
       resolver: bundles
@@ -294,7 +288,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: build-image-index
     params:
     - name: IMAGE
@@ -315,7 +309,7 @@ spec:
       - name: name
         value: build-image-index
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3cf3dcc0bf7b674b940063b4d55e41fe7d43636a1d82572e3850228aa5350fa8
       - name: kind
         value: task
       resolver: bundles
@@ -323,7 +317,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
@@ -339,7 +333,7 @@ spec:
       - name: name
         value: source-build-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:c96a73714286564a02354fd52d866da24bcfe74aad8ed5fd2d77a617dd2983ba
+        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:f0784e8e0e396f40a6523693825b5966c3c615ba3d342350165e83cb72a24ef7
       - name: kind
         value: task
       resolver: bundles
@@ -347,11 +341,11 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
     - input: $(params.build-source-image)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL
@@ -365,7 +359,7 @@ spec:
       - name: name
         value: deprecated-image-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:270a79138a98e43c366d3722978cb5940d2bcb822ba6b60377330f863b7a1e62
       - name: kind
         value: task
       resolver: bundles
@@ -373,7 +367,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: clair-scan
     params:
     - name: image-digest
@@ -387,7 +381,7 @@ spec:
       - name: name
         value: clair-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
+        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:d354939892f3a904223ec080cc3771bd11931085a5d202323ea491ee8e8c5e43
       - name: kind
         value: task
       resolver: bundles
@@ -395,7 +389,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: ecosystem-cert-preflight-checks
     params:
     - name: image-url
@@ -407,7 +401,7 @@ spec:
       - name: name
         value: ecosystem-cert-preflight-checks
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e16e33931bccd678b6b10b87636f37a08a0288b65a662ff76b5dad6fcbbb077f
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:95ca11d147ee97d98f495477e9f42afe94ba3f869fc81c4e7b241ebd21e7395f
       - name: kind
         value: task
       resolver: bundles
@@ -415,7 +409,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: clamav-scan
     params:
     - name: image-digest
@@ -429,7 +423,7 @@ spec:
       - name: name
         value: clamav-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:11b1684965b64f1fa7c65f90a3524413022246a3863eaba188c84eb4bf0b687a
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:9cab95ac9e833d77a63c079893258b73b8d5a298d93aaf9bdd6722471bc2f338
       - name: kind
         value: task
       resolver: bundles
@@ -437,7 +431,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: sast-shell-check
     params:
     - name: image-digest
@@ -455,7 +449,7 @@ spec:
       - name: name
         value: sast-shell-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:1e8f18f892e16f5d0fc0f42ae8512e3c78251d43cd9d9f7cfd3f6667242bf619
       - name: kind
         value: task
       resolver: bundles
@@ -463,7 +457,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: sast-unicode-check
     params:
     - name: image-digest
@@ -481,7 +475,7 @@ spec:
       - name: name
         value: sast-unicode-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:df185dbe4e2852668f9c46f938dd752e90ea9c79696363378435a6499596c319
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:24ad71fde435fc25abba2c4c550beb088b1530f738d3c377e2f635b5f320d57b
       - name: kind
         value: task
       resolver: bundles
@@ -489,7 +483,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: push-dockerfile
     params:
     - name: IMAGE
@@ -509,7 +503,7 @@ spec:
       - name: name
         value: push-dockerfile-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:278f84550844c1c050a65536799f4b54e7c203e0ac51393aa75379dd974c82e9
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:5d8013b6a27bbc5e4ff261144616268f28417ed0950d583ef36349fcd59d3d3d
       - name: kind
         value: task
       resolver: bundles
@@ -526,7 +520,7 @@ spec:
       - name: name
         value: rpms-signature-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:d01508e7a0df9059af2ef455e3e81588a70e0b24cd4a5def35af3cc1537bf84a
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
       - name: kind
         value: task
       resolver: bundles
@@ -534,7 +528,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   workspaces:
   - name: git-auth
     optional: true

--- a/pkg/konfluxgen/docker-build.yaml
+++ b/pkg/konfluxgen/docker-build.yaml
@@ -184,8 +184,10 @@ spec:
     params:
     - name: ADDITIONAL_TAGS
       value: $(params.additional-tags[*])
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-image-index
     taskRef:

--- a/pkg/konfluxgen/docker-java-build.yaml
+++ b/pkg/konfluxgen/docker-java-build.yaml
@@ -312,8 +312,10 @@ spec:
     params:
     - name: ADDITIONAL_TAGS
       value: $(params.additional-tags[*])
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-image-index
     taskRef:

--- a/pkg/konfluxgen/docker-java-build.yaml
+++ b/pkg/konfluxgen/docker-java-build.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  creationTimestamp: null
+  creationTimestamp:
   labels:
     pipelines.openshift.io/runtime: generic
     pipelines.openshift.io/strategy: docker
@@ -33,21 +33,19 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
-    description: List of platforms to build the container images on. The available
-      set of values is determined by the configuration of the multi-platform-controller.
+    description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
   - default: --all-projects --org=3e1a4cca-ebfb-495f-b64c-3cc960d566b4 --exclude=test*,vendor,third_party
     description: Append arguments to Snyk code command.
     name: snyk-args
     type: string
-  - default: "true"
+  - default: 'true'
     description: Build a source image.
     name: build-source-image
     type: string
-  - default: "false"
-    description: 'Enable in-development package managers. WARNING: the behavior may
-      change at any time without notice. Use at your own risk.'
+  - default: 'false'
+    description: 'Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk.'
     name: prefetch-input-dev-package-managers
   - default: []
     description: Additional image tags
@@ -56,7 +54,7 @@ spec:
   - description: Source Repository URL
     name: git-url
     type: string
-  - default: ""
+  - default: ''
     description: Revision of the Source Repository
     name: revision
     type: string
@@ -64,36 +62,33 @@ spec:
     name: output-image
     type: string
   - default: .
-    description: Path to the source code of an application's component from where
-      to build image.
+    description: Path to the source code of an application's component from where to build image.
     name: path-context
     type: string
   - default: Dockerfile
-    description: Path to the Dockerfile inside the context specified by parameter
-      path-context
+    description: Path to the Dockerfile inside the context specified by parameter path-context
     name: dockerfile
     type: string
-  - default: "false"
+  - default: 'false'
     description: Force rebuild image
     name: rebuild
     type: string
-  - default: "false"
+  - default: 'false'
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: "false"
+  - default: 'false'
     description: Execute the build with network isolation
     name: hermetic
     type: string
-  - default: ""
+  - default: ''
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
-  - default: ""
-    description: Image tag expiration time, time values could be something like 1h,
-      2d, 3w for hours, days, and weeks, respectively.
+  - default: ''
+    description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
-  - default: "true"
+  - default: 'true'
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
@@ -101,26 +96,25 @@ spec:
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
-  - default: ""
+  - default: ''
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "false"
-    description: Whether to enable privileged mode, should be used only with remote
-      VMs
+  - default: 'false'
+    description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
     type: string
   results:
-  - description: ""
+  - description: ''
     name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
-  - description: ""
+  - description: ''
     name: IMAGE_DIGEST
     value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-  - description: ""
+  - description: ''
     name: CHAINS-GIT_URL
     value: $(tasks.clone-repository.results.url)
-  - description: ""
+  - description: ''
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
   tasks:
@@ -138,7 +132,7 @@ spec:
     - name: CONTEXT
       value: $(params.path-context)
     - name: HERMETIC
-      value: "false"
+      value: 'false'
     - name: PREFETCH_INPUT
       value: $(params.prefetch-input)
     - name: IMAGE_EXPIRES_AFTER
@@ -155,7 +149,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
-      value: "true"
+      value: 'true'
     runAfter:
     - prefetch-dependencies
     taskRef:
@@ -163,7 +157,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:3141de71b1b98725e37c15c4287b8aa10008b755403a6d2518b85c6f19194fcc
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:28d8a4f7c1ff6e8bb09d89b06c7c8769093ac7e9325ad9edfe7b2d766f643b87
       - name: kind
         value: task
       resolver: bundles
@@ -171,7 +165,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: build-image-index-deps
     params:
     - name: IMAGE
@@ -192,7 +186,7 @@ spec:
       - name: name
         value: build-image-index
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3cf3dcc0bf7b674b940063b4d55e41fe7d43636a1d82572e3850228aa5350fa8
       - name: kind
         value: task
       resolver: bundles
@@ -200,7 +194,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - matrix:
       params:
       - name: PLATFORM
@@ -235,7 +229,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
-      value: "true"
+      value: 'true'
     runAfter:
     - build-image-index-deps
     taskRef:
@@ -243,7 +237,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:3141de71b1b98725e37c15c4287b8aa10008b755403a6d2518b85c6f19194fcc
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:28d8a4f7c1ff6e8bb09d89b06c7c8769093ac7e9325ad9edfe7b2d766f643b87
       - name: kind
         value: task
       resolver: bundles
@@ -251,7 +245,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: sast-snyk-check
     params:
     - name: ARGS
@@ -271,7 +265,7 @@ spec:
       - name: name
         value: sast-snyk-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:89aead32dc21404e4e0913be9668bdd2eea795db3e4caa762fb619044e479cb8
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:e61f541189b30d14292ef8df36ccaf13f7feb2378fed5f74cb6293b3e79eb687
       - name: kind
         value: task
       resolver: bundles
@@ -279,7 +273,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: prefetch-dependencies
     params:
     - name: dev-package-managers
@@ -299,7 +293,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3a1b3280d6300ebedb9923ddc441b91b6980512be5dae8da4b9d3be21feeb48e
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d0cbc492da865be336d09926eb6e3494403dccaa4a212bbdf472d8adbf80ab08
       - name: kind
         value: task
       resolver: bundles
@@ -323,7 +317,7 @@ spec:
       - name: name
         value: apply-tags
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:53934b9d7649273d1bf99525f3c92da518842697f525cdb9502280f5c395b9fd
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:517a51e260c0b59654a9d7b842e1ab07d76bce15ca7ce9c8fd2489a19be6463d
       - name: kind
         value: task
       resolver: bundles
@@ -340,7 +334,7 @@ spec:
       - name: name
         value: init
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:de2d7b8cff0ea9d7f4563fffaaea0b0955dd6d81a1f7e323e1668f7d876e4191
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:66e90d31e1386bf516fb548cd3e3f0082b5d0234b8b90dbf9e0d4684b70dbe1a
       - name: kind
         value: task
       resolver: bundles
@@ -361,7 +355,7 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0e512b12775b2bcc4eb47bb34b7a2db2e91c3ceef04b2f2487fa421032d8859a
       - name: kind
         value: task
       resolver: bundles
@@ -369,7 +363,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
     workspaces:
     - name: basic-auth
       workspace: git-auth
@@ -393,7 +387,7 @@ spec:
       - name: name
         value: build-image-index
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3cf3dcc0bf7b674b940063b4d55e41fe7d43636a1d82572e3850228aa5350fa8
       - name: kind
         value: task
       resolver: bundles
@@ -401,7 +395,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
@@ -417,7 +411,7 @@ spec:
       - name: name
         value: source-build-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:c96a73714286564a02354fd52d866da24bcfe74aad8ed5fd2d77a617dd2983ba
+        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:f0784e8e0e396f40a6523693825b5966c3c615ba3d342350165e83cb72a24ef7
       - name: kind
         value: task
       resolver: bundles
@@ -425,11 +419,11 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
     - input: $(params.build-source-image)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL
@@ -443,7 +437,7 @@ spec:
       - name: name
         value: deprecated-image-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:270a79138a98e43c366d3722978cb5940d2bcb822ba6b60377330f863b7a1e62
       - name: kind
         value: task
       resolver: bundles
@@ -451,7 +445,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: clair-scan
     params:
     - name: image-digest
@@ -465,7 +459,7 @@ spec:
       - name: name
         value: clair-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
+        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:d354939892f3a904223ec080cc3771bd11931085a5d202323ea491ee8e8c5e43
       - name: kind
         value: task
       resolver: bundles
@@ -473,7 +467,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: ecosystem-cert-preflight-checks
     params:
     - name: image-url
@@ -485,7 +479,7 @@ spec:
       - name: name
         value: ecosystem-cert-preflight-checks
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e16e33931bccd678b6b10b87636f37a08a0288b65a662ff76b5dad6fcbbb077f
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:95ca11d147ee97d98f495477e9f42afe94ba3f869fc81c4e7b241ebd21e7395f
       - name: kind
         value: task
       resolver: bundles
@@ -493,7 +487,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: clamav-scan
     params:
     - name: image-digest
@@ -507,7 +501,7 @@ spec:
       - name: name
         value: clamav-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:11b1684965b64f1fa7c65f90a3524413022246a3863eaba188c84eb4bf0b687a
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:9cab95ac9e833d77a63c079893258b73b8d5a298d93aaf9bdd6722471bc2f338
       - name: kind
         value: task
       resolver: bundles
@@ -515,7 +509,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: sast-shell-check
     params:
     - name: image-digest
@@ -533,7 +527,7 @@ spec:
       - name: name
         value: sast-shell-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:1e8f18f892e16f5d0fc0f42ae8512e3c78251d43cd9d9f7cfd3f6667242bf619
       - name: kind
         value: task
       resolver: bundles
@@ -541,7 +535,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: sast-unicode-check
     params:
     - name: image-digest
@@ -559,7 +553,7 @@ spec:
       - name: name
         value: sast-unicode-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:df185dbe4e2852668f9c46f938dd752e90ea9c79696363378435a6499596c319
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:24ad71fde435fc25abba2c4c550beb088b1530f738d3c377e2f635b5f320d57b
       - name: kind
         value: task
       resolver: bundles
@@ -567,7 +561,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: push-dockerfile
     params:
     - name: IMAGE
@@ -587,7 +581,7 @@ spec:
       - name: name
         value: push-dockerfile-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:278f84550844c1c050a65536799f4b54e7c203e0ac51393aa75379dd974c82e9
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:5d8013b6a27bbc5e4ff261144616268f28417ed0950d583ef36349fcd59d3d3d
       - name: kind
         value: task
       resolver: bundles
@@ -604,7 +598,7 @@ spec:
       - name: name
         value: rpms-signature-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:d01508e7a0df9059af2ef455e3e81588a70e0b24cd4a5def35af3cc1537bf84a
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
       - name: kind
         value: task
       resolver: bundles
@@ -612,7 +606,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   workspaces:
   - name: git-auth
     optional: true

--- a/pkg/konfluxgen/fbc-builder.yaml
+++ b/pkg/konfluxgen/fbc-builder.yaml
@@ -115,8 +115,10 @@ spec:
     params:
     - name: ADDITIONAL_TAGS
       value: $(params.additional-tags[*])
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-image-index
     taskRef:

--- a/pkg/konfluxgen/fbc-builder.yaml
+++ b/pkg/konfluxgen/fbc-builder.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  creationTimestamp: null
+  creationTimestamp:
   labels:
     pipelines.openshift.io/runtime: fbc
     pipelines.openshift.io/strategy: fbc
@@ -33,11 +33,10 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
-    description: List of platforms to build the container images on. The available
-      set of values is determined by the configuration of the multi-platform-controller.
+    description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
-  - default: "true"
+  - default: 'true'
     description: Build a source image.
     name: build-source-image
     type: string
@@ -48,7 +47,7 @@ spec:
   - description: Source Repository URL
     name: git-url
     type: string
-  - default: ""
+  - default: ''
     description: Revision of the Source Repository
     name: revision
     type: string
@@ -56,36 +55,33 @@ spec:
     name: output-image
     type: string
   - default: .
-    description: Path to the source code of an application's component from where
-      to build image.
+    description: Path to the source code of an application's component from where to build image.
     name: path-context
     type: string
   - default: Dockerfile
-    description: Path to the Dockerfile inside the context specified by parameter
-      path-context
+    description: Path to the Dockerfile inside the context specified by parameter path-context
     name: dockerfile
     type: string
-  - default: "false"
+  - default: 'false'
     description: Force rebuild image
     name: rebuild
     type: string
-  - default: "false"
+  - default: 'false'
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: "true"
+  - default: 'true'
     description: Execute the build with network isolation
     name: hermetic
     type: string
-  - default: ""
+  - default: ''
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
-  - default: ""
-    description: Image tag expiration time, time values could be something like 1h,
-      2d, 3w for hours, days, and weeks, respectively.
+  - default: ''
+    description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
-  - default: "true"
+  - default: 'true'
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
@@ -93,21 +89,21 @@ spec:
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
-  - default: ""
+  - default: ''
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
   results:
-  - description: ""
+  - description: ''
     name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
-  - description: ""
+  - description: ''
     name: IMAGE_DIGEST
     value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-  - description: ""
+  - description: ''
     name: CHAINS-GIT_URL
     value: $(tasks.clone-repository.results.url)
-  - description: ""
+  - description: ''
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
   tasks:
@@ -126,7 +122,7 @@ spec:
       - name: name
         value: apply-tags
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:53934b9d7649273d1bf99525f3c92da518842697f525cdb9502280f5c395b9fd
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:517a51e260c0b59654a9d7b842e1ab07d76bce15ca7ce9c8fd2489a19be6463d
       - name: kind
         value: task
       resolver: bundles
@@ -143,7 +139,7 @@ spec:
       - name: name
         value: init
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:de2d7b8cff0ea9d7f4563fffaaea0b0955dd6d81a1f7e323e1668f7d876e4191
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:66e90d31e1386bf516fb548cd3e3f0082b5d0234b8b90dbf9e0d4684b70dbe1a
       - name: kind
         value: task
       resolver: bundles
@@ -164,7 +160,7 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0e512b12775b2bcc4eb47bb34b7a2db2e91c3ceef04b2f2487fa421032d8859a
       - name: kind
         value: task
       resolver: bundles
@@ -172,7 +168,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
     workspaces:
     - name: basic-auth
       workspace: git-auth
@@ -193,7 +189,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3a1b3280d6300ebedb9923ddc441b91b6980512be5dae8da4b9d3be21feeb48e
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d0cbc492da865be336d09926eb6e3494403dccaa4a212bbdf472d8adbf80ab08
       - name: kind
         value: task
       resolver: bundles
@@ -233,7 +229,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
-      value: "true"
+      value: 'true'
     runAfter:
     - clone-repository
     taskRef:
@@ -241,7 +237,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:3141de71b1b98725e37c15c4287b8aa10008b755403a6d2518b85c6f19194fcc
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:28d8a4f7c1ff6e8bb09d89b06c7c8769093ac7e9325ad9edfe7b2d766f643b87
       - name: kind
         value: task
       resolver: bundles
@@ -249,7 +245,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: build-image-index
     params:
     - name: IMAGE
@@ -270,7 +266,7 @@ spec:
       - name: name
         value: build-image-index
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3cf3dcc0bf7b674b940063b4d55e41fe7d43636a1d82572e3850228aa5350fa8
       - name: kind
         value: task
       resolver: bundles
@@ -278,7 +274,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values:
-      - "true"
+      - 'true'
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL
@@ -292,7 +288,7 @@ spec:
       - name: name
         value: deprecated-image-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:270a79138a98e43c366d3722978cb5940d2bcb822ba6b60377330f863b7a1e62
       - name: kind
         value: task
       resolver: bundles
@@ -300,7 +296,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: validate-fbc
     params:
     - name: IMAGE_URL
@@ -314,7 +310,7 @@ spec:
       - name: name
         value: validate-fbc
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:4311767f6c448a2e4693f075346a723a47139bb040b30d70bd728df81d009c42
+        value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:cf1e41bc38f6e7ae7094b2a2501eedca374f7e1d8a4c49a2fd027c2a6277e1c0
       - name: kind
         value: task
       resolver: bundles
@@ -322,7 +318,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: fbc-target-index-pruning-check
     params:
     - name: IMAGE_URL
@@ -340,7 +336,7 @@ spec:
       - name: name
         value: fbc-target-index-pruning-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:a4d0bedb2aeed06d060b5a38f3dc020625e1c11665fc1a0317765c1f90edb485
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:8c248084b0329fbde6f0acbaf2f0f9f78e2f45ec02e5dcdfdf674e6e98594254
       - name: kind
         value: task
       resolver: bundles
@@ -348,7 +344,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   - name: fbc-fips-check-oci-ta
     params:
     - name: image-digest
@@ -364,7 +360,7 @@ spec:
       - name: name
         value: fbc-fips-check-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2bc6985a2bd9379ddd3d0ce4343580517bb1a10ffdb7036aa3dd2bbe1943cc0a
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:58ec48ff55d3590cad7a1f8d142498581ac1b717ac4722621bed971997b56e06
       - name: kind
         value: task
       resolver: bundles
@@ -372,7 +368,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values:
-      - "false"
+      - 'false'
   workspaces:
   - name: git-auth
     optional: true

--- a/pkg/konfluxgen/konfluxgen_test.go
+++ b/pkg/konfluxgen/konfluxgen_test.go
@@ -390,8 +390,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-container
     taskRef:
@@ -785,8 +787,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-container
     taskRef:
@@ -1180,8 +1184,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-container
     taskRef:

--- a/pkg/konfluxgen/kustomize/docker-build.yaml
+++ b/pkg/konfluxgen/kustomize/docker-build.yaml
@@ -520,8 +520,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-image-index
     taskRef:

--- a/pkg/konfluxgen/kustomize/fbc-builder.yaml
+++ b/pkg/konfluxgen/kustomize/fbc-builder.yaml
@@ -277,8 +277,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-image-index
     taskRef:

--- a/pkg/konfluxgen/kustomize/kustomize-bundle-build/patch_build-image-index-param.patch.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-bundle-build/patch_build-image-index-param.patch.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   params:
     - name: build-image-index
-      default: "false"
+      default: 'false'
   tasks:
     - name: build-images
       params:

--- a/pkg/konfluxgen/kustomize/kustomize-fbc-builder/patch_related_image_check.patch.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-fbc-builder/patch_related_image_check.patch.yaml
@@ -7,11 +7,11 @@ spec:
     - name: skip-fbc-related-image-check
       description: Skip fbc-related-image-check
       type: string
-      default: "false"
+      default: 'false'
   tasks:
     - name: fbc-related-image-check
       when:
         - input: $(params.skip-fbc-related-image-check)
           operator: in
           values:
-            - "false"
+            - 'false'

--- a/pkg/konfluxgen/kustomize/kustomize-java-docker-build/patch_java_build.patch.yaml
+++ b/pkg/konfluxgen/kustomize/kustomize-java-docker-build/patch_java_build.patch.yaml
@@ -18,7 +18,7 @@ spec:
         - name: CONTEXT
           value: $(params.path-context)
         - name: HERMETIC
-          value: "false"
+          value: 'false'
         - name: PREFETCH_INPUT
           value: $(params.prefetch-input)
         - name: IMAGE_EXPIRES_AFTER
@@ -35,7 +35,7 @@ spec:
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         - name: IMAGE_APPEND_PLATFORM
-          value: "true"
+          value: 'true'
       runAfter:
         - prefetch-dependencies
       taskRef:
@@ -43,7 +43,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:a01ac7eef5b4e889b5619fe397c115e16a70eafe1d39315b5654a781f2e294e1
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:28d8a4f7c1ff6e8bb09d89b06c7c8769093ac7e9325ad9edfe7b2d766f643b87
           - name: kind
             value: task
         resolver: bundles
@@ -51,7 +51,7 @@ spec:
         - input: $(tasks.init.results.build)
           operator: in
           values:
-            - "true"
+            - 'true'
 
     - name: build-image-index-deps
       params:
@@ -73,7 +73,7 @@ spec:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:e4871851566d8b496966b37bcb8c5ce9748a52487f116373d96c6cd28ef684c6
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3cf3dcc0bf7b674b940063b4d55e41fe7d43636a1d82572e3850228aa5350fa8
           - name: kind
             value: task
         resolver: bundles
@@ -81,7 +81,7 @@ spec:
         - input: $(tasks.init.results.build)
           operator: in
           values:
-            - "true"
+            - 'true'
 
     - name: build-images
       params:

--- a/pkg/konfluxgen/testdata/docker-build-expected.yaml
+++ b/pkg/konfluxgen/testdata/docker-build-expected.yaml
@@ -369,8 +369,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-container
     taskRef:

--- a/pkg/konfluxgen/testdata/docker-build.yaml
+++ b/pkg/konfluxgen/testdata/docker-build.yaml
@@ -369,8 +369,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-container
     taskRef:


### PR DESCRIPTION
as per Migration from 0.1 to 0.2 [see](https://github.com/openshift-knative/serverless-operator/pull/3667)

ref: https://github.com/konflux-ci/build-definitions/blob/main/task/apply-tags/0.2/MIGRATION.md

cc @rudyredhat1 