### PR TITLE
Update kn plugins owners file

### DIFF
--- a/config/kn-plugin-event.yaml
+++ b/config/kn-plugin-event.yaml
@@ -82,6 +82,7 @@ repositories:
       - dsimansk
       - cardil
       - creydr
+      - Kaustubh-pande
       - maschmid
       - openshift-cherrypick-robot
       - rudyredhat1

--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -96,7 +96,9 @@ repositories:
     approvers:
       - creydr
       - dsimansk
+      - Kaustubh-pande
       - lkingland
+      - maschmid
       - matejvasek
       - gauron99
       - rudyredhat1


### PR DESCRIPTION
Adding @maschmid and @Kaustubh-pande to kn's plugin repos to make sure we have a critical approvers to move either component's PR or CI configs. (similarly to Serving components in previous PR)

/cc @creydr @maschmid 