### PR TITLE
Fix gcp cluster profile name

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -254,7 +254,7 @@ repositories:
       - as: e2e-gcp-continuous
         cron: 10 14 * * 6
         steps:
-          cluster_profile: gcp
+          cluster_profile: openshift-org-gcp
           test:
           - as: operator-e2e
             commands: GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka
@@ -354,7 +354,7 @@ repositories:
       - as: e2e-sno-continuous
         cron: 24 10 * * 0
         steps:
-          cluster_profile: gcp
+          cluster_profile: openshift-org-gcp
           test:
           - as: operator-e2e
             commands: HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka-no-tracing


### PR DESCRIPTION
Per generator error:
```
time="2026-04-13T16:49:04Z" level=error error="[failed to validate configuration openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__420-gcp.yaml: invalid configuration: tests[0]: invalid cluster profile \"gcp\", use the cluster profile set \"openshift-org-gcp\" instead, failed to validate configuration openshift-knative/serverless-operator/openshift-knative-serverless-operator-main__420-single-node.yaml: invalid configuration: tests[0]: invalid cluster profile \"gcp\", use the cluster profile set \"openshift-org-gcp\" instead]"
time="2026-04-13T16:49:04Z" level=fatal msg="error validating configuration files"

```

@maschmid @creydr 