### PR TITLE
Use RHEL 8 variant for Golang 1.24 builder image

### DIFF
--- a/pkg/dockerfilegen/generator.go
+++ b/pkg/dockerfilegen/generator.go
@@ -554,19 +554,18 @@ func writeRPMLockFile(rpmsLockTemplate fs.FS, rootDir string) error {
 }
 
 func builderImageForGoVersion(goVersion string) string {
-	builderImageFmt := "registry.ci.openshift.org/openshift/release:rhel-%d-release-golang-%s-openshift-%s"
+	builderImageFmt := "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-%s"
 
 	switch goVersion {
 	case "1.21":
-		return fmt.Sprintf(builderImageFmt, 8, goVersion, "4.16")
+		return fmt.Sprintf(builderImageFmt, goVersion, "4.16")
 	case "1.22":
-		return fmt.Sprintf(builderImageFmt, 8, goVersion, "4.17")
+		return fmt.Sprintf(builderImageFmt, goVersion, "4.17")
 	case "1.23":
-		return fmt.Sprintf(builderImageFmt, 8, goVersion, "4.19")
+		return fmt.Sprintf(builderImageFmt, goVersion, "4.19")
 	case "1.24":
-		// no 1.24 golang image will be built for rhel 8 and only no-fips exists for rhel 9 -- this is a temporary measure
 		fallthrough
 	default:
-		return fmt.Sprintf(builderImageFmt, 9, goVersion, "4.20")
+		return fmt.Sprintf(builderImageFmt, goVersion, "4.20")
 	}
 }


### PR DESCRIPTION
RHEL 8 variant for Golang 1.24 seems to be available nevertheless.

```
$ docker pull registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.24-openshift-4.20                                                                           
rhel-8-release-golang-1.24-openshift-4.20: Pulling from openshift/release
c7965aa70860: Downloading [==========>                                        ]  16.14MB/78.96MB
45b08c48498c: Downloading [>                                                  ]  1.081MB/697.1MB
8a9007f9a0f1: Downloading [>                                                  ]  540.7kB/110.9MB
1f3c9d2ed5a8: Waiting 
^C%                                                                                                                                                                                                                                                                                                                                                           

$ docker pull brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.24                                                                                                                                                                                                                                                            
rhel_8_golang_1.24: Pulling from rh-osbs/openshift-golang-builder
c7965aa70860: Pulling fs layer 
e69c4d9b35de: Pulling fs layer 
^C%   
```