### PR TITLE
Update FBC 4.22 stage Release CR with fixed catalog snapshot

### DIFF
--- a/.konflux/releases/serverless-operator-137-fbc-422-1371-stage.yaml
+++ b/.konflux/releases/serverless-operator-137-fbc-422-1371-stage.yaml
@@ -1,9 +1,9 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: serverless-operator-137-fbc-422-1371-stage-2
+  name: serverless-operator-137-fbc-422-1371-stage-3
 spec:
-  snapshot: serverless-operator-137-fbc-422-override-snapshot-a6d1d181
+  snapshot: serverless-operator-137-fbc-422-override-snapshot-5e01a078
   releasePlan: serverless-operator-137-fbc-422-1371-stage
   data:
     releaseNotes:


### PR DESCRIPTION
Update snapshot reference to the fixed v4.22 catalog index image that restores the upgrade path from v1.34 to v1.37.1.