### PR TITLE
increase size of the vsphere cluster to 3 nodes

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -382,6 +382,8 @@ repositories:
         cron: 26 4 * * 3
         steps:
           cluster_profile: vsphere-elastic
+          env:
+            COMPUTE_NODE_REPLICAS: "3"
           test:
           - as: operator-e2e
             commands: HA=false GOPATH=/tmp/go PATH=$PATH:/tmp/go/bin make test-e2e-with-kafka


### PR DESCRIPTION
We see EKB dispatchers not able to scale up due to insufficient resources on the cluster, e.g. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-serverless-operator-main-420-vsphere-e2e-vsphere-continuous/2041734414412550144

increasing the worker node count from the default 2 to 3 seems to help:

tested on https://github.com/openshift/release/pull/77540 