### PR TITLE
Use Golang 1.24 for SO >= 1.38 (and components >= 1.18) in Konflux

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -7,7 +7,7 @@ config:
         - .*rosa.*
         imageOverrides:
         - name: GO_BUILDER
-          pullSpec: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.23
+          pullSpec: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.24
         - name: GO_RUNTIME
           pullSpec: registry.access.redhat.com/ubi8/ubi-minimal
         - name: JAVA_BUILDER


### PR DESCRIPTION
Use Golang 1.24 RHEL 8 for SO >= 1.38 (and thus components >= 1.18).

#764 is to have the same in Prow