### PR TITLE
Remove outdated versions (1.14 / 1.34)

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -221,30 +221,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[backstage-plugins - release-v1.14] Create OWNERS file update PR'
-        run: |
-          set -x
-          repo="backstage-plugins"
-          branch="sync-owners-release-v1.14"
-          target_branch="release-v1.14"
-          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
-          remote_exists=$(git ls-remote --heads fork "$branch")
-          if [ -z "$remote_exists" ]; then
-            # remote doesn't exist.
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
-          fi
-          git fetch fork "$branch"
-          if git diff --quiet "fork/$branch" "$branch"; then
-            echo "Branches are identical. No need to force push."
-          else
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
-          fi
-          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update OWNERS file" --body "Update OWNERS file" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/backstage-plugins
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[backstage-plugins - release-v1.15] Create Konflux PR'
         run: |
           set -x
@@ -941,30 +917,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[eventing-istio - release-v1.14] Create OWNERS file update PR'
-        run: |
-          set -x
-          repo="eventing-istio"
-          branch="sync-owners-release-v1.14"
-          target_branch="release-v1.14"
-          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
-          remote_exists=$(git ls-remote --heads fork "$branch")
-          if [ -z "$remote_exists" ]; then
-            # remote doesn't exist.
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
-          fi
-          git fetch fork "$branch"
-          if git diff --quiet "fork/$branch" "$branch"; then
-            echo "Branches are identical. No need to force push."
-          else
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
-          fi
-          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update OWNERS file" --body "Update OWNERS file" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[eventing-istio - release-v1.15] Create Konflux PR'
         run: |
           set -x
@@ -1205,30 +1157,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[eventing-kafka-broker - release-v1.14] Create OWNERS file update PR'
-        run: |
-          set -x
-          repo="eventing-kafka-broker"
-          branch="sync-owners-release-v1.14"
-          target_branch="release-v1.14"
-          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
-          remote_exists=$(git ls-remote --heads fork "$branch")
-          if [ -z "$remote_exists" ]; then
-            # remote doesn't exist.
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
-          fi
-          git fetch fork "$branch"
-          if git diff --quiet "fork/$branch" "$branch"; then
-            echo "Branches are identical. No need to force push."
-          else
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
-          fi
-          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update OWNERS file" --body "Update OWNERS file" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[eventing-kafka-broker - release-v1.15] Create Konflux PR'
         run: |
           set -x
@@ -1464,30 +1392,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[eventing - release-v1.14] Create OWNERS file update PR'
-        run: |
-          set -x
-          repo="eventing"
-          branch="sync-owners-release-v1.14"
-          target_branch="release-v1.14"
-          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
-          remote_exists=$(git ls-remote --heads fork "$branch")
-          if [ -z "$remote_exists" ]; then
-            # remote doesn't exist.
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
-          fi
-          git fetch fork "$branch"
-          if git diff --quiet "fork/$branch" "$branch"; then
-            echo "Branches are identical. No need to force push."
-          else
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
-          fi
-          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update OWNERS file" --body "Update OWNERS file" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
@@ -2165,30 +2069,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[kn-plugin-func - serverless-1.34] Create OWNERS file update PR'
-        run: |
-          set -x
-          repo="kn-plugin-func"
-          branch="sync-owners-serverless-1.34"
-          target_branch="serverless-1.34"
-          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
-          remote_exists=$(git ls-remote --heads fork "$branch")
-          if [ -z "$remote_exists" ]; then
-            # remote doesn't exist.
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
-          fi
-          git fetch fork "$branch"
-          if git diff --quiet "fork/$branch" "$branch"; then
-            echo "Branches are identical. No need to force push."
-          else
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
-          fi
-          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update OWNERS file" --body "Update OWNERS file" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/kn-plugin-func
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[kn-plugin-func - main] Create OWNERS file update PR'
         run: |
           set -x
@@ -2405,30 +2285,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[net-istio - release-v1.14] Create OWNERS file update PR'
-        run: |
-          set -x
-          repo="net-istio"
-          branch="sync-owners-release-v1.14"
-          target_branch="release-v1.14"
-          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
-          remote_exists=$(git ls-remote --heads fork "$branch")
-          if [ -z "$remote_exists" ]; then
-            # remote doesn't exist.
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
-          fi
-          git fetch fork "$branch"
-          if git diff --quiet "fork/$branch" "$branch"; then
-            echo "Branches are identical. No need to force push."
-          else
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
-          fi
-          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update OWNERS file" --body "Update OWNERS file" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[net-istio - release-v1.15] Create Konflux PR'
         run: |
           set -x
@@ -2621,30 +2477,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
           GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
         if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[net-kourier - release-v1.14] Create OWNERS file update PR'
-        run: |
-          set -x
-          repo="net-kourier"
-          branch="sync-owners-release-v1.14"
-          target_branch="release-v1.14"
-          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
-          remote_exists=$(git ls-remote --heads fork "$branch")
-          if [ -z "$remote_exists" ]; then
-            # remote doesn't exist.
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
-          fi
-          git fetch fork "$branch"
-          if git diff --quiet "fork/$branch" "$branch"; then
-            echo "Branches are identical. No need to force push."
-          else
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
-          fi
-          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update OWNERS file" --body "Update OWNERS file" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
         name: '[net-kourier - release-v1.15] Create Konflux PR'
         run: |
           set -x
@@ -2832,30 +2664,6 @@ jobs:
             git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
           fi
           gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update dependabot configurations" --body "Update dependabot configurations" || true
-        working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving
-      - env:
-          GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-          GITHUB_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}
-        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
-        name: '[serving - release-v1.14] Create OWNERS file update PR'
-        run: |
-          set -x
-          repo="serving"
-          branch="sync-owners-release-v1.14"
-          target_branch="release-v1.14"
-          git remote add fork "https://github.com/serverless-qe/$repo.git" || true # ignore: already exists errors
-          remote_exists=$(git ls-remote --heads fork "$branch")
-          if [ -z "$remote_exists" ]; then
-            # remote doesn't exist.
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f || exit 1
-          fi
-          git fetch fork "$branch"
-          if git diff --quiet "fork/$branch" "$branch"; then
-            echo "Branches are identical. No need to force push."
-          else
-            git push "https://serverless-qe:${GH_TOKEN}@github.com/serverless-qe/$repo.git" "$branch:$branch" -f
-          fi
-          gh pr create --base "$target_branch" --head "serverless-qe:$branch" --title "[$target_branch] Update OWNERS file" --body "Update OWNERS file" || true
         working-directory: ./src/github.com/openshift-knative/hack/openshift-knative/serving
       - env:
           GH_TOKEN: ${{ secrets.SERVERLESS_QE_ROBOT }}

--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -1,11 +1,5 @@
 config:
   branches:
-    release-v1.14:
-      openShiftVersions:
-      - onDemand: true
-        version: "4.16"
-      - onDemand: true
-        version: "4.14"
     release-v1.15:
       konflux:
         enabled: true

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -6,12 +6,6 @@ config:
         version: "4.19"
       - onDemand: true
         version: "4.14"
-    release-v1.14:
-      openShiftVersions:
-      - onDemand: true
-        version: "4.16"
-      - onDemand: true
-        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
@@ -63,21 +57,21 @@ repositories:
   ignoreConfigs: {}
   imagePrefix: knative-eventing-istio
   org: openshift-knative
+  owners:
+    approvers:
+    - aliok
+    - creydr
+    - lberk
+    - matzew
+    - Cali0707
+    - rudyredhat1
+    reviewers:
+    - aliok
+    - creydr
+    - lberk
+    - matzew
+    - Cali0707
   promotion:
     namespace: openshift
   repo: eventing-istio
   slackChannel: '#knative-eventing-ci'
-  owners:
-    reviewers:
-      - aliok
-      - creydr
-      - lberk
-      - matzew
-      - Cali0707
-    approvers:
-      - aliok
-      - creydr
-      - lberk
-      - matzew
-      - Cali0707
-      - rudyredhat1

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -12,12 +12,6 @@ config:
         version: "4.14"
       skipDockerFilesMatches:
       - .*hermetic.*
-    release-v1.14:
-      openShiftVersions:
-      - onDemand: true
-        version: "4.16"
-      - onDemand: true
-        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
@@ -91,21 +85,21 @@ repositories:
   ignoreConfigs: {}
   imagePrefix: knative-eventing-kafka-broker
   org: openshift-knative
+  owners:
+    approvers:
+    - aliok
+    - creydr
+    - lberk
+    - matzew
+    - Cali0707
+    - rudyredhat1
+    reviewers:
+    - aliok
+    - creydr
+    - lberk
+    - matzew
+    - Cali0707
   promotion:
     namespace: openshift
   repo: eventing-kafka-broker
   slackChannel: '#knative-eventing-ci'
-  owners:
-    reviewers:
-      - aliok
-      - creydr
-      - lberk
-      - matzew
-      - Cali0707
-    approvers:
-      - aliok
-      - creydr
-      - lberk
-      - matzew
-      - Cali0707
-      - rudyredhat1

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -10,12 +10,6 @@ config:
         version: "4.19"
       - onDemand: true
         version: "4.14"
-    release-v1.14:
-      openShiftVersions:
-      - onDemand: true
-        version: "4.16"
-      - onDemand: true
-        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true
@@ -69,21 +63,21 @@ repositories:
   ignoreConfigs: {}
   imagePrefix: knative-eventing
   org: openshift-knative
+  owners:
+    approvers:
+    - aliok
+    - creydr
+    - lberk
+    - matzew
+    - Cali0707
+    - rudyredhat1
+    reviewers:
+    - aliok
+    - creydr
+    - lberk
+    - matzew
+    - Cali0707
   promotion:
     namespace: openshift
   repo: eventing
   slackChannel: '#knative-eventing-ci'
-  owners:
-    reviewers:
-      - aliok
-      - creydr
-      - lberk
-      - matzew
-      - Cali0707
-    approvers:
-      - aliok
-      - creydr
-      - lberk
-      - matzew
-      - Cali0707
-      - rudyredhat1

--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -44,11 +44,6 @@ config:
       - skipCron: true
         useClusterPool: true
         version: "4.19"
-    serverless-1.34:
-      openShiftVersions:
-      - onDemand: true
-        skipCron: true
-        version: "4.16"
 repositories:
 - dockerfiles: {}
   ignoreConfigs: {}

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -1,11 +1,5 @@
 config:
   branches:
-    release-v1.14:
-      openShiftVersions:
-      - onDemand: true
-        version: "4.16"
-      - onDemand: true
-        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -1,11 +1,5 @@
 config:
   branches:
-    release-v1.14:
-      openShiftVersions:
-      - onDemand: true
-        version: "4.16"
-      - onDemand: true
-        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -11,12 +11,6 @@ config:
       skipE2EMatches:
       - perf-tests$
       - .*e2e-tls$
-    release-v1.14:
-      openShiftVersions:
-      - onDemand: true
-        version: "4.16"
-      - onDemand: true
-        version: "4.13"
     release-v1.15:
       konflux:
         enabled: true


### PR DESCRIPTION
Removing the outdated 1.14 / 1.34 versions. 
Actually this should happen through our discover job, but as I removed the 1.34 manually from the unsupported.yaml it didn't trigger it correctly :facepalm: 