### PR TITLE
Tweak dependabot for istio.io/* to only update patch level version

### DIFF
--- a/pkg/dependabotgen/dependabotgen.go
+++ b/pkg/dependabotgen/dependabotgen.go
@@ -101,15 +101,16 @@ func (cfg *DependabotConfig) WithGo(branch string) {
 				DependencyName: "sigs.k8s.io/controller-runtime",
 				UpdateTypes:    []string{"version-update:semver-major", "version-update:semver-minor"},
 			},
+			{
+				DependencyName: "istio.io/*",
+				UpdateTypes:    []string{"version-update:semver-major", "version-update:semver-minor"},
+			},
 		},
 		Groups: map[string]Group{
 			"patch": {
 				UpdateTypes: []string{"patch"},
 				Patterns:    []string{"*"},
 				AppliesTo:   "version-updates",
-				ExcludePatterns: []string{
-					"istio.io/*",
-				},
 			},
 			"minor": {
 				UpdateTypes: []string{"minor"},


### PR DESCRIPTION
Without this config the istio client version moves to latest `.minor` that's a lot newer and diverge from upstream originally used version a lot. 

Based on test PRs:
https://github.com/openshift-knative/net-istio/pull/257
https://github.com/openshift-knative/net-istio/pull/265 
https://github.com/openshift-knative/net-istio/pull/268

/cc @creydr @Kaustubh-pande 