### PR TITLE
Adds the `GOFLAGS='-mod=mod'` build var on vendorless projects

### DIFF
--- a/pkg/dockerfilegen/dockerfile-templates/Default.dockerfile.tmpl
+++ b/pkg/dockerfilegen/dockerfile-templates/Default.dockerfile.tmpl
@@ -7,7 +7,7 @@ FROM $GO_BUILDER as builder
 WORKDIR /workspace
 COPY . .
 {{ range $c := .build_env_vars}}
-{{ $c }}
+ENV {{ $c }}
 {{- end }}
 
 RUN go build -tags strictfipsruntime -o /usr/bin/main ./{{.main}}

--- a/pkg/dockerfilegen/params.go
+++ b/pkg/dockerfilegen/params.go
@@ -72,7 +72,7 @@ func DefaultParams(wd string) Params {
 // DefaultBuildEnvVars is default set of FIPS flags to be used per builds
 func DefaultBuildEnvVars() []string {
 	return []string{
-		"ENV CGO_ENABLED=1",
-		"ENV GOEXPERIMENT=strictfipsruntime",
+		"CGO_ENABLED=1",
+		"GOEXPERIMENT=strictfipsruntime",
 	}
 }

--- a/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
+++ b/pkg/project/testoutput/openshift/ci-operator/knative-images/discover/Dockerfile
@@ -9,6 +9,7 @@ COPY . .
 
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS='-mod=mod'
 
 RUN go build -tags strictfipsruntime -o /usr/bin/main ./cmd/discover
 


### PR DESCRIPTION
Vendorless projects are failing, because GOFLAGS is not unset and thus points to -mod=vendor. This leds to issues like in backstage [here](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/ocp-serverless-tenant/applications/serverless-operator-138/pipelineruns/kn-backstage-plugins-eventmesh-118-on-pull-request-82q2l/) or client.
So we add the `GOFLAGS='-mod=mod'` build env var when no `vendor/` folder exists