### PR TITLE
re-enable prowgen for supported SO branches

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -53,6 +53,7 @@ config:
         onDemand: true
         version: "4.20"
       - useClusterPool: true
+        onDemand: true
         version: "4.19"
       - onDemand: true
         version: "4.13"
@@ -79,6 +80,7 @@ config:
         onDemand: true
         version: "4.20"
       - useClusterPool: true
+        onDemand: true
         version: "4.19"
       - onDemand: true
         version: "4.14"

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -52,11 +52,13 @@ config:
       - candidateRelease: true
         onDemand: true
         version: "4.20"
+        skipCron: true
       - useClusterPool: true
-        onDemand: true
         version: "4.19"
+        skipCron: true
       - onDemand: true
         version: "4.13"
+        skipCron: true
     release-1.36:
       konflux:
         enabled: true
@@ -79,11 +81,13 @@ config:
       - candidateRelease: true
         onDemand: true
         version: "4.20"
+        skipCron: true
       - useClusterPool: true
-        onDemand: true
         version: "4.19"
+        skipCron: true
       - onDemand: true
         version: "4.14"
+        skipCron: true
     release-1.37:
       konflux:
         enabled: true

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -30,7 +30,6 @@ config:
           enabled: true
           excludes:
           - .*ocp4.20-lp-interop.*
-        onDemand: true
         useClusterPool: true
         version: "4.19"
       - onDemand: true
@@ -54,12 +53,9 @@ config:
         onDemand: true
         version: "4.20"
       - useClusterPool: true
-        onDemand: true
         version: "4.19"
       - onDemand: true
         version: "4.13"
-      prowgen:
-        disabled: true
     release-1.36:
       konflux:
         enabled: true
@@ -86,8 +82,6 @@ config:
         version: "4.19"
       - onDemand: true
         version: "4.14"
-      prowgen:
-        disabled: true
     release-1.37:
       konflux:
         enabled: true

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -422,6 +422,7 @@ func AlwaysRunInjector() JobConfigInjector {
 						if !onDemandForOpenShift && strings.HasSuffix(jobConfig.PresubmitsStatic[k][i].Name, ocpVersion+"-images") {
 							// Image jobs which should "always" run, still use the SkipIfOnlyChanged field, but with a valid value
 							// to run only on meaningfully changes
+							jobConfig.PresubmitsStatic[k][i].RunIfChanged = ""
 							jobConfig.PresubmitsStatic[k][i].SkipIfOnlyChanged = prowSkipIfOnlyChangedFiles
 						} else {
 							// default to always_run = false for image jobs

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -270,7 +270,7 @@ func DependenciesForTestSteps() ReleaseBuildConfigurationOption {
 func SkipIfOnlyChanged() ReleaseBuildConfigurationOption {
 	return func(cfg *cioperatorapi.ReleaseBuildConfiguration) error {
 		for i, testConfig := range cfg.Tests {
-			if testConfig.Cron == nil && testConfig.Interval == nil && testConfig.MinimumInterval == nil {
+			if testConfig.Cron == nil && testConfig.Interval == nil && testConfig.MinimumInterval == nil && testConfig.RunIfChanged == "" {
 				cfg.Tests[i].SkipIfOnlyChanged = prowSkipIfOnlyChangedFiles
 			}
 		}


### PR DESCRIPTION
- re-enable prowgen for supported SO branches
- drop onDemand from our SO main on 4.19 (our target for continuous jobs)
- try to fix an issue that caused generation of both RunIfChanged and SkipIfOnlyChanged  (for soak and ui tests, which declare `runIfChanged` explicitly