### PR TITLE
move kitchensink upgrade to ocp 4.20

### DIFF
--- a/config/serverless-operator.yaml
+++ b/config/serverless-operator.yaml
@@ -29,8 +29,15 @@ config:
           enabled: true
           excludes:
           - .*ocp-4.22-lp-interop.*
+        skipE2EMatches:
+        - "^kitchensink-upgrade$"
         useClusterPool: true
         version: "4.21"
+      - includeE2EMatches:
+        - "^kitchensink-upgrade$"
+        onDemand: true
+        skipPromotion: true
+        version: "4.20"
       - onDemand: true
         version: "4.16"
       promotion: {}

--- a/pkg/prowgen/prowgen_config.go
+++ b/pkg/prowgen/prowgen_config.go
@@ -123,6 +123,12 @@ type OpenShift struct {
 	OnDemand         bool                     `json:"onDemand,omitempty" yaml:"onDemand,omitempty"`
 	CustomConfigs    *CustomConfigsEnablement `json:"customConfigs,omitempty" yaml:"customConfigs,omitempty"`
 	CandidateRelease bool                     `json:"candidateRelease,omitempty" yaml:"candidateRelease,omitempty"`
+	// SkipPromotion excludes this OpenShift version from promotion indexing.
+	SkipPromotion bool `json:"skipPromotion,omitempty" yaml:"skipPromotion,omitempty"`
+	// SkipE2EMatches excludes e2e tests (by exact match on E2ETest.Match) from this OpenShift version.
+	SkipE2EMatches []string `json:"skipE2EMatches,omitempty" yaml:"skipE2EMatches,omitempty"`
+	// IncludeE2EMatches, if non-empty, limits this OpenShift version to only the listed e2e tests (by exact match on E2ETest.Match).
+	IncludeE2EMatches []string `json:"includeE2EMatches,omitempty" yaml:"includeE2EMatches,omitempty"`
 }
 
 type CustomConfigsEnablement struct {
@@ -187,7 +193,8 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 
 		openshiftVersions := branch.OpenShiftVersions
 
-		for i, ov := range openshiftVersions {
+		promotionIndex := 0
+		for _, ov := range openshiftVersions {
 			log.Println(r.RepositoryDirectory(), "Generating config", branchName, "OpenShiftVersion", ov)
 
 			variant := strings.ReplaceAll(ov.Version, ".", "")
@@ -261,10 +268,13 @@ func NewGenerateConfigs(ctx context.Context, r Repository, cc CommonConfig, opts
 
 			options := make([]ReleaseBuildConfigurationOption, 0, len(opts))
 			copy(options, opts)
-			if i == 0 {
-				options = append(options, withNamePromotion(r, branch, branchName))
-			} else if i == 1 {
-				options = append(options, withTagPromotion(r, branch, branchName))
+			if !ov.SkipPromotion {
+				if promotionIndex == 0 {
+					options = append(options, withNamePromotion(r, branch, branchName))
+				} else if promotionIndex == 1 {
+					options = append(options, withTagPromotion(r, branch, branchName))
+				}
+				promotionIndex++
 			}
 
 			fromImage := srcImage

--- a/pkg/prowgen/prowgen_tests.go
+++ b/pkg/prowgen/prowgen_tests.go
@@ -50,7 +50,8 @@ var makefileTargetPattern = regexp.MustCompile("^(\\S+):\\s*(.*)$")
 
 func DiscoverTests(r Repository, openShift OpenShift, sourceImageName string, skipE2ETestMatch []string, random *rand.Rand) ReleaseBuildConfigurationOption {
 	return func(cfg *cioperatorapi.ReleaseBuildConfiguration) error {
-		tests, err := discoverE2ETests(r, skipE2ETestMatch)
+		combinedSkip := append(append([]string(nil), skipE2ETestMatch...), openShift.SkipE2EMatches...)
+		tests, err := discoverE2ETests(r, combinedSkip, openShift.IncludeE2EMatches)
 		if err != nil {
 			return err
 		}
@@ -316,7 +317,7 @@ func (t *Test) HexSha() string {
 	return hex.EncodeToString(h.Sum(nil))[:shaLength]
 }
 
-func discoverE2ETests(r Repository, skipE2ETestMatch []string) ([]Test, error) {
+func discoverE2ETests(r Repository, skipE2ETestMatch []string, includeE2ETestMatch []string) ([]Test, error) {
 	makefilePath := filepath.Join(r.RepositoryDirectory(), "Makefile")
 	if _, err := os.Stat(makefilePath); err != nil && os.IsNotExist(err) {
 		return nil, nil
@@ -341,6 +342,9 @@ func discoverE2ETests(r Repository, skipE2ETestMatch []string) ([]Test, error) {
 			}
 			for _, e2e := range r.E2ETests {
 				if slices.Contains(skipE2ETestMatch, e2e.Match) {
+					continue
+				}
+				if len(includeE2ETestMatch) > 0 && !slices.Contains(includeE2ETestMatch, e2e.Match) {
 					continue
 				}
 				if err := createTest(r, target, e2e, &targets, commands); err != nil {


### PR DESCRIPTION
As the kitchensink-upgrade is broken on OCP 4.21 due to https://redhat.atlassian.net/browse/SRVKE-1817 (kitchensink upgrade starts with installing 1.35, which breaks on OCP 4.21 due to that issue only fixed in 1.37) , the easiest fix is to run the kitchensink-upgrade on OCP 4.20

Adding a few fields to make it possible:
* skipE2EMatches / includeE2EMatches on the OpenShift version level to include/exclude specific e2e matches (reuses the mechanism that existed already for branches)
* skipPromotion on the OpenShift version to skip being considered for the name/tag promotion, so that this addition of OCP 4.20 does not change the existing promotion.

Assisted-by: Claude Opus 4.6