### PR TITLE
Bump to Golang 1.24 as default in shared setup-go action

### DIFF
--- a/actions/setup-go/action.yaml
+++ b/actions/setup-go/action.yaml
@@ -15,4 +15,4 @@ runs:
     - name: setup go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ inputs.go-version || '1.23' }}
+        go-version: ${{ inputs.go-version || '1.24' }}


### PR DESCRIPTION
As per title