### PR TITLE
Checkout latest changes from main branch in generate-ci workflow

### DIFF
--- a/.github/workflows/release-generate-ci.yaml
+++ b/.github/workflows/release-generate-ci.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/backstage-plugins
+          ref: main
           repository: openshift-knative/backstage-plugins
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -32,6 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/client
+          ref: main
           repository: openshift-knative/client
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -39,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-hyperfoil-benchmark
+          ref: main
           repository: openshift-knative/eventing-hyperfoil-benchmark
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -46,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-integrations
+          ref: main
           repository: openshift-knative/eventing-integrations
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -53,6 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-istio
+          ref: main
           repository: openshift-knative/eventing-istio
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -60,6 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/eventing-kafka-broker
+          ref: main
           repository: openshift-knative/eventing-kafka-broker
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -67,6 +73,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/eventing
+          ref: main
           repository: openshift-knative/eventing
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -74,6 +81,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/kn-plugin-event
+          ref: main
           repository: openshift-knative/kn-plugin-event
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -81,6 +89,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/kn-plugin-func
+          ref: main
           repository: openshift-knative/kn-plugin-func
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -88,6 +97,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/serverless-operator
+          ref: main
           repository: openshift-knative/serverless-operator
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -95,6 +105,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/net-istio
+          ref: main
           repository: openshift-knative/net-istio
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -102,6 +113,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/net-kourier
+          ref: main
           repository: openshift-knative/net-kourier
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref_name == 'main' }}
@@ -109,6 +121,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./src/github.com/openshift-knative/hack/openshift-knative/serving
+          ref: main
           repository: openshift-knative/serving
           token: ${{ secrets.SERVERLESS_QE_ROBOT }}
       - name: Checkout openshift-knative/hack

--- a/pkg/action/update_action.go
+++ b/pkg/action/update_action.go
@@ -107,6 +107,7 @@ func updateAction(ctx context.Context, inConfig *prowgen.Config) ([]interface{},
 				"uses": "actions/checkout@v4",
 				"with": map[string]interface{}{
 					"repository": r.RepositoryDirectory(),
+					"ref":        "main",
 					"token":      "${{ secrets.SERVERLESS_QE_ROBOT }}",
 					"path":       fmt.Sprintf("./src/github.com/openshift-knative/hack/%s", r.RepositoryDirectory()),
 				},


### PR DESCRIPTION
We are seeing some PRs from the generate-ci workflow, which are not based on the latest changes on the target branch. This results in some duplicate PRs. 

For example:
* Initial PR to update OWNERS file: https://github.com/openshift-knative/eventing-istio/pull/574/files
* Duplicate PR to do same changes: https://github.com/openshift-knative/eventing-istio/pull/586/commits/b05764967609ee69c0485249b5f3dfaf5b76190f

I am not fully sure, if this fixes it, but according to the [docs](https://github.com/actions/checkout), specifying the `ref`, will make sure to pull the latest changes from there.