### PR TITLE
Add explicit override-snapshot.yaml to renovate ignore

### DIFF
--- a/pkg/dependabotgen/renovate.template.json
+++ b/pkg/dependabotgen/renovate.template.json
@@ -3,7 +3,8 @@
   "enabledManagers": ["tekton"],
   "commitMessagePrefix": "[{{baseBranch}}]",
   "ignorePaths": [
-    ".konflux-release/**",
+    "**/.konflux-release/**",
+    "**/override-snapshot.yaml",
     "third_party/**",
     "vendor/**",
     "**/images-rekt.yaml"


### PR DESCRIPTION

That should prevent this kind of unintended change: 

https://github.com/openshift-knative/serverless-operator/pull/4078/changes#diff-fd3b52564a5d64b6555731e492f4fd4532ed818dc649a5fe0f1a098fa33bc228

/cc @creydr 