### PR TITLE
Add sync for OWNERS files

### DIFF
--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -60,3 +60,16 @@ repositories:
     namespace: openshift
   repo: backstage-plugins
   slackChannel: '#knative-eventing-ci'
+  owners:
+    reviewers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707
+    approvers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707

--- a/config/client.yaml
+++ b/config/client.yaml
@@ -71,3 +71,13 @@ repositories:
     namespace: openshift
   repo: client
   slackChannel: '#serverless-ci'
+  owners:
+    reviewers:
+      - dsimansk
+      - Kaustubh-pande
+      - rudyredhat1
+    approvers:
+      - dsimansk
+      - Kaustubh-pande
+      - creydr
+      - rudyredhat1

--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -16,3 +16,16 @@ repositories:
   promotion: {}
   repo: eventing-hyperfoil-benchmark
   slackChannel: '#knative-eventing-ci'
+  owners:
+    reviewers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707
+    approvers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707

--- a/config/eventing-integrations.yaml
+++ b/config/eventing-integrations.yaml
@@ -103,3 +103,16 @@ repositories:
     namespace: openshift
   repo: eventing-integrations
   slackChannel: '#knative-eventing-ci'
+  owners:
+    reviewers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707
+    approvers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -67,3 +67,16 @@ repositories:
     namespace: openshift
   repo: eventing-istio
   slackChannel: '#knative-eventing-ci'
+  owners:
+    reviewers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707
+    approvers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -95,3 +95,16 @@ repositories:
     namespace: openshift
   repo: eventing-kafka-broker
   slackChannel: '#knative-eventing-ci'
+  owners:
+    reviewers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707
+    approvers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -73,3 +73,16 @@ repositories:
     namespace: openshift
   repo: eventing
   slackChannel: '#knative-eventing-ci'
+  owners:
+    reviewers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707
+    approvers:
+      - aliok
+      - creydr
+      - lberk
+      - matzew
+      - Cali0707

--- a/config/kn-plugin-event.yaml
+++ b/config/kn-plugin-event.yaml
@@ -68,3 +68,19 @@ repositories:
     commands: make unit
     container:
       from: src
+  owners:
+    reviewers:
+      - dsimansk
+      - cardil
+      - creydr
+      - maschmid
+      - mvinkler
+      - jrangelramos
+      - rudyredhat1
+      - Kaustubh-pande
+    approvers:
+      - dsimansk
+      - cardil
+      - creydr
+      - maschmid
+      - openshift-cherrypick-robot

--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -95,3 +95,12 @@ repositories:
             cpu: 100m
         timeout: 1h0m0s
       workflow: generic-claim
+  owners:
+    reviewers:
+      - jrangelramos
+    approvers:
+      - creydr
+      - dsimansk
+      - lkingland
+      - matejvasek
+      - gauron99

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -654,3 +654,19 @@ repositories:
         cpu: 100m
         memory: 200Mi
   slackChannel: '#serverless-ci'
+  owners:
+    reviewers:
+      - aliok
+      - creydr
+      - dsimansk
+      - matzew
+      - Kaustubh-pande
+    approvers:
+      - aliok
+      - creydr
+      - dsimansk
+      - lberk
+      - matzew
+      - openshift-cherrypick-robot
+      - Kaustubh-pande
+      - maschmid

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -47,3 +47,12 @@ repositories:
     namespace: openshift
   repo: net-istio
   slackChannel: '#knative-serving-ci'
+  owners:
+    reviewers:
+      - dsimansk
+      - Fedosin
+      - mvinkler
+    approvers:
+      - dsimansk
+      - Fedosin
+      - mvinkler

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -47,3 +47,12 @@ repositories:
     namespace: openshift
   repo: net-kourier
   slackChannel: '#knative-serving-ci'
+  owners:
+    reviewers:
+      - dsimansk
+      - Fedosin
+      - mvinkler
+    approvers:
+      - dsimansk
+      - Fedosin
+      - mvinkler

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -112,3 +112,12 @@ repositories:
         cpu: 500m
         memory: 4Gi
   slackChannel: '#knative-serving-ci'
+  owners:
+    reviewers:
+      - dsimansk
+      - Fedosin
+      - mvinkler
+    approvers:
+      - dsimansk
+      - Fedosin
+      - mvinkler

--- a/pkg/ownersfilegen/owners.tmpl
+++ b/pkg/ownersfilegen/owners.tmpl
@@ -1,0 +1,13 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+# DO NOT EDIT! File generated via https://github.com/openshift-knative/hack/tree/main/config.
+
+approvers:
+{{- range .approvers }}
+- {{.}}
+{{- end}}
+
+reviewers:
+{{- range .reviewers }}
+- {{.}}
+{{- end}}

--- a/pkg/ownersfilegen/ownersfilegen.go
+++ b/pkg/ownersfilegen/ownersfilegen.go
@@ -1,0 +1,47 @@
+package ownersfilegen
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"text/template"
+)
+
+//go:embed owners.tmpl
+var OwnersTemplate embed.FS
+
+func WriteOwnersFile(repoDir string, reviewers, approvers []string) error {
+	buf := &bytes.Buffer{}
+
+	ownersTemplate, err := template.New("owners.tmpl").ParseFS(OwnersTemplate, "*.tmpl")
+	if err != nil {
+		return fmt.Errorf("failed to parse OWNERS template: %w", err)
+	}
+
+	sortedReviewers := make([]string, len(reviewers))
+	sortedApprovers := make([]string, len(approvers))
+	copy(sortedReviewers, reviewers)
+	copy(sortedApprovers, approvers)
+	slices.Sort(sortedReviewers)
+	slices.Sort(sortedApprovers)
+
+	d := map[string]interface{}{
+		"reviewers": sortedReviewers,
+		"approvers": sortedApprovers,
+	}
+
+	if err := ownersTemplate.Execute(buf, d); err != nil {
+		return fmt.Errorf("failed to execute OWNERS file template: %w", err)
+	}
+
+	ownersFilePath := filepath.Join(repoDir, "OWNERS")
+	if err := os.WriteFile(ownersFilePath, buf.Bytes(), fs.ModePerm); err != nil {
+		return fmt.Errorf("failed to write OWNERS file %q: %w", ownersFilePath, err)
+	}
+
+	return nil
+}

--- a/pkg/ownersfilegen/ownersfilegen.go
+++ b/pkg/ownersfilegen/ownersfilegen.go
@@ -2,12 +2,14 @@ package ownersfilegen
 
 import (
 	"bytes"
+	"cmp"
 	"embed"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"text/template"
 )
 
@@ -22,12 +24,15 @@ func WriteOwnersFile(repoDir string, reviewers, approvers []string) error {
 		return fmt.Errorf("failed to parse OWNERS template: %w", err)
 	}
 
+	compareIgnoreCase := func(a, b string) int {
+		return cmp.Compare(strings.ToLower(a), strings.ToLower(b))
+	}
 	sortedReviewers := make([]string, len(reviewers))
 	sortedApprovers := make([]string, len(approvers))
 	copy(sortedReviewers, reviewers)
 	copy(sortedApprovers, approvers)
-	slices.Sort(sortedReviewers)
-	slices.Sort(sortedApprovers)
+	slices.SortFunc(sortedReviewers, compareIgnoreCase)
+	slices.SortFunc(sortedApprovers, compareIgnoreCase)
 
 	d := map[string]interface{}{
 		"reviewers": sortedReviewers,

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -35,6 +35,7 @@ type Repository struct {
 	Images                []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration `json:"images,omitempty" yaml:"images,omitempty"`
 	Tests                 []cioperatorapi.TestStepConfiguration                       `json:"tests,omitempty" yaml:"tests,omitempty"`
 	Resources             cioperatorapi.ResourceConfiguration                         `json:"resources,omitempty" yaml:"resources,omitempty"`
+	Owners                Owners                                                      `json:"owners,omitempty" yaml:"owners,omitempty"`
 }
 
 type E2ETest struct {
@@ -69,6 +70,11 @@ type CustomConfigs struct {
 	// ReleaseBuildConfiguration allows defining configuration manually. The final configuration
 	// is extended with images and test steps with dependencies.
 	ReleaseBuildConfiguration cioperatorapi.ReleaseBuildConfiguration `json:"releaseBuildConfiguration,omitempty" yaml:"releaseBuildConfiguration,omitempty"`
+}
+
+type Owners struct {
+	Reviewers []string `json:"reviewers,omitempty" yaml:"reviewers,omitempty"`
+	Approvers []string `json:"approvers,omitempty" yaml:"approvers,omitempty"`
 }
 
 func (r Repository) RepositoryDirectory() string {

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/openshift-knative/hack/pkg/dependabotgen"
+	"github.com/openshift-knative/hack/pkg/ownersfilegen"
 	"github.com/openshift-knative/hack/pkg/soversion"
 	"golang.org/x/sync/errgroup"
 
@@ -247,6 +248,15 @@ func GenerateKonflux(ctx context.Context, openshiftRelease Repository, configs [
 						}
 
 						commitMsg := fmt.Sprintf("[%s] Sync Konflux configurations", targetBranch)
+						if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
+							return err
+						}
+
+						if err := ownersfilegen.WriteOwnersFile(r.RepositoryDirectory(), r.Owners.Reviewers, r.Owners.Approvers); err != nil {
+							return fmt.Errorf("[%s][%s] failed to write OWNERS file: %w", r.RepositoryDirectory(), branchName, err)
+						}
+
+						commitMsg = fmt.Sprintf("[%s] Update OWNERS file", targetBranch)
 						if err := PushBranch(ctx, r, nil, pushBranch, commitMsg); err != nil {
 							return err
 						}


### PR DESCRIPTION
Lets us define reviewers and approvers in the repo config in hack and distribute it to the repos and all maintained branches. 
For now the changes are distributed via the "Sync Konflux configurations" PRs. We could also do this via a separate PR, but I didn't want to increase the noise.

I took the current owners config from the repos main branches and removed users which are not in the team anymore.