### PR TITLE
[S-O] sync vsphere cron with openshift/release so we don't override their config

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -376,7 +376,7 @@ repositories:
           tag: upi-installer
       tests:
       - as: e2e-vsphere-continuous
-        cron: 35 17 * * 0
+        cron: 26 4 * * 3
         steps:
           cluster_profile: vsphere-elastic
           test:


### PR DESCRIPTION
The current value set by https://github.com/openshift/release/pull/75617 ... apparently generated by https://github.com/jcpowermac/vsphere-prow-job-management