### PR TITLE
Move `skip_if_only_changed` to config folder

### DIFF
--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -258,6 +258,7 @@ func (jcis JobConfigCopiedInjectors) Inject(prowcopyCfg *Config, prowgenCfg *pro
 func runProwCopyInjectors(config *Config, inConfig *prowgen.Config, openShiftRelease prowgen.Repository) error {
 	injectors := JobConfigCopiedInjectors{
 		prowgen.AlwaysRunInjector(),
+		prowgen.SkipIfOnlyKonfluxChangedInjector(),
 	}
 	return injectors.Inject(config, inConfig, openShiftRelease)
 }

--- a/pkg/prowcopy/prowcopy.go
+++ b/pkg/prowcopy/prowcopy.go
@@ -258,7 +258,6 @@ func (jcis JobConfigCopiedInjectors) Inject(prowcopyCfg *Config, prowgenCfg *pro
 func runProwCopyInjectors(config *Config, inConfig *prowgen.Config, openShiftRelease prowgen.Repository) error {
 	injectors := JobConfigCopiedInjectors{
 		prowgen.AlwaysRunInjector(),
-		prowgen.SkipIfOnlyKonfluxChangedInjector(),
 	}
 	return injectors.Inject(config, inConfig, openShiftRelease)
 }

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -347,27 +347,12 @@ func runJobConfigInjectors(inConfigs []*Config, openShiftRelease Repository) err
 		injectors := JobConfigInjectors{
 			AlwaysRunInjector(),
 			slackInjector(),
-			SkipIfOnlyKonfluxChangedInjector(),
 		}
 		if err := injectors.Inject(inConfig, openShiftRelease); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func SkipIfOnlyKonfluxChangedInjector() JobConfigInjector {
-	return JobConfigInjector{
-		Type: PreSubmit,
-		Update: func(r *Repository, b *Branch, branchName string, jobConfig *prowconfig.JobConfig) error {
-			for k := range jobConfig.PresubmitsStatic {
-				for i := range jobConfig.PresubmitsStatic[k] {
-					jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = "^.tekton/.*|^.konflux.*|^.github/.*"
-				}
-			}
-			return nil
-		},
-	}
 }
 
 func slackInjector() JobConfigInjector {

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -427,6 +427,7 @@ func AlwaysRunInjector() JobConfigInjector {
 							// default to always_run = false for image jobs
 							// use hack from https://redhat-internal.slack.com/archives/CBN38N3MW/p1753111329185729?thread_ts=1752996614.456229&cid=CBN38N3MW to make always_run=false
 							jobConfig.PresubmitsStatic[k][i].RunIfChanged = "^non-existing$"
+							jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = ""
 						}
 					}
 
@@ -436,6 +437,7 @@ func AlwaysRunInjector() JobConfigInjector {
 							// On demand jobs don't run even when specific dir changes.
 							// use hack from https://redhat-internal.slack.com/archives/CBN38N3MW/p1753111329185729?thread_ts=1752996614.456229&cid=CBN38N3MW to make always_run=false
 							jobConfig.PresubmitsStatic[k][i].RunIfChanged = "^non-existing$"
+							jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = ""
 						}
 					}
 				}

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -421,7 +421,7 @@ func AlwaysRunInjector() JobConfigInjector {
 					// Prevent sneaking in wrong settings from previous runs of "make jobs".
 					// Make sure we reset it to default.
 					jobConfig.PresubmitsStatic[k][i].AlwaysRun = false
-					jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = "^.tekton/.*|^.konflux.*|^.github/.*|^rpms.lock.yaml$|^hack/.*|^OWNERS.*|.*\\.md"
+					jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = "^.tekton/.*|^.konflux.*|^.github/.*"
 
 					// Build images in pre-submit phase only for OpenShift versions that are mandatory to test.
 					if strings.HasSuffix(jobConfig.PresubmitsStatic[k][i].Name, "-images") {

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -281,6 +281,18 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 				DiscoverTests(r, ov, fromImage, branch.SkipE2EMatches, random),
 			)
 
+			if !ov.OnDemand {
+				options = append(options,
+					SkipIfOnlyChanged(),
+				)
+			} else {
+
+				options = append(options,
+					// onDemand jobs, should only run tests when needed / triggered manually
+					DisableAlwaysRunForTests(),
+				)
+			}
+
 			log.Println(r.RepositoryDirectory(), "Apply input options", len(options))
 
 			if err := applyOptions(&cfg, options...); err != nil {
@@ -334,6 +346,17 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 					DiscoverImages(r, branch.SkipDockerFilesMatches),
 					DependenciesForTestSteps(),
 				)
+
+				if !ov.OnDemand {
+					customBuildOptions = append(customBuildOptions,
+						SkipIfOnlyChanged(),
+					)
+				} else {
+					customBuildOptions = append(customBuildOptions,
+						// onDemand jobs, should only run tests when needed / triggered manually
+						DisableAlwaysRunForTests(),
+					)
+				}
 
 				log.Println(r.RepositoryDirectory(), "Apply input options", len(customBuildOptions))
 


### PR DESCRIPTION
We cannot change the `always_run` prow configs under ci-operator/jobs anymore (see [Slack](https://redhat-internal.slack.com/archives/CBN38N3MW/p1752996614456229), [Slack](https://redhat-internal.slack.com/archives/CBN38N3MW/p1752835745451229) and https://github.com/openshift/release/pull/67251/files). So moving the `skip_if_only_changed` configuration to the normal test setup in ci-operator/configs.
To update still set the `always_run` field on image builds, we are leveraging the exception mentioned [here](https://redhat-internal.slack.com/archives/CBN38N3MW/p1752996614456229), so not run all image builds on all PRs. This is a known hack for image builds and helps until we have support for `skip_if_only_changed` on image builds.

The diff of the testrun can be seen here for now https://github.com/openshift/release/pull/67356/files