### PR TITLE
update OCP versions for SO 1.37 and 1.38

### DIFF
--- a/config/backstage-plugins.yaml
+++ b/config/backstage-plugins.yaml
@@ -29,9 +29,9 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         version: "4.14"
       promotion: {}
@@ -42,11 +42,11 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
 repositories:
 - dockerfiles: {}

--- a/config/client.yaml
+++ b/config/client.yaml
@@ -36,10 +36,10 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - skipCron: true
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       promotion: {}
     release-v1.21:
       konflux:
@@ -51,10 +51,10 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - skipCron: true
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       promotion: {}
 repositories:
 - canonicalGoRepository: github.com/knative/client

--- a/config/eventing-hyperfoil-benchmark.yaml
+++ b/config/eventing-hyperfoil-benchmark.yaml
@@ -4,7 +4,7 @@ config:
       dependabotEnabled: false
       openShiftVersions:
       - skipCron: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
 repositories:
 - dockerfiles: {}

--- a/config/eventing-integrations.yaml
+++ b/config/eventing-integrations.yaml
@@ -63,9 +63,9 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         version: "4.14"
       promotion: {}
@@ -87,11 +87,11 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
       skipDockerFilesMatches:
       - .*hermetic.*

--- a/config/eventing-istio.yaml
+++ b/config/eventing-istio.yaml
@@ -36,9 +36,9 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         version: "4.14"
       promotion: {}
@@ -47,9 +47,9 @@ config:
         enabled: true
       openShiftVersions:
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
 repositories:
 - dockerfiles: {}

--- a/config/eventing-kafka-broker.yaml
+++ b/config/eventing-kafka-broker.yaml
@@ -55,9 +55,9 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         version: "4.14"
       promotion: {}
@@ -70,10 +70,14 @@ config:
         - .*eventing-kafka-broker-receiver
         - .*eventing-kafka-broker-dispatcher
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
       skipDockerFilesMatches:
       - .*hermetic.*

--- a/config/eventing.yaml
+++ b/config/eventing.yaml
@@ -40,9 +40,9 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         version: "4.14"
       promotion: {}
@@ -53,11 +53,11 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
 repositories:
 - dockerfiles: {}

--- a/config/kn-plugin-event.yaml
+++ b/config/kn-plugin-event.yaml
@@ -25,10 +25,10 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - skipCron: true
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       promotion: {}
     release-1.21:
       konflux:
@@ -36,13 +36,13 @@ config:
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       promotion: {}
     release-next:
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       promotion: {}
 repositories:
 - dockerfiles: {}

--- a/config/kn-plugin-func.yaml
+++ b/config/kn-plugin-func.yaml
@@ -33,10 +33,10 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - skipCron: true
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       promotion: {}
     release-v1.21:
       konflux:
@@ -44,7 +44,7 @@ config:
       openShiftVersions:
       - skipCron: true
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       promotion: {}
 repositories:
 - dockerfiles: {}

--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -24,15 +24,15 @@ config:
       openShiftVersions:
       - candidateRelease: true
         onDemand: true
-        version: "4.21"
+        version: "4.22"
       - customConfigs:
           enabled: true
           excludes:
           - .*ocp-4.22-lp-interop.*
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
     release-1.35:
       golangVersion: "1.25"
@@ -123,15 +123,12 @@ config:
           - .*ocp-4.22-lp-interop.*
         onDemand: true
         version: "4.22"
-      - candidateRelease: true
-        onDemand: true
-        version: "4.21"
       - skipCron: true
         useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         skipCron: true
-        version: "4.14"
+        version: "4.16"
       promotion:
         template: release-1.37.1
     release-1.38:
@@ -158,17 +155,17 @@ config:
       openShiftVersions:
       - candidateRelease: true
         onDemand: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
       prowgen:
         disabled: true
 repositories:
 - customConfigs:
-  - name: 420-aws-ovn
+  - name: 421-aws-ovn
     releaseBuildConfiguration:
       tests:
       - as: e2e-aws-ovn-continuous
@@ -208,7 +205,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: 420-azure
+  - name: 421-azure
     releaseBuildConfiguration:
       tests:
       - as: e2e-azure-continuous
@@ -248,7 +245,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: 420-gcp
+  - name: 421-gcp
     releaseBuildConfiguration:
       tests:
       - as: e2e-gcp-continuous
@@ -288,7 +285,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: 420-hypershift
+  - name: 421-hypershift
     releaseBuildConfiguration:
       base_images:
         hypershift-operator:
@@ -296,14 +293,14 @@ repositories:
           namespace: hypershift
           tag: latest
         upi-installer:
-          name: "4.20"
+          name: "4.21"
           namespace: ocp
           tag: upi-installer
       releases:
         latest:
           integration:
             include_built_images: true
-            name: "4.20"
+            name: "4.21"
             namespace: ocp
       tests:
       - as: e2e-hypershift-continuous
@@ -348,7 +345,7 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: 420-single-node
+  - name: 421-single-node
     releaseBuildConfiguration:
       tests:
       - as: e2e-sno-continuous
@@ -370,11 +367,11 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: 420-vsphere
+  - name: 421-vsphere
     releaseBuildConfiguration:
       base_images:
         upi-installer:
-          name: "4.20"
+          name: "4.21"
           namespace: ocp
           tag: upi-installer
       tests:
@@ -523,14 +520,14 @@ repositories:
         branch: ""
         org: ""
         repo: ""
-  - name: 4.20-techpreview
+  - name: 4.21-techpreview
     releaseBuildConfiguration:
       releases:
         latest:
           candidate:
             product: ocp
             stream: nightly
-            version: "4.20"
+            version: "4.21"
       tests:
       - as: olmv1-operator-e2e
         cron: 25 3 * * 6

--- a/config/serving-net-istio.yaml
+++ b/config/serving-net-istio.yaml
@@ -29,9 +29,9 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         version: "4.14"
       promotion: {}
@@ -42,11 +42,11 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
 repositories:
 - dockerfiles: {}

--- a/config/serving-net-kourier.yaml
+++ b/config/serving-net-kourier.yaml
@@ -29,9 +29,9 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         version: "4.14"
       promotion: {}
@@ -42,11 +42,11 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
 repositories:
 - dockerfiles: {}

--- a/config/serving.yaml
+++ b/config/serving.yaml
@@ -41,9 +41,9 @@ config:
       - candidateRelease: true
         onDemand: true
         skipCron: true
-        version: "4.21"
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
         version: "4.14"
       promotion: {}
@@ -56,10 +56,14 @@ config:
       konflux:
         enabled: true
       openShiftVersions:
+      - candidateRelease: true
+        onDemand: true
+        skipCron: true
+        version: "4.22"
       - useClusterPool: true
-        version: "4.20"
+        version: "4.21"
       - onDemand: true
-        version: "4.14"
+        version: "4.16"
       promotion: {}
       skipDockerFilesMatches:
       - openshift/ci-operator/knative-perf-images.*


### PR DESCRIPTION
Only touching the SO 1.37/1.38 (knative 1.17/1.21) configurations.

Make 4.22 the candidate OCP, use 4.21 as the default.
For SO 1.38, update the older OCP version from 4.14 to 4.16
Add 4.22 candidate on-demand jobs where 1.17 had them, but 1.21 didn't .