### PR TITLE
Downgrade Golang to 1.22

### DIFF
--- a/.github/workflows/go-unit-tests.yaml
+++ b/.github/workflows/go-unit-tests.yaml
@@ -15,9 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+        uses: ./actions/setup-go
 
       - name: Run unit tests
         run: make unit-tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-knative/hack
 
-go 1.23.10
+go 1.22.9
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/build-image/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.ci.openshift.org/ocp/4.17:cli-artifacts as tools
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 ARG TARGETARCH
 

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for cmd/discover.
-ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19
+ARG GO_BUILDER=registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
 ARG GO_RUNTIME=registry.access.redhat.com/ubi8/ubi-minimal
 
 FROM $GO_BUILDER as builder


### PR DESCRIPTION
Downgrading to go 1.22 again, as we require 1.23 only for the unit tests (therefor using the setup-go action from hack repo, which [defaults to Go 1.23](https://github.com/openshift-knative/hack/blob/5d3110a5cad17174e0e3fd72530a917f53f8481e/actions/setup-go/action.yaml#L18)).

```
go: gotest.tools/gotestsum@v1.12.3 requires go >= 1.23.0; switching to go1.23.11
```

Through this change, we don't need to upgrade all the Gobuilder images to Go 1.23 only because we use the latest code from hack repo