### PR TITLE
downgrade go 1.23.10 to 1.23.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-knative/hack
 
-go 1.23.10
+go 1.23.9
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
as that is the version registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 currently has