### PR TITLE
Use Go version from hack repository go.mod

### DIFF
--- a/.github/workflows/run-command-repository.yaml
+++ b/.github/workflows/run-command-repository.yaml
@@ -22,6 +22,9 @@ jobs:
     name: run-command ${{ inputs.repository }} - ${{ inputs.command }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout hack repo
+        uses: actions/checkout@v6
+
       - name: Checkout ${{ inputs.repository }}
         uses: actions/checkout@v6
         with:
@@ -33,6 +36,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           cache: false
+          go-version-file: "go.mod"
 
       - name: Install prerequisites
         env:


### PR DESCRIPTION
Use the Go version defined in the `hack` repository `go.mod` instead of the dynamically checked out target repository.

This keeps the workflow environment aligned with the automation/tooling repository while still allowing commands to run against other checked out repositories.

This is follow up PR for https://github.com/openshift-knative/hack/pull/972