### PR TITLE
refactor: extract goVersionFromConfig into testable helpers

### DIFF
--- a/pkg/dockerfilegen/generator.go
+++ b/pkg/dockerfilegen/generator.go
@@ -168,7 +168,7 @@ func generateDockerfile(params Params, mainPackagesPaths sets.Set[string]) error
 	}
 
 	// get target go version
-	goVersion, err := goVersionFromConfig(metadata)
+	goVersion, err := goVersionFromConfig(config.Configs, metadata)
 	if err != nil {
 		return fmt.Errorf("failed to get Go version from config: %w", err)
 	}
@@ -417,96 +417,6 @@ func generateDockerfile(params Params, mainPackagesPaths sets.Set[string]) error
 	}
 	log.Println("Images mapping file written:", immapPath)
 	return nil
-}
-
-// goVersionFromConfig returns the target go version for the project.
-// First it checks if a dedicated go version is defined for the repositories branch in the config.
-// If no repo-branch specific config is set, it uses the one from the coresponding SO branch config.
-// If SO does not have a default go version in it's config neither it returns nil to let the caller
-// decide.
-func goVersionFromConfig(metadata *project.Metadata) (*string, error) {
-	// get repo config
-	if imagePrefix := metadata.Project.ImagePrefix; imagePrefix != "" {
-
-		// this is a component repo
-		branch := ""
-		if metadata.Project.Tag == "knative-nightly" {
-			branch = "release-next"
-		} else {
-			branch = fmt.Sprintf("release-%s", strings.TrimPrefix(metadata.Project.Tag, "knative-"))
-		}
-
-		configFiles, err := fs.ReadDir(config.Configs, ".")
-		if err != nil {
-			return nil, fmt.Errorf("failed to read config directory: %w", err)
-		}
-
-		for _, configFile := range configFiles {
-			if configFile.IsDir() {
-				continue
-			}
-
-			content, err := fs.ReadFile(config.Configs, configFile.Name())
-			if err != nil {
-				return nil, fmt.Errorf("failed to load config from %s: %w", configFile.Name(), err)
-			}
-
-			cfg, err := prowgen.UnmarshalConfig(content)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse config from %s: %w", configFile.Name(), err)
-			}
-
-			for _, repo := range cfg.Repositories {
-				if repo.ImagePrefix == imagePrefix {
-					// this is the repo we are generating the dockerfile for
-
-					if branchConfig, ok := cfg.Config.Branches[branch]; ok {
-						if branchConfig.GolangVersion != nil && *branchConfig.GolangVersion != "" {
-							return branchConfig.GolangVersion, nil
-						}
-						// we didn't find a repo-branch specific default --> fall back to SO default
-					}
-				}
-			}
-		}
-	}
-
-	// check SO config
-	soBranch := ""
-	if metadata.Project.Tag != "" {
-		// this is a component repo (-> we falled through, as we didn't find a repo-branch specific default
-		if metadata.Project.Tag == "knative-nightly" || metadata.Project.Tag == "main" {
-			soBranch = "main"
-		} else {
-			soVersion := soversion.FromUpstreamVersion(strings.TrimPrefix(metadata.Project.Tag, "knative-"))
-			soBranch = soversion.BranchName(soVersion)
-		}
-	} else if metadata.Project.Version != "" {
-		if v, err := semver.NewVersion(metadata.Project.Version); err == nil {
-			soBranch = soversion.BranchName(v)
-		}
-	}
-
-	if soBranch != "" {
-		soYaml, err := config.Configs.ReadFile("serverless-operator.yaml")
-		if err != nil {
-			return nil, fmt.Errorf("failed to load config for serverless-operator: %w", err)
-		}
-
-		soConfig, err := prowgen.UnmarshalConfig(soYaml)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse config for serverless-operator: %w", err)
-		}
-
-		if cfg, ok := soConfig.Config.Branches[soBranch]; ok {
-			if cfg.GolangVersion != nil && *cfg.GolangVersion != "" {
-				return cfg.GolangVersion, nil
-			}
-			// we didn't find a repo-branch specific default --> fall back to go.mod version
-		}
-	}
-
-	return nil, nil
 }
 
 func hasVendorFolder(dir string) (bool, error) {

--- a/pkg/dockerfilegen/goversion.go
+++ b/pkg/dockerfilegen/goversion.go
@@ -1,0 +1,117 @@
+package dockerfilegen
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/openshift-knative/hack/pkg/project"
+	"github.com/openshift-knative/hack/pkg/prowgen"
+	"github.com/openshift-knative/hack/pkg/soversion"
+)
+
+func componentBranchForTag(tag string) string {
+	if tag == "knative-nightly" {
+		return "release-next"
+	}
+	return fmt.Sprintf("release-%s", strings.TrimPrefix(tag, "knative-"))
+}
+
+func soBranchForMetadata(metadata *project.Metadata) string {
+	if metadata.Project.Tag != "" {
+		if metadata.Project.Tag == "knative-nightly" || metadata.Project.Tag == "main" {
+			return "main"
+		}
+		upstream := strings.TrimPrefix(metadata.Project.Tag, "knative-")
+		return soversion.BranchName(soversion.FromUpstreamVersion(upstream))
+	}
+	if metadata.Project.Version != "" {
+		v, err := semver.NewVersion(metadata.Project.Version)
+		if err != nil {
+			return ""
+		}
+		return soversion.BranchName(v)
+	}
+	return ""
+}
+
+func hasImagePrefix(repos []prowgen.Repository, prefix string) bool {
+	for _, r := range repos {
+		if r.ImagePrefix == prefix {
+			return true
+		}
+	}
+	return false
+}
+
+func golangVersionFromRepoConfig(configs fs.FS, imagePrefix, branch string) (*string, error) {
+	configFiles, err := fs.ReadDir(configs, ".")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config directory: %w", err)
+	}
+	for _, configFile := range configFiles {
+		if configFile.IsDir() {
+			continue
+		}
+		content, err := fs.ReadFile(configs, configFile.Name())
+		if err != nil {
+			return nil, fmt.Errorf("failed to load config from %s: %w", configFile.Name(), err)
+		}
+		cfg, err := prowgen.UnmarshalConfig(content)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse config from %s: %w", configFile.Name(), err)
+		}
+		if !hasImagePrefix(cfg.Repositories, imagePrefix) {
+			continue
+		}
+		branchConfig, ok := cfg.Config.Branches[branch]
+		if !ok {
+			continue
+		}
+		if branchConfig.GolangVersion != nil && *branchConfig.GolangVersion != "" {
+			return branchConfig.GolangVersion, nil
+		}
+	}
+	return nil, nil
+}
+
+func golangVersionFromSOConfig(configs fs.FS, branch string) (*string, error) {
+	soYaml, err := fs.ReadFile(configs, "serverless-operator.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config for serverless-operator: %w", err)
+	}
+	soConfig, err := prowgen.UnmarshalConfig(soYaml)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config for serverless-operator: %w", err)
+	}
+	cfg, ok := soConfig.Config.Branches[branch]
+	if !ok {
+		return nil, nil
+	}
+	if cfg.GolangVersion != nil && *cfg.GolangVersion != "" {
+		return cfg.GolangVersion, nil
+	}
+	return nil, nil
+}
+
+// goVersionFromConfig returns the Go version for the project. It checks the
+// repo-branch config first, then falls back to the SO branch config, returning
+// nil if neither defines one.
+func goVersionFromConfig(configs fs.FS, metadata *project.Metadata) (*string, error) {
+	if imagePrefix := metadata.Project.ImagePrefix; imagePrefix != "" {
+		branch := componentBranchForTag(metadata.Project.Tag)
+		v, err := golangVersionFromRepoConfig(configs, imagePrefix, branch)
+		if err != nil {
+			return nil, err
+		}
+		if v != nil {
+			return v, nil
+		}
+	}
+	soBranch := soBranchForMetadata(metadata)
+	if soBranch == "" {
+		return nil, nil
+	}
+	return golangVersionFromSOConfig(configs, soBranch)
+}

--- a/pkg/dockerfilegen/goversion.go
+++ b/pkg/dockerfilegen/goversion.go
@@ -3,6 +3,8 @@ package dockerfilegen
 import (
 	"fmt"
 	"io/fs"
+	"log"
+	"slices"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
@@ -29,6 +31,7 @@ func soBranchForMetadata(metadata *project.Metadata) string {
 	if metadata.Project.Version != "" {
 		v, err := semver.NewVersion(metadata.Project.Version)
 		if err != nil {
+			log.Printf("WARNING: failed to parse S-O version %q to determine Go toolchain: %v", metadata.Project.Version, err)
 			return ""
 		}
 		return soversion.BranchName(v)
@@ -36,13 +39,8 @@ func soBranchForMetadata(metadata *project.Metadata) string {
 	return ""
 }
 
-func hasImagePrefix(repos []prowgen.Repository, prefix string) bool {
-	for _, r := range repos {
-		if r.ImagePrefix == prefix {
-			return true
-		}
-	}
-	return false
+func isGoVersionSet(v *string) bool {
+	return v != nil && *v != ""
 }
 
 func golangVersionFromRepoConfig(configs fs.FS, imagePrefix, branch string) (*string, error) {
@@ -62,14 +60,16 @@ func golangVersionFromRepoConfig(configs fs.FS, imagePrefix, branch string) (*st
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse config from %s: %w", configFile.Name(), err)
 		}
-		if !hasImagePrefix(cfg.Repositories, imagePrefix) {
+		if !slices.ContainsFunc(cfg.Repositories, func(r prowgen.Repository) bool {
+			return r.ImagePrefix == imagePrefix
+		}) {
 			continue
 		}
 		branchConfig, ok := cfg.Config.Branches[branch]
 		if !ok {
 			continue
 		}
-		if branchConfig.GolangVersion != nil && *branchConfig.GolangVersion != "" {
+		if isGoVersionSet(branchConfig.GolangVersion) {
 			return branchConfig.GolangVersion, nil
 		}
 	}
@@ -89,7 +89,7 @@ func golangVersionFromSOConfig(configs fs.FS, branch string) (*string, error) {
 	if !ok {
 		return nil, nil
 	}
-	if cfg.GolangVersion != nil && *cfg.GolangVersion != "" {
+	if isGoVersionSet(cfg.GolangVersion) {
 		return cfg.GolangVersion, nil
 	}
 	return nil, nil

--- a/pkg/dockerfilegen/goversion_test.go
+++ b/pkg/dockerfilegen/goversion_test.go
@@ -7,7 +7,6 @@ import (
 	"testing/fstest"
 
 	"github.com/openshift-knative/hack/pkg/project"
-	"github.com/openshift-knative/hack/pkg/prowgen"
 )
 
 func Test_componentBranchForTag(t *testing.T) {
@@ -112,51 +111,6 @@ func Test_soBranchForMetadata(t *testing.T) {
 	}
 }
 
-func Test_hasImagePrefix(t *testing.T) {
-	repos := []prowgen.Repository{
-		{ImagePrefix: "knative-eventing"},
-		{ImagePrefix: "knative-serving"},
-	}
-	tests := []struct {
-		name   string
-		repos  []prowgen.Repository
-		prefix string
-		want   bool
-	}{
-		{
-			name:   "found",
-			repos:  repos,
-			prefix: "knative-serving",
-			want:   true,
-		},
-		{
-			name:   "not found",
-			repos:  repos,
-			prefix: "knative-client",
-			want:   false,
-		},
-		{
-			name:   "empty repos",
-			repos:  nil,
-			prefix: "knative-serving",
-			want:   false,
-		},
-		{
-			name:   "empty prefix matches empty ImagePrefix",
-			repos:  []prowgen.Repository{{ImagePrefix: ""}},
-			prefix: "",
-			want:   true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := hasImagePrefix(tt.repos, tt.prefix); got != tt.want {
-				t.Errorf("hasImagePrefix() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func makeConfigYAML(imagePrefix, branch, golangVersion string) []byte {
 	tmpl := `config:
   branches:
@@ -186,7 +140,6 @@ func Test_golangVersionFromRepoConfig(t *testing.T) {
 		branch      string
 		wantVersion string
 		wantNil     bool
-		wantErr     bool
 	}{
 		{
 			name: "returns golang version for matching repo and branch",
@@ -259,6 +212,28 @@ func Test_golangVersionFromRepoConfig(t *testing.T) {
 			wantVersion: "1.23",
 		},
 		{
+			name: "returns golang version for main branch",
+			fs: fstest.MapFS{
+				"eventing.yaml": &fstest.MapFile{
+					Data: makeConfigYAML("knative-eventing", "main", "1.25"),
+				},
+			},
+			imagePrefix: "knative-eventing",
+			branch:      "main",
+			wantVersion: "1.25",
+		},
+		{
+			name: "returns golang version for release-1.38 branch",
+			fs: fstest.MapFS{
+				"serving.yaml": &fstest.MapFile{
+					Data: makeConfigYAML("knative-serving", "release-1.38", "1.24"),
+				},
+			},
+			imagePrefix: "knative-serving",
+			branch:      "release-1.38",
+			wantVersion: "1.24",
+		},
+		{
 			name:        "returns nil for empty filesystem",
 			fs:          fstest.MapFS{},
 			imagePrefix: "knative-eventing",
@@ -269,12 +244,6 @@ func Test_golangVersionFromRepoConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := golangVersionFromRepoConfig(tt.fs, tt.imagePrefix, tt.branch)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				return
-			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -352,6 +321,12 @@ repositories:
 			wantVersion: "1.25",
 		},
 		{
+			name:        "returns golang version for release-1.38",
+			fs:          soConfigWithVersion("release-1.38", "1.24"),
+			branch:      "release-1.38",
+			wantVersion: "1.24",
+		},
+		{
 			name:    "returns nil when branch not found",
 			fs:      soConfigNoBranch,
 			branch:  "release-1.99",
@@ -367,6 +342,14 @@ repositories:
 			name:    "returns error when SO config file missing",
 			fs:      fstest.MapFS{},
 			branch:  "release-1.37",
+			wantErr: true,
+		},
+		{
+			name: "returns error when SO config is malformed YAML",
+			fs: fstest.MapFS{
+				"serverless-operator.yaml": &fstest.MapFile{Data: []byte(`not: valid: yaml: [`)},
+			},
+			branch:  "main",
 			wantErr: true,
 		},
 	}
@@ -529,6 +512,41 @@ repositories:
 				Project: project.Project{},
 			},
 			wantNil: true,
+		},
+		{
+			name: "component repo: propagates repo config error",
+			fs: fstest.MapFS{
+				"eventing.yaml": &fstest.MapFile{Data: []byte(`not: valid: yaml: [`)},
+			},
+			metadata: &project.Metadata{
+				Project: project.Project{
+					Tag:         "knative-v1.17",
+					ImagePrefix: "knative-eventing",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "component repo: returns repo version for main branch",
+			fs:   repoAndSOConfig("knative-eventing", "release-next", "1.25", "main", "1.23"),
+			metadata: &project.Metadata{
+				Project: project.Project{
+					Tag:         "knative-nightly",
+					ImagePrefix: "knative-eventing",
+				},
+			},
+			wantVersion: "1.25",
+		},
+		{
+			name: "component repo: returns repo version for release-1.38",
+			fs:   repoAndSOConfig("knative-serving", "release-v1.21", "1.24", "release-1.38", "1.23"),
+			metadata: &project.Metadata{
+				Project: project.Project{
+					Tag:         "knative-v1.21",
+					ImagePrefix: "knative-serving",
+				},
+			},
+			wantVersion: "1.24",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/dockerfilegen/goversion_test.go
+++ b/pkg/dockerfilegen/goversion_test.go
@@ -1,0 +1,560 @@
+package dockerfilegen
+
+import (
+	"fmt"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/openshift-knative/hack/pkg/project"
+	"github.com/openshift-knative/hack/pkg/prowgen"
+)
+
+func Test_componentBranchForTag(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{
+			name: "knative-nightly maps to release-next",
+			tag:  "knative-nightly",
+			want: "release-next",
+		},
+		{
+			name: "versioned tag strips knative- prefix",
+			tag:  "knative-v1.17",
+			want: "release-v1.17",
+		},
+		{
+			name: "tag without knative prefix",
+			tag:  "v1.11",
+			want: "release-v1.11",
+		},
+		{
+			name: "main tag",
+			tag:  "main",
+			want: "release-main",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := componentBranchForTag(tt.tag); got != tt.want {
+				t.Errorf("componentBranchForTag(%q) = %q, want %q", tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_soBranchForMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *project.Metadata
+		want     string
+	}{
+		{
+			name:     "knative-nightly tag returns main",
+			metadata: &project.Metadata{Project: project.Project{Tag: "knative-nightly"}},
+			want:     "main",
+		},
+		{
+			name:     "main tag returns main",
+			metadata: &project.Metadata{Project: project.Project{Tag: "main"}},
+			want:     "main",
+		},
+		{
+			name:     "upstream v1.17 tag maps to release-1.37",
+			metadata: &project.Metadata{Project: project.Project{Tag: "knative-v1.17"}},
+			want:     "release-1.37",
+		},
+		{
+			name:     "upstream v1.21 tag maps to release-1.38",
+			metadata: &project.Metadata{Project: project.Project{Tag: "knative-v1.21"}},
+			want:     "release-1.38",
+		},
+		{
+			name:     "SO version 1.37.0 maps to release-1.37",
+			metadata: &project.Metadata{Project: project.Project{Version: "1.37.0"}},
+			want:     "release-1.37",
+		},
+		{
+			name:     "SO patch version 1.37.1 maps to release-1.37",
+			metadata: &project.Metadata{Project: project.Project{Version: "1.37.1"}},
+			want:     "release-1.37",
+		},
+		{
+			name:     "SO version 1.38.0 maps to release-1.38",
+			metadata: &project.Metadata{Project: project.Project{Version: "1.38.0"}},
+			want:     "release-1.38",
+		},
+		{
+			name:     "invalid version returns empty",
+			metadata: &project.Metadata{Project: project.Project{Version: "not-a-version"}},
+			want:     "",
+		},
+		{
+			name:     "empty metadata returns empty",
+			metadata: &project.Metadata{},
+			want:     "",
+		},
+		{
+			name:     "tag takes precedence over version",
+			metadata: &project.Metadata{Project: project.Project{Tag: "knative-nightly", Version: "1.37.0"}},
+			want:     "main",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := soBranchForMetadata(tt.metadata); got != tt.want {
+				t.Errorf("soBranchForMetadata() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_hasImagePrefix(t *testing.T) {
+	repos := []prowgen.Repository{
+		{ImagePrefix: "knative-eventing"},
+		{ImagePrefix: "knative-serving"},
+	}
+	tests := []struct {
+		name   string
+		repos  []prowgen.Repository
+		prefix string
+		want   bool
+	}{
+		{
+			name:   "found",
+			repos:  repos,
+			prefix: "knative-serving",
+			want:   true,
+		},
+		{
+			name:   "not found",
+			repos:  repos,
+			prefix: "knative-client",
+			want:   false,
+		},
+		{
+			name:   "empty repos",
+			repos:  nil,
+			prefix: "knative-serving",
+			want:   false,
+		},
+		{
+			name:   "empty prefix matches empty ImagePrefix",
+			repos:  []prowgen.Repository{{ImagePrefix: ""}},
+			prefix: "",
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasImagePrefix(tt.repos, tt.prefix); got != tt.want {
+				t.Errorf("hasImagePrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func makeConfigYAML(imagePrefix, branch, golangVersion string) []byte {
+	tmpl := `config:
+  branches:
+    %s:
+      golangVersion: "%s"
+repositories:
+- imagePrefix: %s
+`
+	return []byte(fmt.Sprintf(tmpl, branch, golangVersion, imagePrefix))
+}
+
+func makeConfigYAMLNoGolang(imagePrefix, branch string) []byte {
+	tmpl := `config:
+  branches:
+    %s: {}
+repositories:
+- imagePrefix: %s
+`
+	return []byte(fmt.Sprintf(tmpl, branch, imagePrefix))
+}
+
+func Test_golangVersionFromRepoConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		fs          fstest.MapFS
+		imagePrefix string
+		branch      string
+		wantVersion string
+		wantNil     bool
+		wantErr     bool
+	}{
+		{
+			name: "returns golang version for matching repo and branch",
+			fs: fstest.MapFS{
+				"eventing.yaml": &fstest.MapFile{
+					Data: makeConfigYAML("knative-eventing", "release-v1.17", "1.23"),
+				},
+			},
+			imagePrefix: "knative-eventing",
+			branch:      "release-v1.17",
+			wantVersion: "1.23",
+		},
+		{
+			name: "returns nil when branch not found",
+			fs: fstest.MapFS{
+				"eventing.yaml": &fstest.MapFile{
+					Data: makeConfigYAML("knative-eventing", "release-v1.17", "1.23"),
+				},
+			},
+			imagePrefix: "knative-eventing",
+			branch:      "release-v1.16",
+			wantNil:     true,
+		},
+		{
+			name: "returns nil when imagePrefix not found",
+			fs: fstest.MapFS{
+				"eventing.yaml": &fstest.MapFile{
+					Data: makeConfigYAML("knative-eventing", "release-v1.17", "1.23"),
+				},
+			},
+			imagePrefix: "knative-serving",
+			branch:      "release-v1.17",
+			wantNil:     true,
+		},
+		{
+			name: "returns nil when golangVersion not set in branch config",
+			fs: fstest.MapFS{
+				"eventing.yaml": &fstest.MapFile{
+					Data: makeConfigYAMLNoGolang("knative-eventing", "release-v1.17"),
+				},
+			},
+			imagePrefix: "knative-eventing",
+			branch:      "release-v1.17",
+			wantNil:     true,
+		},
+		{
+			name: "scans multiple config files and finds match in second",
+			fs: fstest.MapFS{
+				"aaa-eventing.yaml": &fstest.MapFile{
+					Data: makeConfigYAML("knative-eventing", "release-v1.17", "1.22"),
+				},
+				"bbb-serving.yaml": &fstest.MapFile{
+					Data: makeConfigYAML("knative-serving", "release-v1.17", "1.23"),
+				},
+			},
+			imagePrefix: "knative-serving",
+			branch:      "release-v1.17",
+			wantVersion: "1.23",
+		},
+		{
+			name: "skips directories",
+			fs: fstest.MapFS{
+				"subdir": &fstest.MapFile{Mode: 0o755 | fs.ModeDir},
+				"eventing.yaml": &fstest.MapFile{
+					Data: makeConfigYAML("knative-eventing", "release-v1.17", "1.23"),
+				},
+			},
+			imagePrefix: "knative-eventing",
+			branch:      "release-v1.17",
+			wantVersion: "1.23",
+		},
+		{
+			name:        "returns nil for empty filesystem",
+			fs:          fstest.MapFS{},
+			imagePrefix: "knative-eventing",
+			branch:      "release-v1.17",
+			wantNil:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := golangVersionFromRepoConfig(tt.fs, tt.imagePrefix, tt.branch)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %q", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil result, got nil")
+			}
+			if *got != tt.wantVersion {
+				t.Errorf("got %q, want %q", *got, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func Test_golangVersionFromSOConfig(t *testing.T) {
+	soConfigWithVersion := func(branch, version string) fstest.MapFS {
+		yaml := fmt.Sprintf(`config:
+  branches:
+    %s:
+      golangVersion: "%s"
+repositories:
+- imagePrefix: serverless
+`, branch, version)
+		return fstest.MapFS{
+			"serverless-operator.yaml": &fstest.MapFile{Data: []byte(yaml)},
+		}
+	}
+
+	soConfigNoBranch := fstest.MapFS{
+		"serverless-operator.yaml": &fstest.MapFile{
+			Data: []byte(`config:
+  branches:
+    main:
+      golangVersion: "1.25"
+repositories:
+- imagePrefix: serverless
+`),
+		},
+	}
+
+	soConfigNoGolang := fstest.MapFS{
+		"serverless-operator.yaml": &fstest.MapFile{
+			Data: []byte(`config:
+  branches:
+    release-1.37: {}
+repositories:
+- imagePrefix: serverless
+`),
+		},
+	}
+
+	tests := []struct {
+		name        string
+		fs          fstest.MapFS
+		branch      string
+		wantVersion string
+		wantNil     bool
+		wantErr     bool
+	}{
+		{
+			name:        "returns golang version for matching branch",
+			fs:          soConfigWithVersion("release-1.37", "1.23"),
+			branch:      "release-1.37",
+			wantVersion: "1.23",
+		},
+		{
+			name:        "returns golang version for main",
+			fs:          soConfigWithVersion("main", "1.25"),
+			branch:      "main",
+			wantVersion: "1.25",
+		},
+		{
+			name:    "returns nil when branch not found",
+			fs:      soConfigNoBranch,
+			branch:  "release-1.99",
+			wantNil: true,
+		},
+		{
+			name:    "returns nil when golangVersion not set",
+			fs:      soConfigNoGolang,
+			branch:  "release-1.37",
+			wantNil: true,
+		},
+		{
+			name:    "returns error when SO config file missing",
+			fs:      fstest.MapFS{},
+			branch:  "release-1.37",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := golangVersionFromSOConfig(tt.fs, tt.branch)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %q", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil result, got nil")
+			}
+			if *got != tt.wantVersion {
+				t.Errorf("got %q, want %q", *got, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func Test_goVersionFromConfig(t *testing.T) {
+	repoAndSOConfig := func(imagePrefix, repoBranch, repoGoVer, soBranch, soGoVer string) fstest.MapFS {
+		repoYaml := fmt.Sprintf(`config:
+  branches:
+    %s:
+      golangVersion: "%s"
+repositories:
+- imagePrefix: %s
+`, repoBranch, repoGoVer, imagePrefix)
+		soYaml := fmt.Sprintf(`config:
+  branches:
+    %s:
+      golangVersion: "%s"
+repositories:
+- imagePrefix: serverless
+`, soBranch, soGoVer)
+		return fstest.MapFS{
+			"eventing.yaml":            &fstest.MapFile{Data: []byte(repoYaml)},
+			"serverless-operator.yaml": &fstest.MapFile{Data: []byte(soYaml)},
+		}
+	}
+
+	soOnlyConfig := func(soBranch, soGoVer string) fstest.MapFS {
+		soYaml := fmt.Sprintf(`config:
+  branches:
+    %s:
+      golangVersion: "%s"
+repositories:
+- imagePrefix: serverless
+`, soBranch, soGoVer)
+		return fstest.MapFS{
+			"serverless-operator.yaml": &fstest.MapFile{Data: []byte(soYaml)},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		fs          fstest.MapFS
+		metadata    *project.Metadata
+		wantVersion string
+		wantNil     bool
+		wantErr     bool
+	}{
+		{
+			name: "component repo: returns repo-specific golang version",
+			fs:   repoAndSOConfig("knative-eventing", "release-v1.17", "1.22", "release-1.37", "1.25"),
+			metadata: &project.Metadata{
+				Project: project.Project{
+					Tag:         "knative-v1.17",
+					ImagePrefix: "knative-eventing",
+				},
+			},
+			wantVersion: "1.22",
+		},
+		{
+			name: "component repo: falls back to SO when repo has no golang version",
+			fs: func() fstest.MapFS {
+				repoYaml := `config:
+  branches:
+    release-v1.17: {}
+repositories:
+- imagePrefix: knative-eventing
+`
+				soYaml := `config:
+  branches:
+    release-1.37:
+      golangVersion: "1.25"
+repositories:
+- imagePrefix: serverless
+`
+				return fstest.MapFS{
+					"eventing.yaml":            &fstest.MapFile{Data: []byte(repoYaml)},
+					"serverless-operator.yaml": &fstest.MapFile{Data: []byte(soYaml)},
+				}
+			}(),
+			metadata: &project.Metadata{
+				Project: project.Project{
+					Tag:         "knative-v1.17",
+					ImagePrefix: "knative-eventing",
+				},
+			},
+			wantVersion: "1.25",
+		},
+		{
+			name: "SO version: returns golang version for release branch",
+			fs:   soOnlyConfig("release-1.37", "1.25"),
+			metadata: &project.Metadata{
+				Project: project.Project{Version: "1.37.0"},
+			},
+			wantVersion: "1.25",
+		},
+		{
+			name: "SO patch version: returns golang version (original bug fix)",
+			fs:   soOnlyConfig("release-1.37", "1.25"),
+			metadata: &project.Metadata{
+				Project: project.Project{Version: "1.37.1"},
+			},
+			wantVersion: "1.25",
+		},
+		{
+			name: "SO patch version: 1.38.2 maps to release-1.38",
+			fs:   soOnlyConfig("release-1.38", "1.25"),
+			metadata: &project.Metadata{
+				Project: project.Project{Version: "1.38.2"},
+			},
+			wantVersion: "1.25",
+		},
+		{
+			name: "knative-nightly component: falls back to SO main",
+			fs:   soOnlyConfig("main", "1.25"),
+			metadata: &project.Metadata{
+				Project: project.Project{
+					Tag:         "knative-nightly",
+					ImagePrefix: "knative-eventing",
+				},
+			},
+			wantVersion: "1.25",
+		},
+		{
+			name:     "empty metadata returns nil",
+			fs:       fstest.MapFS{"serverless-operator.yaml": &fstest.MapFile{Data: []byte(`config: {}`)}},
+			metadata: &project.Metadata{},
+			wantNil:  true,
+		},
+		{
+			name: "no imagePrefix, no version, no tag returns nil",
+			fs:   fstest.MapFS{"serverless-operator.yaml": &fstest.MapFile{Data: []byte(`config: {}`)}},
+			metadata: &project.Metadata{
+				Project: project.Project{},
+			},
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := goVersionFromConfig(tt.fs, tt.metadata)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %q", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil result, got nil")
+			}
+			if *got != tt.wantVersion {
+				t.Errorf("got %q, want %q", *got, tt.wantVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I let claude to do some clauding around go version code. 


/cc @creydr @maschmid 