### PR TITLE
Fix: List all available branches

### DIFF
--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -98,7 +98,7 @@ func discover(ctx context.Context, path string, unsupported []Unsupported) error
 			latest = "release-next"
 		}
 
-		availableBranches, err := prowgen.Branches(ctx, r)
+		availableBranches, err := prowgen.ReleaseBranches(ctx, r)
 		if err != nil {
 			return err
 		}

--- a/pkg/prowgen/prowgen_konflux.go
+++ b/pkg/prowgen/prowgen_konflux.go
@@ -304,7 +304,7 @@ func writeDependabotConfig(ctx context.Context, dependabotConfig *dependabotgen.
 
 func ServerlessOperatorKonfluxVersions(ctx context.Context) (map[string]string, error) {
 	r := Repository{Org: "openshift-knative", Repo: "serverless-operator"}
-	sortedBranches, err := Branches(ctx, r)
+	sortedBranches, err := ReleaseBranches(ctx, r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list branches for %q: %w", r.RepositoryDirectory(), err)
 	}

--- a/pkg/prowgen/prowgen_owners.go
+++ b/pkg/prowgen/prowgen_owners.go
@@ -24,7 +24,7 @@ func GenerateOwners(ctx context.Context, configs []*Config) error {
 		config := config
 		eg.Go(func() error {
 			for _, r := range config.Repositories {
-				branchesInGit, err := Branches(ctx, r)
+				branchesInGit, err := Branches(ctx, r, "*")
 				if err != nil {
 					return fmt.Errorf("could not get branches for %q: %w", r.Repo, err)
 				}


### PR DESCRIPTION
Currently the generate-ci action fails on the hyperfoil repo to create the owners file, because the prowgen.Branches() lists only release branches and thus the OWNER file generator skips the main branch (because it thinks it's an invalid branch).
This PR addresses it and lets prowgen.Branches() return all branches (including main)