### PR TITLE
Fix version fallback for patch SO versions

### DIFF
--- a/pkg/dockerfilegen/generator.go
+++ b/pkg/dockerfilegen/generator.go
@@ -482,8 +482,9 @@ func goVersionFromConfig(metadata *project.Metadata) (*string, error) {
 			soBranch = soversion.BranchName(soVersion)
 		}
 	} else if metadata.Project.Version != "" {
-		majorMinor := strings.TrimSuffix(metadata.Project.Version, ".0")
-		soBranch = fmt.Sprintf("release-v%s", majorMinor)
+		if v, err := semver.NewVersion(metadata.Project.Version); err == nil {
+			soBranch = soversion.BranchName(v)
+		}
 	}
 
 	if soBranch != "" {


### PR DESCRIPTION
There was a bug related to `release-1.37` not being update to latest golang version. 


/cc @maschmid 