### PR TITLE
Enable automatic Go toolchain upgrades in release workflow

### DIFF
--- a/.github/workflows/run-command-repository.yaml
+++ b/.github/workflows/run-command-repository.yaml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           cache: false
-          go-version-file: "./src/github.com/${{ inputs.repository }}/go.mod"
 
       - name: Install prerequisites
         env:
@@ -50,8 +49,6 @@ jobs:
 
       - name: Generate release
         working-directory: "./src/github.com/${{ inputs.repository }}"
-        env:
-          GOTOOLCHAIN: auto
         run: make ${{ inputs.command }}
 
       - name: Create Pull Request

--- a/.github/workflows/run-command-repository.yaml
+++ b/.github/workflows/run-command-repository.yaml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Generate release
         working-directory: "./src/github.com/${{ inputs.repository }}"
+        env:
+          GOTOOLCHAIN: auto
         run: make ${{ inputs.command }}
 
       - name: Create Pull Request


### PR DESCRIPTION
## Summary

Enable `GOTOOLCHAIN=auto` for the release generation workflow.

`actions/setup-go` installs the Go version defined in `go.mod`, but some dependencies from `openshift-knative/hack` may require a newer patch version than the one currently specified.

Without automatic toolchain upgrades enabled, the workflow fails with errors similar to:

```text
requires go >= 1.25.5 (running go 1.25.0; GOTOOLCHAIN=local)
```

Setting `GOTOOLCHAIN=auto` allows Go to automatically download and use a newer compatible toolchain version when required, while still defaulting to the version defined in `go.mod`.

This also makes the workflow more future-proof for future patch version updates.
