### PR TITLE
Update SkipIfOnlyChanged pattern to not include hack/lib dirs

### DIFF
--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -38,7 +38,7 @@ const (
 	// Phony targets in Makefile that should be skipped.
 	makefilePhonyTarget = ".PHONY"
 	// Files which do not require to run builds on Prow
-	prowSkipIfOnlyChangedFiles = "^.tekton/.*|^.konflux.*|^.github/.*|^rpms.lock.yaml$|^hack/.*|^OWNERS.*|.*\\.md"
+	prowSkipIfOnlyChangedFiles = "^.tekton/.*|^.konflux.*|^.github/.*|^rpms.lock.yaml$|^hack/(?!lib/).*|^OWNERS.*|.*\\.md"
 )
 
 // Makefile targets can be defined in multiple ways:


### PR DESCRIPTION
Ignoring changes on the hack dir does not make sense always. For example in SO, we have some Kafka config in hack/lib folder. Therefor we update the pattern to exclude hack, but not hack/lib

Slack: https://redhat-internal.slack.com/archives/CD87JDUB0/p1755005331665209