### PR TITLE
Refactor slack notification to use .prowgen config file

### DIFF
--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -52,9 +52,6 @@ repositories:
 - dockerfiles: {}
   e2e:
   - match: .*e2e-tests$
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: knative-backstage-plugins
   org: openshift-knative
   owners:

--- a/config/client.yaml
+++ b/config/client.yaml
@@ -69,7 +69,6 @@ repositories:
     matches:
     - .*release-next*
     - .*release-v1.1[0-4]*.yaml$
-    - .config.prowgen
   imagePrefix: knative-client
   org: openshift-knative
   owners:

--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -11,9 +11,6 @@ repositories:
   e2e:
   - match: test.*
     onDemand: true
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: knative-eventing-hyperfoil-benchmark
   org: openshift-knative
   owners:

--- a/config/eventing-integrations.yaml
+++ b/config/eventing-integrations.yaml
@@ -100,9 +100,6 @@ repositories:
   e2e:
   - match: .*e2e$
   - match: .*reconciler.*
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: knative-eventing-integrations
   org: openshift-knative
   owners:

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -55,9 +55,6 @@ repositories:
 - dockerfiles: {}
   e2e:
   - match: .*e2e-tests$
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: knative-eventing-istio
   org: openshift-knative
   owners:

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -83,9 +83,6 @@ repositories:
   - match: .*e2e$
   - match: .*reconciler.*
   - match: .*conformance.*
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: knative-eventing-kafka-broker
   org: openshift-knative
   owners:

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -65,9 +65,6 @@ repositories:
   - match: .*e2e$
   - match: .*reconciler.*
   - match: .*conformance.*
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: knative-eventing
   org: openshift-knative
   owners:

--- a/config/kn-plugin-event.yaml
+++ b/config/kn-plugin-event.yaml
@@ -52,7 +52,6 @@ repositories:
     matches:
     - release-1\.13
     - release-1\.14
-    - .config.prowgen
   imageNameOverrides:
     kn-event-sender: sender
   imagePrefix: kn-plugin-event

--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -48,9 +48,6 @@ config:
       promotion: {}
 repositories:
 - dockerfiles: {}
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: knative-kn-plugin-func
   org: openshift-knative
   owners:

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -601,7 +601,6 @@ repositories:
   ignoreConfigs:
     matches:
     - .*main.yaml$
-    - .config.prowgen
   imageNameOverrides:
     serverless-operator: bundle
     serverless-operator-index: index

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -50,9 +50,6 @@ config:
       promotion: {}
 repositories:
 - dockerfiles: {}
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: net-istio
   org: openshift-knative
   owners:

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -50,9 +50,6 @@ config:
       promotion: {}
 repositories:
 - dockerfiles: {}
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imagePrefix: net-kourier
   org: openshift-knative
   owners:

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -93,9 +93,6 @@ repositories:
     - knative-serving-scale-from-zero
   - match: perf-tests$
     onDemand: true
-  ignoreConfigs:
-    matches:
-    - .config.prowgen
   imageNameOverrides:
     migrate: storage-version-migration
   imagePrefix: knative-serving

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/openshift-knative/hack/pkg/util"
 	"github.com/openshift/ci-tools/pkg/api/shardprowconfig"
+	ciconfig "github.com/openshift/ci-tools/pkg/config"
 	"sigs.k8s.io/yaml"
 
 	"github.com/coreos/go-semver/semver"
 	"golang.org/x/sync/errgroup"
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
-	prowconfig "sigs.k8s.io/prow/pkg/config"
 )
 
 // Config is the prowgen configuration file struct.
@@ -149,6 +149,11 @@ func Main() {
 					return err
 				}
 
+				prowgenCfg := NewProwgenConfig(repository, inConfig.Config, cfgs)
+				if err := SaveProwgenConfig(outConfig, repository, prowgenCfg); err != nil {
+					return err
+				}
+
 				return nil
 			})
 		}
@@ -164,12 +169,6 @@ func Main() {
 	if *build {
 		if err := RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
 			log.Fatalln("Failed to run openshift/release generator:", err)
-		}
-		if err := runJobConfigInjectors(inConfigs, openShiftRelease); err != nil {
-			log.Fatalln("Failed to inject Slack reporter", err)
-		}
-		if err := RunOpenShiftReleaseGenerator(ctx, openShiftRelease); err != nil {
-			log.Fatalln("Failed to run openshift/release generator after injecting Slack reporter", err)
 		}
 	}
 	if *push {
@@ -298,6 +297,85 @@ func SaveProwConfig(openShiftRelease Repository, repository Repository, config s
 	return os.WriteFile(outPath, out, os.ModePerm)
 }
 
+const slackReportTemplate = `{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano: {{end}}`
+
+func NewProwgenConfig(r Repository, cc CommonConfig, cfgs []ReleaseBuildConfiguration) *ciconfig.Prowgen {
+	if r.SlackChannel == "" {
+		return nil
+	}
+
+	jobNameSet := make(map[string]struct{})
+	for _, cfg := range cfgs {
+		for _, test := range cfg.Tests {
+			if test.Cron != nil {
+				jobNameSet[test.As] = struct{}{}
+			}
+		}
+	}
+
+	if len(jobNameSet) == 0 {
+		return nil
+	}
+
+	jobNames := make([]string, 0, len(jobNameSet))
+	for name := range jobNameSet {
+		jobNames = append(jobNames, name)
+	}
+	sort.Strings(jobNames)
+
+	variantSet := make(map[string]struct{})
+	for _, branch := range cc.Branches {
+		if branch.Prowgen != nil && branch.Prowgen.Disabled {
+			continue
+		}
+		for _, ov := range branch.OpenShiftVersions {
+			if ov.SkipCron || ov.CandidateRelease {
+				variant := strings.ReplaceAll(ov.Version, ".", "")
+				variantSet[variant] = struct{}{}
+			}
+		}
+	}
+
+	var excludedVariants []string
+	if len(variantSet) > 0 {
+		excludedVariants = make([]string, 0, len(variantSet))
+		for v := range variantSet {
+			excludedVariants = append(excludedVariants, v)
+		}
+		sort.Strings(excludedVariants)
+	}
+
+	return &ciconfig.Prowgen{
+		SlackReporterConfigs: []ciconfig.SlackReporterConfig{
+			{
+				Channel:           r.SlackChannel,
+				JobStatesToReport: []prowapi.ProwJobState{prowapi.SuccessState, prowapi.FailureState, prowapi.ErrorState},
+				ReportTemplate:    slackReportTemplate,
+				JobNames:          jobNames,
+				ExcludedVariants:  excludedVariants,
+			},
+		},
+	}
+}
+
+func SaveProwgenConfig(outConfig *string, r Repository, prowgenCfg *ciconfig.Prowgen) error {
+	if prowgenCfg == nil {
+		return nil
+	}
+
+	dir := filepath.Join(*outConfig, r.RepositoryDirectory())
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
+
+	out, err := yaml.Marshal(prowgenCfg)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, ciconfig.ProwgenFile), out, os.ModePerm)
+}
+
 func SaveReleaseBuildConfiguration(outConfig *string, cfg ReleaseBuildConfiguration) error {
 	dir := filepath.Join(*outConfig, filepath.Dir(cfg.Path))
 
@@ -339,130 +417,6 @@ func RunOpenShiftReleaseGenerator(ctx context.Context, openShiftRelease Reposito
 		return err
 	}
 	return nil
-}
-
-func runJobConfigInjectors(inConfigs []*Config, openShiftRelease Repository) error {
-	for _, inConfig := range inConfigs {
-		injectors := JobConfigInjectors{
-			slackInjector(),
-		}
-		if err := injectors.Inject(inConfig, openShiftRelease); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func slackInjector() JobConfigInjector {
-	return JobConfigInjector{
-		Type: Periodic,
-		Update: func(r *Repository, _ *Branch, _ string, jobConfig *prowconfig.JobConfig) error {
-			for i := range jobConfig.Periodics {
-				if !shouldIgnoreJob(r, jobConfig.Periodics[i].Name) {
-					jobConfig.Periodics[i].ReporterConfig = &prowapi.ReporterConfig{
-						Slack: &prowapi.SlackReporterConfig{
-							Channel: r.SlackChannel,
-							JobStatesToReport: []prowapi.ProwJobState{
-								prowapi.SuccessState,
-								prowapi.FailureState,
-								prowapi.ErrorState,
-							},
-							ReportTemplate: `{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano: {{end}}`,
-						},
-					}
-				}
-			}
-			return nil
-		},
-	}
-}
-
-func shouldIgnoreJob(r *Repository, jobName string) bool {
-	for _, r := range util.MustToRegexp(r.IgnoreConfigs.Matches) {
-		if r.MatchString(jobName) {
-			return true
-		}
-	}
-	return false
-}
-
-type JobConfigType string
-
-const (
-	Periodic   JobConfigType = "periodics"
-	PreSubmit  JobConfigType = "presubmits"
-	PostSubmit JobConfigType = "postsubmits"
-)
-
-type JobConfigInjectors []JobConfigInjector
-
-func (jcis JobConfigInjectors) Inject(inConfig *Config, openShiftRelease Repository) error {
-	for _, jci := range jcis {
-		for branchName, branch := range inConfig.Config.Branches {
-			for _, r := range inConfig.Repositories {
-				generatedOutputDir := "ci-operator/jobs"
-				dir := filepath.Join(openShiftRelease.RepositoryDirectory(), generatedOutputDir, r.RepositoryDirectory())
-				glob := filepath.Join(dir, "*"+branchName+"*"+string(jci.Type)+"*")
-				if err := copyOwnersFileIfNotPresent(dir); err != nil {
-					return err
-				}
-				matches, err := filepath.Glob(glob)
-				if err != nil {
-					return err
-				}
-				for _, match := range matches {
-					jobConfig, err := GetJobConfig(match)
-					if err != nil {
-						return err
-					}
-					if err := jci.Update(&r, &branch, branchName, jobConfig); err != nil {
-						return err
-					}
-					if err := SaveJobConfig(match, jobConfig); err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-type JobConfigInjector struct {
-	Type   JobConfigType
-	Update func(r *Repository, b *Branch, branchName string, jobConfig *prowconfig.JobConfig) error
-}
-
-func SaveJobConfig(match string, jobConfig *prowconfig.JobConfig) error {
-	y, err := yaml.Marshal(jobConfig)
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(match, y, os.ModePerm); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func GetJobConfig(match string) (*prowconfig.JobConfig, error) {
-	// Going directly from YAML raw input produces unexpected configs (due to missing YAML tags),
-	// so we convert YAML to JSON and unmarshal the struct from the JSON object.
-	y, err := os.ReadFile(match)
-	if err != nil {
-		return nil, err
-	}
-	j, err := yaml.YAMLToJSON(y)
-	if err != nil {
-		return nil, err
-	}
-
-	jobConfig := &prowconfig.JobConfig{}
-	if err := json.Unmarshal(j, jobConfig); err != nil {
-		return nil, err
-	}
-	return jobConfig, nil
 }
 
 // InitializeOpenShiftReleaseRepository clones openshift/release and clean up existing jobs

--- a/pkg/prowgen/prowgen_prowgenconfig_test.go
+++ b/pkg/prowgen/prowgen_prowgenconfig_test.go
@@ -1,0 +1,246 @@
+package prowgen
+
+import (
+	"os"
+	"testing"
+
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	ciconfig "github.com/openshift/ci-tools/pkg/config"
+	"sigs.k8s.io/yaml"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/pointer"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+)
+
+func TestNewProwgenConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     Repository
+		cc       CommonConfig
+		cfgs     []ReleaseBuildConfiguration
+		expected *ciconfig.Prowgen
+	}{
+		{
+			name: "generates config with periodic tests and excluded variants",
+			repo: Repository{
+				SlackChannel: "#knative-eventing-ci",
+			},
+			cc: CommonConfig{
+				Branches: map[string]Branch{
+					"release-next": {
+						OpenShiftVersions: []OpenShift{
+							{Version: "4.21", CandidateRelease: true, SkipCron: true},
+							{Version: "4.20"},
+							{Version: "4.14", OnDemand: true},
+						},
+					},
+				},
+			},
+			cfgs: []ReleaseBuildConfiguration{
+				{
+					ReleaseBuildConfiguration: cioperatorapi.ReleaseBuildConfiguration{
+						Tests: []cioperatorapi.TestStepConfiguration{
+							{As: "test-e2e"},
+							{As: "test-e2e-c", Cron: pointer.String("0 2 * * 2,6")},
+							{As: "test-conformance-c", Cron: pointer.String("0 3 * * 2,6")},
+						},
+					},
+				},
+			},
+			expected: &ciconfig.Prowgen{
+				SlackReporterConfigs: []ciconfig.SlackReporterConfig{
+					{
+						Channel:           "#knative-eventing-ci",
+						JobStatesToReport: []prowv1.ProwJobState{prowv1.SuccessState, prowv1.FailureState, prowv1.ErrorState},
+						ReportTemplate:    slackReportTemplate,
+						JobNames:          []string{"test-conformance-c", "test-e2e-c"},
+						ExcludedVariants:  []string{"421"},
+					},
+				},
+			},
+		},
+		{
+			name: "returns nil when SlackChannel is empty",
+			repo: Repository{},
+			cc:   CommonConfig{},
+			cfgs: []ReleaseBuildConfiguration{
+				{
+					ReleaseBuildConfiguration: cioperatorapi.ReleaseBuildConfiguration{
+						Tests: []cioperatorapi.TestStepConfiguration{
+							{As: "test-e2e-c", Cron: pointer.String("0 2 * * 2,6")},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "returns nil when no periodic tests exist",
+			repo: Repository{
+				SlackChannel: "#test-channel",
+			},
+			cc: CommonConfig{},
+			cfgs: []ReleaseBuildConfiguration{
+				{
+					ReleaseBuildConfiguration: cioperatorapi.ReleaseBuildConfiguration{
+						Tests: []cioperatorapi.TestStepConfiguration{
+							{As: "test-e2e"},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "deduplicates job names across configs",
+			repo: Repository{
+				SlackChannel: "#test-channel",
+			},
+			cc: CommonConfig{
+				Branches: map[string]Branch{
+					"release-next": {
+						OpenShiftVersions: []OpenShift{
+							{Version: "4.20"},
+						},
+					},
+				},
+			},
+			cfgs: []ReleaseBuildConfiguration{
+				{
+					ReleaseBuildConfiguration: cioperatorapi.ReleaseBuildConfiguration{
+						Tests: []cioperatorapi.TestStepConfiguration{
+							{As: "test-e2e-c", Cron: pointer.String("0 2 * * 2,6")},
+						},
+					},
+				},
+				{
+					ReleaseBuildConfiguration: cioperatorapi.ReleaseBuildConfiguration{
+						Tests: []cioperatorapi.TestStepConfiguration{
+							{As: "test-e2e-c", Cron: pointer.String("0 3 * * 2,6")},
+						},
+					},
+				},
+			},
+			expected: &ciconfig.Prowgen{
+				SlackReporterConfigs: []ciconfig.SlackReporterConfig{
+					{
+						Channel:           "#test-channel",
+						JobStatesToReport: []prowv1.ProwJobState{prowv1.SuccessState, prowv1.FailureState, prowv1.ErrorState},
+						ReportTemplate:    slackReportTemplate,
+						JobNames:          []string{"test-e2e-c"},
+					},
+				},
+			},
+		},
+		{
+			name: "skips disabled prowgen branches for excluded_variants",
+			repo: Repository{
+				SlackChannel: "#test-channel",
+			},
+			cc: CommonConfig{
+				Branches: map[string]Branch{
+					"release-next": {
+						OpenShiftVersions: []OpenShift{
+							{Version: "4.20"},
+						},
+					},
+					"disabled-branch": {
+						Prowgen: &Prowgen{Disabled: true},
+						OpenShiftVersions: []OpenShift{
+							{Version: "4.19", SkipCron: true},
+						},
+					},
+				},
+			},
+			cfgs: []ReleaseBuildConfiguration{
+				{
+					ReleaseBuildConfiguration: cioperatorapi.ReleaseBuildConfiguration{
+						Tests: []cioperatorapi.TestStepConfiguration{
+							{As: "test-e2e-c", Cron: pointer.String("0 2 * * 2,6")},
+						},
+					},
+				},
+			},
+			expected: &ciconfig.Prowgen{
+				SlackReporterConfigs: []ciconfig.SlackReporterConfig{
+					{
+						Channel:           "#test-channel",
+						JobStatesToReport: []prowv1.ProwJobState{prowv1.SuccessState, prowv1.FailureState, prowv1.ErrorState},
+						ReportTemplate:    slackReportTemplate,
+						JobNames:          []string{"test-e2e-c"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewProwgenConfig(tt.repo, tt.cc, tt.cfgs)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("NewProwgenConfig() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSaveProwgenConfig(t *testing.T) {
+	t.Run("writes correct YAML", func(t *testing.T) {
+		dir := t.TempDir()
+		outConfig := dir
+		r := Repository{
+			Org:  "openshift-knative",
+			Repo: "eventing",
+		}
+		cfg := &ciconfig.Prowgen{
+			SlackReporterConfigs: []ciconfig.SlackReporterConfig{
+				{
+					Channel:           "#knative-eventing-ci",
+					JobStatesToReport: []prowv1.ProwJobState{prowv1.SuccessState, prowv1.FailureState, prowv1.ErrorState},
+					ReportTemplate:    slackReportTemplate,
+					JobNames:          []string{"test-conformance-c", "test-e2e-c"},
+					ExcludedVariants:  []string{"421"},
+				},
+			},
+		}
+
+		if err := SaveProwgenConfig(&outConfig, r, cfg); err != nil {
+			t.Fatalf("SaveProwgenConfig() error: %v", err)
+		}
+
+		filePath := dir + "/openshift-knative/eventing/.config.prowgen"
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatalf("failed to read .config.prowgen: %v", err)
+		}
+
+		// Unmarshal back and verify structurally
+		var got ciconfig.Prowgen
+		if err := yaml.Unmarshal(data, &got); err != nil {
+			t.Fatalf("failed to unmarshal .config.prowgen: %v", err)
+		}
+
+		if diff := cmp.Diff(*cfg, got); diff != "" {
+			t.Errorf("SaveProwgenConfig() roundtrip mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("skips writing when config is nil", func(t *testing.T) {
+		dir := t.TempDir()
+		outConfig := dir
+		r := Repository{
+			Org:  "openshift-knative",
+			Repo: "eventing",
+		}
+
+		if err := SaveProwgenConfig(&outConfig, r, nil); err != nil {
+			t.Fatalf("SaveProwgenConfig() error: %v", err)
+		}
+
+		filePath := dir + "/openshift-knative/eventing/.config.prowgen"
+		if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+			t.Errorf("expected .config.prowgen to not exist, but it does")
+		}
+	})
+}


### PR DESCRIPTION
Changes: 
 - Refactor slack notification away from job injector to .prowgen file
   - `.prowgen` file will be [refactored](https://github.com/openshift/ci-tools/pull/5012) into `ReleaseBuildConfiguration` struct, but from our point of view it will be straight-forward refactor nesting the structs together 
   - Current set of changes removes decorator pattern and eliminates double exec of `make jobs` on the openshift/release repo 
     - as a result generator pipeline run should be a bit quicker as a result 🤞  

Preview of changes: https://github.com/openshift/release/pull/77640

/cc @maschmid @creydr @Kaustubh-pande 